### PR TITLE
[SUPERSEDED] Mobile production hardening: phase 1 shell and release plan

### DIFF
--- a/docs/mobile/MOBILE_AUDIT_FINDINGS.md
+++ b/docs/mobile/MOBILE_AUDIT_FINDINGS.md
@@ -1,0 +1,60 @@
+# Loadify Market — Mobile Engineering Audit Findings
+
+**Baseline:** `22e13a6933c7c7a3bc423bffbd0364eb34f35a04`  
+**Hardening branch:** `mobile-production-hardening`  
+**Rule:** findings are not marked resolved until the applicable static, build and device gates pass.
+
+## Status legend
+
+- `OPEN` — verified defect/risk, remediation not yet accepted.
+- `IN PROGRESS` — isolated remediation exists but validation is incomplete.
+- `BLOCKED` — verification/remediation depends on an external prerequisite.
+- `RESOLVED` — all required PASS criteria have been demonstrated.
+
+---
+
+| ID | Severity | Area | Finding | Status |
+|---|---:|---|---|---|
+| MOB-001 | P1 | App shell | Mobile viewport/safe-area ownership is fragmented. Home used `MobileAppLayout` with document-style `min-h-screen` + fixed nav + hard-coded spacer while Home itself also compensated for nav/safe-area. | IN PROGRESS |
+| MOB-002 | P1 | Edge-to-edge | Home header owned top safe-area inside scrollable content, allowing page content to move into the Android status-bar region after header scroll. | IN PROGRESS |
+| MOB-003 | P1 | Shell consistency | Standalone mobile routes (`/inbox`, `/orders`, `/profile/*`, etc.) implement their own full-screen/safe-area/nav rules instead of one application-shell contract. | OPEN |
+| MOB-004 | P0 | Seller media | Mobile seller upload derives storage extension from the selected filename and collapses upload failures into a generic error; real camera/gallery compatibility and size/type behaviour are not certified. | OPEN |
+| MOB-005 | P0 | Startup | Supabase configuration validation can throw before the React tree is mounted; a bad native build configuration can therefore produce a blank WebView instead of a recovery screen. | OPEN |
+| MOB-006 | P1 | Push | Push-token client logic exists, but the official Capacitor Push Notifications dependency is absent from package dependencies. Native push cannot be considered implemented. | OPEN |
+| MOB-007 | P1 | App Links | `appUrlOpen` routing exists in React, but AndroidManifest exposes only MAIN/LAUNCHER and no verified HTTPS VIEW/BROWSABLE App Link filters. | OPEN |
+| MOB-008 | P1 | Networking | Native networking is split between a global `window.fetch` patch, CapacitorHttp, Supabase custom fetch and higher-level authenticated fetch wrappers. Ownership and environment routing are too implicit. | OPEN |
+| MOB-009 | P1 | Environment safety | `capacitorFetchPatch` contains a production URL fallback. A non-production APK with missing `VITE_APP_URL` can silently talk to production rather than fail closed. | OPEN |
+| MOB-010 | P1 | Auth storage | Native auth uses Capacitor Preferences with localStorage fallback while Android backup is enabled. Backup/restore treatment of session material is not an explicit documented security decision. | OPEN |
+| MOB-011 | P1 | Documentation/security | Supabase storage comments describe native Preferences/SharedPreferences as encrypted at rest. That guarantee is not established by the current implementation and should not be claimed. | OPEN |
+| MOB-012 | P1 | PWA/native | `main.tsx` registers the service worker based on browser capability and does not explicitly exclude Capacitor native runtime, adding an unnecessary cache/lifecycle layer to the APK unless deliberately required. | OPEN |
+| MOB-013 | P1 | PWA correctness | `main.tsx` comments describe a cleanup/no-cache service worker while `public/sw.js` implements real cache-first/network-first behaviour. Source documentation and runtime behaviour disagree. | OPEN |
+| MOB-014 | P1 | Lifecycle | Android Back/predictive Back, background/resume and listener restoration do not yet have an accepted device validation matrix. | OPEN |
+| MOB-015 | P0 | Release identity | Native Gradle metadata remains `versionCode 1` / `versionName 1.0`; automated release tags exist, but app-version identity is not yet a monotonic production release contract. | OPEN |
+| MOB-016 | P1 | Release validation | GitHub CI is currently unable to start because the GitHub account is locked by a billing issue. The hardening branch therefore has no CI test/lint/typecheck evidence yet. | BLOCKED |
+| MOB-017 | P2 | UI system | Mobile pages contain duplicated inline spacing/colour/layout values and do not consistently use shared mobile primitives/tokens. | OPEN |
+| MOB-018 | P2 | Accessibility | Touch targets/focus work is partially present, but no end-to-end mobile accessibility certification exists for large text, screen reader, keyboard/IME and contrast across critical flows. | OPEN |
+| MOB-019 | P2 | Observability/privacy | `MobileInboxPage` emits detailed session/user/conversation diagnostic logs outside a `DEV` guard; `?debug=1` can also expose an internal debug state panel in production. | OPEN |
+| MOB-020 | P2 | Branding | HTML/PWA theme metadata uses `#0A0A0A` while the current app background token is `#0A0E1A`, creating avoidable system-chrome/brand inconsistency. | OPEN |
+
+---
+
+## Branch Guard notes
+
+### Phase P1.1 — MOB-001/MOB-002
+
+Current branch changes make `MobileAppLayout` own `100dvh`, reserve the top safe-area outside the scrolling region, create one inner vertical scroll container, and remove duplicate Home-level bottom-nav compensation. `MobileAppHeader` no longer adds a second top safe-area inset.
+
+**Validation state**
+
+- exact diff reviewed and formatting churn self-corrected;
+- Netlify deploy preview built successfully;
+- GitHub Actions lint/typecheck/tests did **not** execute because of the account billing lock;
+- Android APK/device validation remains pending.
+
+Therefore MOB-001/MOB-002 remain `IN PROGRESS`, not `RESOLVED`.
+
+---
+
+## Release rule
+
+No finding may be closed merely because code was written. A finding is closed only when its defined PASS evidence is available and the Branch Guard has checked the final diff for business/security regressions.

--- a/docs/mobile/MOBILE_AUDIT_FINDINGS.md
+++ b/docs/mobile/MOBILE_AUDIT_FINDINGS.md
@@ -18,7 +18,7 @@
 | MOB-001 | P1 | App shell | Mobile viewport/safe-area ownership is fragmented. Home used `MobileAppLayout` with document-style `min-h-screen` + fixed nav + hard-coded spacer while Home itself also compensated for nav/safe-area. | IN PROGRESS |
 | MOB-002 | P1 | Edge-to-edge | Home header owned top safe-area inside scrollable content, allowing page content to move into the Android status-bar region after header scroll. | IN PROGRESS |
 | MOB-003 | P1 | Shell consistency | Standalone mobile routes (`/inbox`, `/orders`, `/profile/*`, etc.) implement their own full-screen/safe-area/nav rules instead of one application-shell contract. | OPEN |
-| MOB-004 | P0 | Seller media | Mobile seller upload derives storage extension from the selected filename and collapses upload failures into a generic error; real camera/gallery compatibility and size/type behaviour are not certified. | OPEN |
+| MOB-004 | P0 | Seller media | Mobile seller upload derives storage extension from the selected filename and collapses upload failures into a generic error; real camera/gallery compatibility and size/type behaviour are not certified. | IN PROGRESS |
 | MOB-005 | P0 | Startup | Supabase configuration validation can throw before the React tree is mounted; a bad native build configuration can therefore produce a blank WebView instead of a recovery screen. | OPEN |
 | MOB-006 | P1 | Push | Push-token client logic exists, but the official Capacitor Push Notifications dependency is absent from package dependencies. Native push cannot be considered implemented. | OPEN |
 | MOB-007 | P1 | App Links | `appUrlOpen` routing exists in React, but AndroidManifest exposes only MAIN/LAUNCHER and no verified HTTPS VIEW/BROWSABLE App Link filters. | OPEN |
@@ -37,7 +37,7 @@
 | MOB-020 | P2 | Branding | HTML/PWA theme metadata uses `#0A0A0A` while the current app background token is `#0A0E1A`, creating avoidable system-chrome/brand inconsistency. | OPEN |
 | MOB-021 | P1 | Messaging presence | `MobileChatPage` subscribes one Presence channel instance, but draft changes create a new channel instance and call `track()` on it without subscribing. Typing state is therefore not tied to the active subscribed channel and can create redundant channel objects. | OPEN |
 | MOB-022 | P1 | Messaging receipts | `lastSentRead` is set true when any matching message UPDATE reports a sent message as read; the callback does not prove that the updated row is the current user's latest sent message, so the UI can show a misleading `Seen` state. | OPEN |
-| MOB-023 | P1 | Seller media lifecycle | Mobile photo upload uses `Promise.all`; if one network upload rejects after others succeeded, successful objects may already exist in Storage but are not added to form state. Removing a photo also removes only the URL from UI, not the uploaded object. | OPEN |
+| MOB-023 | P1 | Seller media lifecycle | Mobile photo upload uses `Promise.all`; if one network upload rejects after others succeeded, successful objects may already exist in Storage but are not added to form state. Removing a photo also removes only the URL from UI, not the uploaded object. | IN PROGRESS |
 | MOB-024 | P1 | Standalone scrolling | Inbox/categories/orders use `min-h-screen` outer containers together with fixed bottom navigation and intended inner scrolling; because the outer height is not constrained to the dynamic viewport, document and inner-scroll ownership is inconsistent. Inbox's list container also lacks its own vertical overflow rule. | OPEN |
 
 ---
@@ -69,6 +69,26 @@ A separate draft PR (`#483`) now keeps PWA service-worker registration on regula
 - native WebView cleanup and web PWA behaviour still require runtime verification.
 
 Therefore MOB-012/MOB-013 remain `IN PROGRESS`, not `RESOLVED`.
+
+### Phase P0.2 — MOB-004/MOB-023
+
+A separate draft PR (`#484`) isolates the mobile seller media remediation from shell and PWA work. The mobile path now validates the existing JPG/PNG/WebP + 5 MB contract before upload, derives the Storage extension deterministically from supported MIME, uses a controlled filename-extension fallback only when the browser supplies no MIME, rolls back successful objects after a partial batch failure, and deletes the actual Storage object before removing a photo from the form. The existing `create-product` business payload remains an array of public image URLs.
+
+**Branch Guard self-correction**
+
+- the first remediation draft attempted to delete every staged photo when `MobileSellWizard` unmounted;
+- that behaviour was removed before PR creation because Android Back/lifecycle can race an in-flight publish and deleting staged files at unmount could break a listing whose server request succeeds after the screen disappears;
+- cleanup is now limited to certain events: failed-batch rollback and explicit `Remove photo`.
+
+**Validation state**
+
+- final branch diff is isolated to three files: the product-image helper, its focused tests, and `MobileSellWizard`;
+- no payment, auth, RLS, schema, shipping, product lifecycle or `create-product` contract changes are present;
+- GitHub Actions jobs did **not** execute. GitHub's check annotation states: `The job was not started because your account is locked due to a billing issue.`;
+- Netlify checks are independent and may provide build evidence, but they do not replace the blocked unit/lint/typecheck gates unless their executed command proves the same coverage;
+- Android camera/gallery, large-file rejection, multi-photo, forced partial failure/retry, Storage cleanup and final publish still require real-device validation.
+
+Therefore MOB-004/MOB-023 remain `IN PROGRESS`, not `RESOLVED`.
 
 ---
 

--- a/docs/mobile/MOBILE_AUDIT_FINDINGS.md
+++ b/docs/mobile/MOBILE_AUDIT_FINDINGS.md
@@ -34,7 +34,7 @@ GitHub is used for branch isolation, diff review, PR history and merge control. 
 | MOB-001 | P1 | App shell | Mobile viewport/safe-area ownership is fragmented. Home used `MobileAppLayout` with document-style `min-h-screen` + fixed nav + hard-coded spacer while Home itself also compensated for nav/safe-area. | IN PROGRESS |
 | MOB-002 | P1 | Edge-to-edge | Home header owned top safe-area inside scrollable content, allowing page content to move into the Android status-bar region after header scroll. | IN PROGRESS |
 | MOB-003 | P1 | Shell consistency | Standalone mobile routes (`/inbox`, `/orders`, `/profile/*`, etc.) implement their own full-screen/safe-area/nav rules instead of one application-shell contract. | OPEN |
-| MOB-004 | P0 | Seller media | Mobile seller upload derives storage extension from the selected filename and collapses upload failures into a generic error; real camera/gallery compatibility and size/type behaviour are not certified. | IN PROGRESS |
+| MOB-004 | P0 | Seller media | Seller media hardening is implemented, but real-device testing found the old combined `multiple` + `capture` input exposed attachment/gallery only and no direct live-camera action. Current remediation separates `Take photo` from `Gallery` and requires fresh static/build + Android validation. | IN PROGRESS |
 | MOB-005 | P0 | Startup | Supabase configuration validation can throw before the React tree is mounted; a bad native build configuration can therefore produce a blank WebView instead of a recovery screen. | OPEN |
 | MOB-006 | P1 | Push | Push-token client logic exists, but the official Capacitor Push Notifications dependency is absent from package dependencies. Native push cannot be considered implemented. | OPEN |
 | MOB-007 | P1 | App Links | `appUrlOpen` routing exists in React, but AndroidManifest exposes only MAIN/LAUNCHER and no verified HTTPS VIEW/BROWSABLE App Link filters. | OPEN |
@@ -53,7 +53,7 @@ GitHub is used for branch isolation, diff review, PR history and merge control. 
 | MOB-020 | P2 | Branding | HTML/PWA theme metadata uses `#0A0A0A` while the current app background token is `#0A0E1A`, creating avoidable system-chrome/brand inconsistency. | OPEN |
 | MOB-021 | P1 | Messaging presence | `MobileChatPage` subscribes one Presence channel instance, but draft changes create a new channel instance and call `track()` on it without subscribing. Typing state is therefore not tied to the active subscribed channel and can create redundant channel objects. | OPEN |
 | MOB-022 | P1 | Messaging receipts | `lastSentRead` is set true when any matching message UPDATE reports a sent message as read; the callback does not prove that the updated row is the current user's latest sent message, so the UI can show a misleading `Seen` state. | OPEN |
-| MOB-023 | P1 | Seller media lifecycle | Mobile photo upload uses `Promise.all`; if one network upload rejects after others succeeded, successful objects may already exist in Storage but are not added to form state. Removing a photo also removes only the URL from UI, not the uploaded object. | IN PROGRESS |
+| MOB-023 | P1 | Seller media lifecycle | Mobile photo upload uses transactional batch rollback and explicit Storage deletion for Remove photo, but lifecycle behaviour remains `IN PROGRESS` until the current seller-media head passes the full real-device matrix. | IN PROGRESS |
 | MOB-024 | P1 | Standalone scrolling | Inbox/categories/orders use `min-h-screen` outer containers together with fixed bottom navigation and intended inner scrolling; because the outer height is not constrained to the dynamic viewport, document and inner-scroll ownership is inconsistent. Inbox's list container also lacks its own vertical overflow rule. | OPEN |
 
 ---
@@ -88,25 +88,27 @@ Therefore MOB-012/MOB-013 remain `IN PROGRESS`, not `RESOLVED`.
 
 ### Phase P0.2 — MOB-004/MOB-023
 
-A separate draft PR (`#484`) isolates the mobile seller media remediation from shell and PWA work. The mobile path now validates the existing JPG/PNG/WebP + 5 MB contract before upload, derives the Storage extension deterministically from supported MIME, uses a controlled filename-extension fallback only when the browser supplies no MIME, rolls back successful objects after a partial batch failure, and deletes the actual Storage object before removing a photo from the form. The existing `create-product` business payload remains an array of public image URLs.
+A separate draft PR (`#484`) isolates the mobile seller media remediation from shell and PWA work. The mobile path validates the existing JPG/PNG/WebP + 5 MB contract before upload, derives the Storage extension deterministically from supported MIME, uses a controlled filename-extension fallback only when the browser supplies no MIME, rolls back successful objects after a partial batch failure, and deletes the actual Storage object before removing a photo from the form. The existing `create-product` business payload remains an array of public image URLs.
 
 **Branch Guard self-correction**
 
 - the first remediation draft attempted to delete every staged photo when `MobileSellWizard` unmounted;
 - that behaviour was removed before PR creation because Android Back/lifecycle can race an in-flight publish and deleting staged files at unmount could break a listing whose server request succeeds after the screen disappears;
-- cleanup is now limited to certain events: failed-batch rollback and explicit `Remove photo`.
+- cleanup is limited to certain events: failed-batch rollback and explicit `Remove photo`;
+- real-device testing then exposed a second issue: the old single hidden input combined `multiple` with `capture="environment"`, but the tested Android WebView offered only attachment/gallery and no direct live-camera action;
+- current PR head `c3b9f022b560bfa2cee4d60414d0093668bd8dc6` self-corrects that device finding by exposing two explicit actions: `Take photo` uses a dedicated single-file capture input and `Gallery` uses a separate multi-select JPG/PNG/WebP input.
 
 **Validation state**
 
-- final branch diff is isolated to three files: the product-image helper, its focused tests, and `MobileSellWizard`;
+- branch diff remains isolated to the same three files: the product-image helper, its focused tests, and `MobileSellWizard`;
 - no payment, auth, RLS, schema, shipping, product lifecycle or `create-product` contract changes are present;
-- Netlify deploy/check suite completed successfully and produced a deploy preview;
-- GitHub Actions did not execute because of the account billing condition; this is supplementary CI only and is not treated as a code failure;
-- **local PowerShell static/build gate PASSED on 16 August 2026 on exact PR head `1ee7d90eda78c048deda6672bdb6135ef411d7ab`**;
-- PowerShell evidence: clean/stashed worktree before checkout, `origin/main` verified at `22e13a6933c7c7a3bc423bffbd0364eb34f35a04`, exact PR head checkout verified, lint PASS, explicit `npx tsc -b --pretty false` PASS, focused seller-media suite **7/7 PASS**, full suite **138/138 PASS across 21/21 test files**, production build PASS, `git diff --check` PASS, and diff surface exactly the expected three files;
-- Android camera/gallery, large-file rejection, multi-photo, forced partial failure/retry, Storage cleanup and final publish still require real-device validation.
+- local PowerShell static/build gate **PASSED on 16 August 2026 on old head `1ee7d90eda78c048deda6672bdb6135ef411d7ab`**: lint PASS, explicit TypeScript PASS, focused seller-media suite **7/7 PASS**, full suite **138/138 PASS across 21/21 test files**, production build PASS, diff check PASS;
+- Android APK preparation also passed on old head: production assets built, Capacitor sync succeeded, Android `assembleDebug` succeeded, isolated package `co.uk.loadifymarket.app.test` installed/launched, and the repository was restored clean;
+- **camera device test FAILED on old head** because no direct live-camera action was available;
+- because the remediation moved the PR head to `c3b9f022b560bfa2cee4d60414d0093668bd8dc6`, the old static/build PASS is evidence for the old head only and **must be rerun on the current head**;
+- after fresh static/build + APK preparation, current-head device validation must cover direct camera capture/preview, gallery JPEG/PNG/WebP, >5 MB rejection, multi-photo, forced partial failure/retry, Storage cleanup and final publish.
 
-Therefore MOB-004/MOB-023 remain `IN PROGRESS`, not `RESOLVED`: the code/static/build gate is accepted, but the required real-device seller-media gate is still outstanding.
+Therefore MOB-004/MOB-023 remain `IN PROGRESS`, not `RESOLVED`: the old head was statically valid but failed the camera device criterion, and the corrective current head is awaiting fresh validation.
 
 ---
 

--- a/docs/mobile/MOBILE_AUDIT_FINDINGS.md
+++ b/docs/mobile/MOBILE_AUDIT_FINDINGS.md
@@ -4,11 +4,25 @@
 **Hardening branch:** `mobile-production-hardening`  
 **Rule:** findings are not marked resolved until the applicable static, build and device gates pass.
 
+## Validation authority
+
+The authoritative engineering gate for mobile hardening is the local Windows repository executed in **PowerShell**, not GitHub Actions.
+
+Required static/build sequence:
+
+1. `npm run lint`
+2. `npm run typecheck`
+3. focused/unit tests for the remediation
+4. `npm run build`
+5. Android/device validation where applicable
+
+GitHub is used for branch isolation, diff review, PR history and merge control. GitHub Actions is supplementary only. If Actions cannot start because of billing/account state, that is an external CI condition and **must not be reported as a code failure or as a blocker to local PowerShell validation**.
+
 ## Status legend
 
 - `OPEN` — verified defect/risk, remediation not yet accepted.
 - `IN PROGRESS` — isolated remediation exists but validation is incomplete.
-- `BLOCKED` — verification/remediation depends on an external prerequisite.
+- `BLOCKED` — that specific check/dependency cannot currently execute; this does not automatically block other independent gates.
 - `RESOLVED` — all required PASS criteria have been demonstrated.
 
 ---
@@ -30,7 +44,7 @@
 | MOB-013 | P1 | PWA correctness | `main.tsx` comments describe a cleanup/no-cache service worker while `public/sw.js` implements real cache-first/network-first behaviour. Source documentation and runtime behaviour disagree. | IN PROGRESS |
 | MOB-014 | P1 | Lifecycle | Android Back/predictive Back, background/resume and listener restoration do not yet have an accepted device validation matrix. | OPEN |
 | MOB-015 | P0 | Release identity | Native Gradle metadata remains `versionCode 1` / `versionName 1.0`; automated release tags exist, but app-version identity is not yet a monotonic production release contract. | OPEN |
-| MOB-016 | P1 | Release validation | GitHub CI is currently unable to start because the GitHub account is locked by a billing issue. The hardening branch therefore has no CI test/lint/typecheck evidence yet. | BLOCKED |
+| MOB-016 | P2 | CI infrastructure | GitHub Actions jobs currently cannot start because the GitHub account is locked by a billing issue. This removes supplementary CI evidence, but local PowerShell remains the authoritative lint/typecheck/test/build gate. | BLOCKED |
 | MOB-017 | P2 | UI system | Mobile pages contain duplicated inline spacing/colour/layout values and do not consistently use shared mobile primitives/tokens. | OPEN |
 | MOB-018 | P2 | Accessibility | Touch targets/focus work is partially present, but no end-to-end mobile accessibility certification exists for large text, screen reader, keyboard/IME and contrast across critical flows. | OPEN |
 | MOB-019 | P2 | Observability/privacy | `MobileInboxPage` and `MobileChatPage` emit detailed session/user/conversation diagnostic logs outside a `DEV` guard; `?debug=1` can expose internal debug state panels in production. | OPEN |
@@ -52,7 +66,7 @@ Current branch changes make `MobileAppLayout` own `100dvh`, reserve the top safe
 
 - exact diff reviewed and formatting churn self-corrected;
 - Netlify deploy preview built successfully;
-- GitHub Actions lint/typecheck/tests did **not** execute because of the account billing lock;
+- local PowerShell lint/typecheck/tests/build remain the authoritative static/build gate;
 - Android APK/device validation remains pending.
 
 Therefore MOB-001/MOB-002 remain `IN PROGRESS`, not `RESOLVED`.
@@ -65,7 +79,7 @@ A separate draft PR (`#483`) now keeps PWA service-worker registration on regula
 
 - exact diff reviewed: one source file, no business/auth/payment/schema/dependency changes;
 - Netlify deploy preview built successfully;
-- GitHub Actions remains blocked by the account billing issue;
+- local PowerShell lint/typecheck/tests/build remain the authoritative static/build gate;
 - native WebView cleanup and web PWA behaviour still require runtime verification.
 
 Therefore MOB-012/MOB-013 remain `IN PROGRESS`, not `RESOLVED`.
@@ -84,8 +98,9 @@ A separate draft PR (`#484`) isolates the mobile seller media remediation from s
 
 - final branch diff is isolated to three files: the product-image helper, its focused tests, and `MobileSellWizard`;
 - no payment, auth, RLS, schema, shipping, product lifecycle or `create-product` contract changes are present;
-- GitHub Actions jobs did **not** execute. GitHub's check annotation states: `The job was not started because your account is locked due to a billing issue.`;
-- Netlify checks are independent and may provide build evidence, but they do not replace the blocked unit/lint/typecheck gates unless their executed command proves the same coverage;
+- Netlify deploy/check suite completed successfully and produced a deploy preview;
+- GitHub Actions did not execute because of the account billing condition; this is supplementary CI only and is not treated as a code failure;
+- authoritative static/build evidence must come from local PowerShell: lint → typecheck → focused/unit tests → production build;
 - Android camera/gallery, large-file rejection, multi-photo, forced partial failure/retry, Storage cleanup and final publish still require real-device validation.
 
 Therefore MOB-004/MOB-023 remain `IN PROGRESS`, not `RESOLVED`.
@@ -94,4 +109,4 @@ Therefore MOB-004/MOB-023 remain `IN PROGRESS`, not `RESOLVED`.
 
 ## Release rule
 
-No finding may be closed merely because code was written. A finding is closed only when its defined PASS evidence is available and the Branch Guard has checked the final diff for business/security regressions.
+No finding may be closed merely because code was written. A finding is closed only when its defined PASS evidence is available and the Branch Guard has checked the final diff for business/security regressions. For mobile code, the static/build PASS evidence is produced from the local Windows repository in PowerShell; GitHub Actions is not a substitute for that gate.

--- a/docs/mobile/MOBILE_AUDIT_FINDINGS.md
+++ b/docs/mobile/MOBILE_AUDIT_FINDINGS.md
@@ -26,15 +26,19 @@
 | MOB-009 | P1 | Environment safety | `capacitorFetchPatch` contains a production URL fallback. A non-production APK with missing `VITE_APP_URL` can silently talk to production rather than fail closed. | OPEN |
 | MOB-010 | P1 | Auth storage | Native auth uses Capacitor Preferences with localStorage fallback while Android backup is enabled. Backup/restore treatment of session material is not an explicit documented security decision. | OPEN |
 | MOB-011 | P1 | Documentation/security | Supabase storage comments describe native Preferences/SharedPreferences as encrypted at rest. That guarantee is not established by the current implementation and should not be claimed. | OPEN |
-| MOB-012 | P1 | PWA/native | `main.tsx` registers the service worker based on browser capability and does not explicitly exclude Capacitor native runtime, adding an unnecessary cache/lifecycle layer to the APK unless deliberately required. | OPEN |
-| MOB-013 | P1 | PWA correctness | `main.tsx` comments describe a cleanup/no-cache service worker while `public/sw.js` implements real cache-first/network-first behaviour. Source documentation and runtime behaviour disagree. | OPEN |
+| MOB-012 | P1 | PWA/native | `main.tsx` registers the service worker based on browser capability and does not explicitly exclude Capacitor native runtime, adding an unnecessary cache/lifecycle layer to the APK unless deliberately required. | IN PROGRESS |
+| MOB-013 | P1 | PWA correctness | `main.tsx` comments describe a cleanup/no-cache service worker while `public/sw.js` implements real cache-first/network-first behaviour. Source documentation and runtime behaviour disagree. | IN PROGRESS |
 | MOB-014 | P1 | Lifecycle | Android Back/predictive Back, background/resume and listener restoration do not yet have an accepted device validation matrix. | OPEN |
 | MOB-015 | P0 | Release identity | Native Gradle metadata remains `versionCode 1` / `versionName 1.0`; automated release tags exist, but app-version identity is not yet a monotonic production release contract. | OPEN |
 | MOB-016 | P1 | Release validation | GitHub CI is currently unable to start because the GitHub account is locked by a billing issue. The hardening branch therefore has no CI test/lint/typecheck evidence yet. | BLOCKED |
 | MOB-017 | P2 | UI system | Mobile pages contain duplicated inline spacing/colour/layout values and do not consistently use shared mobile primitives/tokens. | OPEN |
 | MOB-018 | P2 | Accessibility | Touch targets/focus work is partially present, but no end-to-end mobile accessibility certification exists for large text, screen reader, keyboard/IME and contrast across critical flows. | OPEN |
-| MOB-019 | P2 | Observability/privacy | `MobileInboxPage` emits detailed session/user/conversation diagnostic logs outside a `DEV` guard; `?debug=1` can also expose an internal debug state panel in production. | OPEN |
+| MOB-019 | P2 | Observability/privacy | `MobileInboxPage` and `MobileChatPage` emit detailed session/user/conversation diagnostic logs outside a `DEV` guard; `?debug=1` can expose internal debug state panels in production. | OPEN |
 | MOB-020 | P2 | Branding | HTML/PWA theme metadata uses `#0A0A0A` while the current app background token is `#0A0E1A`, creating avoidable system-chrome/brand inconsistency. | OPEN |
+| MOB-021 | P1 | Messaging presence | `MobileChatPage` subscribes one Presence channel instance, but draft changes create a new channel instance and call `track()` on it without subscribing. Typing state is therefore not tied to the active subscribed channel and can create redundant channel objects. | OPEN |
+| MOB-022 | P1 | Messaging receipts | `lastSentRead` is set true when any matching message UPDATE reports a sent message as read; the callback does not prove that the updated row is the current user's latest sent message, so the UI can show a misleading `Seen` state. | OPEN |
+| MOB-023 | P1 | Seller media lifecycle | Mobile photo upload uses `Promise.all`; if one network upload rejects after others succeeded, successful objects may already exist in Storage but are not added to form state. Removing a photo also removes only the URL from UI, not the uploaded object. | OPEN |
+| MOB-024 | P1 | Standalone scrolling | Inbox/categories/orders use `min-h-screen` outer containers together with fixed bottom navigation and intended inner scrolling; because the outer height is not constrained to the dynamic viewport, document and inner-scroll ownership is inconsistent. Inbox's list container also lacks its own vertical overflow rule. | OPEN |
 
 ---
 
@@ -52,6 +56,19 @@ Current branch changes make `MobileAppLayout` own `100dvh`, reserve the top safe
 - Android APK/device validation remains pending.
 
 Therefore MOB-001/MOB-002 remain `IN PROGRESS`, not `RESOLVED`.
+
+### Phase P1.7 — MOB-012/MOB-013
+
+A separate draft PR (`#483`) now keeps PWA service-worker registration on regular web, while native Capacitor runtime performs best-effort unregister/Loadify-cache cleanup instead of registering the PWA worker. The misleading `main.tsx` service-worker comment was corrected.
+
+**Validation state**
+
+- exact diff reviewed: one source file, no business/auth/payment/schema/dependency changes;
+- Netlify deploy preview built successfully;
+- GitHub Actions remains blocked by the account billing issue;
+- native WebView cleanup and web PWA behaviour still require runtime verification.
+
+Therefore MOB-012/MOB-013 remain `IN PROGRESS`, not `RESOLVED`.
 
 ---
 

--- a/docs/mobile/MOBILE_AUDIT_FINDINGS.md
+++ b/docs/mobile/MOBILE_AUDIT_FINDINGS.md
@@ -11,10 +11,12 @@ The authoritative engineering gate for mobile hardening is the local Windows rep
 Required static/build sequence:
 
 1. `npm run lint`
-2. `npm run typecheck`
+2. `npx tsc -b --pretty false`
 3. focused/unit tests for the remediation
 4. `npm run build`
 5. Android/device validation where applicable
+
+The repository currently has no `npm run typecheck` script. `npm run build` also executes `tsc -b`, but the explicit TypeScript command above is used as a separately visible validation gate.
 
 GitHub is used for branch isolation, diff review, PR history and merge control. GitHub Actions is supplementary only. If Actions cannot start because of billing/account state, that is an external CI condition and **must not be reported as a code failure or as a blocker to local PowerShell validation**.
 
@@ -66,7 +68,7 @@ Current branch changes make `MobileAppLayout` own `100dvh`, reserve the top safe
 
 - exact diff reviewed and formatting churn self-corrected;
 - Netlify deploy preview built successfully;
-- local PowerShell lint/typecheck/tests/build remain the authoritative static/build gate;
+- local PowerShell lint/TypeScript/tests/build remain the authoritative static/build gate;
 - Android APK/device validation remains pending.
 
 Therefore MOB-001/MOB-002 remain `IN PROGRESS`, not `RESOLVED`.
@@ -79,7 +81,7 @@ A separate draft PR (`#483`) now keeps PWA service-worker registration on regula
 
 - exact diff reviewed: one source file, no business/auth/payment/schema/dependency changes;
 - Netlify deploy preview built successfully;
-- local PowerShell lint/typecheck/tests/build remain the authoritative static/build gate;
+- local PowerShell lint/TypeScript/tests/build remain the authoritative static/build gate;
 - native WebView cleanup and web PWA behaviour still require runtime verification.
 
 Therefore MOB-012/MOB-013 remain `IN PROGRESS`, not `RESOLVED`.
@@ -100,10 +102,11 @@ A separate draft PR (`#484`) isolates the mobile seller media remediation from s
 - no payment, auth, RLS, schema, shipping, product lifecycle or `create-product` contract changes are present;
 - Netlify deploy/check suite completed successfully and produced a deploy preview;
 - GitHub Actions did not execute because of the account billing condition; this is supplementary CI only and is not treated as a code failure;
-- authoritative static/build evidence must come from local PowerShell: lint → typecheck → focused/unit tests → production build;
+- **local PowerShell static/build gate PASSED on 16 August 2026 on exact PR head `1ee7d90eda78c048deda6672bdb6135ef411d7ab`**;
+- PowerShell evidence: clean/stashed worktree before checkout, `origin/main` verified at `22e13a6933c7c7a3bc423bffbd0364eb34f35a04`, exact PR head checkout verified, lint PASS, explicit `npx tsc -b --pretty false` PASS, focused seller-media suite **7/7 PASS**, full suite **138/138 PASS across 21/21 test files**, production build PASS, `git diff --check` PASS, and diff surface exactly the expected three files;
 - Android camera/gallery, large-file rejection, multi-photo, forced partial failure/retry, Storage cleanup and final publish still require real-device validation.
 
-Therefore MOB-004/MOB-023 remain `IN PROGRESS`, not `RESOLVED`.
+Therefore MOB-004/MOB-023 remain `IN PROGRESS`, not `RESOLVED`: the code/static/build gate is accepted, but the required real-device seller-media gate is still outstanding.
 
 ---
 

--- a/docs/mobile/MOBILE_PRODUCTION_HARDENING_MASTER_PLAN.md
+++ b/docs/mobile/MOBILE_PRODUCTION_HARDENING_MASTER_PLAN.md
@@ -1,0 +1,297 @@
+# Loadify Market — Mobile Production Hardening Master Plan
+
+**Owner:** Loadify Market engineering  
+**Scope:** Android APK + shared web-mobile runtime  
+**Baseline commit:** `22e13a6933c7c7a3bc423bffbd0364eb34f35a04`  
+**Working branch:** `mobile-production-hardening`  
+**Release policy:** no production merge until every changed stage passes Branch Guard validation.
+
+---
+
+## 1. Engineering contract
+
+This programme finishes the existing Capacitor application as a production mobile product. It does **not** replace the React/Capacitor architecture and it does **not** invent new marketplace business rules.
+
+Every change must follow this loop:
+
+1. Re-read the current implementation and affected contracts.
+2. Make the smallest coherent change that fixes the identified defect class.
+3. Review the exact diff for unintended product/business behaviour changes.
+4. Run lint, type-check, unit tests and production build.
+5. When native code/config changes, run Capacitor sync and Android release build.
+6. Validate the actual runtime flow on a device/emulator where the defect is device-dependent.
+7. Record unresolved risks; never convert an unverified assumption into a PASS.
+
+### Non-negotiable guard rails
+
+- Preserve existing marketplace lifecycle, payments, permissions, RLS assumptions and Stripe/Supabase contracts unless a separately audited defect proves a change is required.
+- Do not weaken authentication, rate limiting, seller eligibility, checkout integrity or payout protections to make tests pass.
+- Do not silently fall back from a non-production build into production services.
+- Do not ship placeholder credentials, debug-only UI, temporary build markers or untracked manual fixes.
+- Do not call an Android release production-ready from web/unit tests alone.
+
+---
+
+## 2. Release gates
+
+A mobile release is `GO` only when all applicable gates are green.
+
+| Gate | Requirement |
+|---|---|
+| G0 Source integrity | exact source SHA recorded; branch based on current main; no unexplained files |
+| G1 Static quality | ESLint PASS, TypeScript PASS, diff check PASS |
+| G2 Behaviour | complete unit suite PASS; critical marketplace smoke tests PASS |
+| G3 Web build | production Vite build PASS with validated environment contract |
+| G4 Native sync | `npx cap sync android` PASS; generated native config inspected |
+| G5 Android build | signed release APK and AAB build PASS |
+| G6 Artifact identity | versionName, versionCode, git SHA, build timestamp and SHA-256 recorded |
+| G7 Device smoke | install/upgrade, cold start, warm start, background/resume, Back navigation PASS |
+| G8 Core marketplace | login, browse, product, cart/checkout, sell/photo/publish, orders, messages PASS |
+| G9 Native integration | app links/auth callback, push registration/routing, external browser returns PASS |
+| G10 UX/accessibility | system insets, keyboard, touch targets, large text, rotation/resizing policy checked |
+| G11 Security/recovery | session persistence/backup policy, startup failure UI, network failure/retry checked |
+
+---
+
+## 3. Priority P0 — release-blocking foundation
+
+### P0.1 Reproducible Android release identity
+
+**Affected files**
+- `.github/workflows/build-android.yml`
+- `android/app/build.gradle`
+- `capacitor.config.ts`
+- release documentation under `docs/mobile/`
+
+**Required state**
+- one documented signing identity and recovery procedure;
+- CI refuses missing signing/environment inputs;
+- release artifact identity is deterministic and traceable to a git SHA;
+- versionCode is monotonically increasing;
+- APK/AAB checksums are produced and retained;
+- no release is produced from an ambiguous environment.
+
+**PASS**
+- clean workflow run produces signed APK+AAB with recorded SHA/version/checksum and no secret exposure.
+
+### P0.2 Seller media publication path
+
+**Affected files**
+- `src/pages/MobileSellWizard.tsx`
+- product image upload helpers/storage calls
+- relevant tests
+
+**Required state**
+- accepted media types validated;
+- filename/MIME/ext handling is deterministic;
+- size and count limits enforced before upload;
+- useful per-step error/retry state;
+- failed product creation does not leave an apparently successful UI state;
+- real-device camera/gallery files are supported.
+
+**PASS**
+- real device: JPEG + PNG/WebP as supported, camera image, large image failure, retry, multi-image and final publish all behave correctly.
+
+### P0.3 Startup recovery instead of blank screen
+
+**Affected files**
+- `src/main.tsx`
+- `src/lib/supabase.ts`
+- startup/error boundary code
+
+**Required state**
+- configuration/native bootstrap failures render a recovery screen rather than a blank WebView;
+- diagnostics expose safe release/build identifiers, never secrets;
+- retry works for recoverable initialisation failures.
+
+**PASS**
+- intentionally broken safe test configuration yields visible recovery UX; normal configuration boots unchanged.
+
+---
+
+## 4. Priority P1 — native product correctness
+
+### P1.1 Mobile application shell / edge-to-edge
+
+**Affected files**
+- `src/layouts/MobileAppLayout.tsx`
+- `src/components/MobileAppHeader.tsx`
+- `src/components/MobileBottomNav.tsx`
+- `src/index.css`
+- mobile standalone pages that currently implement their own inset logic
+
+**Required state**
+- one app-shell contract owns viewport height and OS insets;
+- content never renders behind status/navigation bars;
+- only intended content region scrolls;
+- bottom nav and sticky headers remain stable;
+- keyboard does not hide active form controls;
+- no page-specific magic spacer is required to compensate for nav height.
+
+**PASS**
+- 360/375/390/412 px viewports plus Android gesture and 3-button navigation show no overlap, clipped CTA or horizontal scroll.
+
+### P1.2 Android Back and lifecycle
+
+**Affected files**
+- `src/App.tsx`
+- Capacitor app lifecycle helper/hooks
+
+**Required state**
+- modal/sheet closes before route navigation where appropriate;
+- route back works consistently;
+- root behaviour is intentional;
+- background/resume does not duplicate listeners or corrupt auth state;
+- predictive-back-compatible behaviour is verified on supported Android.
+
+**PASS**
+- defined navigation matrix passes on device/emulator.
+
+### P1.3 App Links, OAuth and password recovery
+
+**Affected files**
+- `android/app/src/main/AndroidManifest.xml`
+- `src/App.tsx`
+- auth callback/reset flows
+- domain association file/configuration outside repo where required
+
+**Required state**
+- verified HTTPS App Links for owned Loadify domain;
+- allow-list only intended paths/hosts;
+- OAuth callback, password reset and product/order links land on correct in-app routes;
+- malformed/untrusted URLs fail safely.
+
+**PASS**
+- cold-start and warm-start deep links pass from external browser/email.
+
+### P1.4 Native push notifications
+
+**Affected files**
+- `package.json` / lockfile
+- Capacitor Android generated/plugin configuration
+- `src/hooks/usePushTokenRegistration.ts`
+- push-token backend and notification routing
+
+**Required state**
+- official Capacitor push plugin installed and synced;
+- Firebase configuration managed as a protected release input;
+- Android runtime notification permission handled for supported API levels;
+- token register/update/logout lifecycle handled;
+- notification tap routes to intended resource;
+- backend has no duplicate/stale-token amplification.
+
+**PASS**
+- foreground/background/killed-state notification tests pass on real Android release build.
+
+### P1.5 Networking contract consolidation
+
+**Affected files**
+- `src/lib/authorizedFetch.ts`
+- `src/lib/capacitorFetchPatch.ts`
+- `src/lib/supabase.ts`
+- `capacitor.config.ts`
+
+**Required state**
+- clear ownership for Netlify API, Supabase and external-browser requests;
+- no accidental production fallback for test/staging builds;
+- timeout/retry/offline errors are classified consistently;
+- request bodies/headers survive native transport unchanged;
+- global fetch patching is reduced or formally constrained with tests.
+
+**PASS**
+- API/auth/storage/payment-return smoke matrix passes on Wi-Fi, offline transition and poor network.
+
+### P1.6 Session storage, backup and logout hygiene
+
+**Affected files**
+- `src/lib/supabase.ts`
+- `android/app/src/main/AndroidManifest.xml`
+- Android backup rules if enabled
+
+**Required state**
+- comments/documentation accurately describe storage guarantees;
+- backup/restore treatment of auth material is explicit;
+- logout removes local session and push association as intended;
+- app reinstall/upgrade behaviour documented and tested.
+
+**PASS**
+- session persistence and removal scenarios pass without relying on undocumented platform behaviour.
+
+### P1.7 PWA/native runtime separation
+
+**Affected files**
+- `src/main.tsx`
+- `public/sw.js`
+
+**Required state**
+- PWA service worker lifecycle is web-only unless a deliberate native caching requirement is documented;
+- source comments match actual caching behaviour;
+- API responses are never cached by the service worker.
+
+**PASS**
+- web PWA retains intended offline/static caching; native APK has no unintended service-worker cache layer.
+
+---
+
+## 5. Priority P2 — premium product quality
+
+### P2.1 Mobile design-system contract
+
+Create/reuse shared primitives for AppShell, AppHeader, Page, ScrollRegion, StickyCTA, FormField, Sheet and safe areas. Reduce raw colours and page-specific magic spacing without performing a cosmetic rewrite.
+
+**PASS:** mobile core screens use common primitives and retain existing brand identity.
+
+### P2.2 Accessibility
+
+Audit touch targets, accessible names, focus management, contrast, reduced motion, screen-reader order and 200%/large-font behaviour.
+
+**PASS:** no critical accessibility blocker in login, browse, product, sell, checkout, orders and messaging.
+
+### P2.3 Performance and memory
+
+Measure cold/warm startup, JS bundle cost, long tasks, image memory, list rendering and repeated navigation leaks. Optimise based on measurements rather than arbitrary rewrites.
+
+**PASS:** agreed device baseline has stable startup/navigation and no reproducible memory-growth defect in core flows.
+
+### P2.4 Media UX
+
+Add native-grade capture/gallery affordances only where they materially improve reliability: preview, reorder, compression/orientation handling, progress and retry.
+
+### P2.5 Mobile automated QA
+
+Add automated coverage for route/back/deep-link/bootstrap and critical mobile component behaviour, plus a repeatable device smoke checklist for items not realistically covered by unit tests.
+
+---
+
+## 6. Current confirmed technical findings at programme start
+
+- Android package/application ID: `co.uk.loadifymarket.app`.
+- Android target/compile SDK: 36; min SDK: 24.
+- Current Gradle metadata: `versionCode 1`, `versionName "1.0"`.
+- Current release build uses CI-injected signing properties and builds APK + AAB.
+- `MobileAppLayout` currently uses document scrolling plus a fixed bottom nav and a hard-coded spacer.
+- Home and several standalone mobile pages also contain their own safe-area/bottom-nav compensation, so inset ownership is duplicated.
+- App-level `appUrlOpen` handling exists, but the current Android manifest does not expose verified HTTPS VIEW/BROWSABLE App Links.
+- Push registration client code exists, but the official Capacitor push-notifications dependency is not present in current package dependencies.
+- `patchCapacitorFetch()` globally wraps fetch for Netlify function URLs in native context; Supabase also supplies a custom fetch path.
+- Native Supabase auth storage uses Capacitor Preferences with localStorage fallback; backup policy remains explicit hardening work.
+- `main.tsx` registers the service worker for any browser exposing `serviceWorker`; it is not currently gated out for Capacitor native runtime.
+
+---
+
+## 7. Execution order
+
+1. Baseline + plan committed on isolated hardening branch.
+2. P1.1 application shell/insets because it affects every mobile screen and is a visible runtime defect.
+3. P0.2 seller media path because listing publication is marketplace-critical.
+4. P0.3 startup recovery.
+5. P0.1 release identity/version/checksum hardening.
+6. P1.2 lifecycle/Back.
+7. P1.3 App Links/auth return.
+8. P1.4 push.
+9. P1.5 networking consolidation.
+10. P1.6 session/backup hygiene.
+11. P1.7 PWA/native separation.
+12. P2 design system, accessibility, performance and automated mobile QA.
+
+The order may change only when a newly verified blocker has higher production risk. Every reorder must be recorded in this document or the PR history.

--- a/src/components/MobileAppHeader.tsx
+++ b/src/components/MobileAppHeader.tsx
@@ -4,9 +4,9 @@
  * Shows: M logo + branding (left) | Bell notification icon (right)
  *        Inline search bar + filter button (second row)
  *
- * Top safe-area ownership belongs to MobileAppLayout.  Keeping the inset in one
- * place prevents double padding at rest and prevents content from scrolling
- * underneath the Android status bar.
+ * Top safe-area ownership belongs to MobileAppLayout. Keeping the inset in one
+ * place prevents double padding and prevents content from scrolling underneath
+ * the Android status bar.
  */
 
 import { useEffect, useState } from 'react';
@@ -40,146 +40,145 @@ export default function MobileAppHeader() {
     })();
     return () => { cancelled = true; };
   }, [user?.id]);
-
   return (
     <>
-      <header
-        style={{
-          paddingTop: '0.75rem',
-          paddingBottom: '0.75rem',
-          paddingLeft: 16,
-          paddingRight: 16,
-        }}
-        className="bg-background"
-      >
-        {/* ── Row 1: logo + brand name (left) | bell (right) ─── */}
-        <div className="flex items-center justify-between">
-          {/* Left: logo + brand */}
-          <div className="flex items-center gap-2.5" style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
-            {/* Logo */}
-            <img
-              src={logo}
-              alt=""
-              aria-hidden="true"
-              width={38}
-              height={38}
-              style={{ width: 38, height: 38, flexShrink: 0 }}
-            />
+    <header
+      style={{
+        paddingTop: '0.75rem',
+        paddingBottom: '0.75rem',
+        paddingLeft: 16,
+        paddingRight: 16,
+      }}
+      className="bg-background"
+    >
+      {/* ── Row 1: logo + brand name (left) | bell (right) ─── */}
+      <div className="flex items-center justify-between">
+        {/* Left: logo + brand */}
+        <div className="flex items-center gap-2.5" style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+          {/* Logo */}
+          <img
+            src={logo}
+            alt=""
+            aria-hidden="true"
+            width={38}
+            height={38}
+            style={{ width: 38, height: 38, flexShrink: 0 }}
+          />
 
-            {/* Brand text */}
-            <div className="flex flex-col leading-none" style={{ minWidth: 0, gap: 2 }}>
-              <span
-                className="text-foreground"
-                style={{
-                  fontSize: 'clamp(14px, 4.2vw, 19px)',
-                  fontWeight: 800,
-                  letterSpacing: 'clamp(0.5px, 0.2vw, 1px)',
-                  lineHeight: 1,
-                  fontFamily: 'var(--font-display)',
-                  whiteSpace: 'nowrap',
-                }}
-              >
-                Loadify
-              </span>
-              <span
-                style={{
-                  fontSize: 'clamp(10px, 2.8vw, 13px)',
-                  fontWeight: 800,
-                  letterSpacing: 'clamp(0.5px, 0.3vw, 1.5px)',
-                  lineHeight: 1,
-                  fontFamily: 'var(--font-display)',
-                  whiteSpace: 'nowrap',
-                }}
-                className="text-primary"
-              >
-                MARKET
-              </span>
-            </div>
-          </div>
-
-          {/* Right: bell */}
-          <button
-            onClick={() => navigate('/inbox')}
-            aria-label={`Notifications${unread > 0 ? `, ${unread} unread` : ''}`}
-            className="relative h-11 w-11 shrink-0 cursor-pointer border-0 bg-transparent p-0 flex items-center justify-center"
-          >
-            <Bell
-              style={{ width: 22, height: 22 }} className="text-white"
-              aria-hidden="true"
-            />
-            {unread > 0 && (
-              <span
-                aria-hidden="true"
-                style={{
-                  position: 'absolute',
-                  top: 4,
-                  right: 4,
-                  minWidth: 17,
-                  height: 17,
-                  borderRadius: 9999,
-                  fontSize: 9,
-                  fontWeight: 700,
-                  display: 'flex',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  paddingLeft: 2,
-                  paddingRight: 2,
-                }}
-                className="bg-primary text-black"
-              >
-                {unread > 9 ? '9+' : unread}
-              </span>
-            )}
-          </button>
-        </div>
-
-        {/* ── Row 2: search bar + filter button ─── */}
-        <div className="flex items-center gap-2" style={{ marginTop: 10 }}>
-          {/* Search bar — taps open full-screen overlay */}
-          <button
-            onClick={() => setSearchOpen(true)}
-            aria-label="Search for items or members"
-            className="h-11 flex-1 rounded-xl border border-white/10 bg-white/[0.07] px-3.5 text-left flex items-center gap-2.5 cursor-pointer"
-          >
-            <Search
-              style={{ width: 18, height: 18, flexShrink: 0 }} className="text-white/45"
-              aria-hidden="true"
-            />
+          {/* Brand text */}
+          <div className="flex flex-col leading-none" style={{ minWidth: 0, gap: 2 }}>
             <span
-              className="text-foreground/55"
+              className="text-foreground"
               style={{
-                fontSize: 14,
+                fontSize: 'clamp(14px, 4.2vw, 19px)',
+                fontWeight: 800,
+                letterSpacing: 'clamp(0.5px, 0.2vw, 1px)',
+                lineHeight: 1,
+                fontFamily: 'var(--font-display)',
                 whiteSpace: 'nowrap',
-                overflow: 'hidden',
-                textOverflow: 'ellipsis',
-                flex: 1,
               }}
             >
-              Search for items or members
+              Loadify
             </span>
-            <Camera
-              style={{ width: 18, height: 18, flexShrink: 0 }} className="text-white/45"
-              aria-hidden="true"
-            />
-          </button>
-
-          {/* Filter button */}
-          <button
-            aria-label="Filter"
-            onClick={() => navigate('/catalog')}
-            className="h-11 w-11 shrink-0 rounded-xl border border-[#f2b84b66] bg-[#1c1400] flex items-center justify-center cursor-pointer"
-          >
-            <Filter
-              style={{ width: 18, height: 18 }}
+            <span
+              style={{
+                fontSize: 'clamp(10px, 2.8vw, 13px)',
+                fontWeight: 800,
+                letterSpacing: 'clamp(0.5px, 0.3vw, 1.5px)',
+                lineHeight: 1,
+                fontFamily: 'var(--font-display)',
+                whiteSpace: 'nowrap',
+              }}
               className="text-primary"
-              aria-hidden="true"
-            />
-          </button>
+            >
+              MARKET
+            </span>
+          </div>
         </div>
-      </header>
 
-      {/* Full-screen search overlay — rendered outside the header flow */}
-      {searchOpen && <MobileSearchOverlay onClose={() => setSearchOpen(false)} />}
-    </>
+        {/* Right: bell */}
+        <button
+          onClick={() => navigate('/inbox')}
+          aria-label={`Notifications${unread > 0 ? `, ${unread} unread` : ''}`}
+          className="relative h-11 w-11 shrink-0 cursor-pointer border-0 bg-transparent p-0 flex items-center justify-center"
+        >
+          <Bell
+            style={{ width: 22, height: 22 }} className="text-white"
+            aria-hidden="true"
+          />
+          {unread > 0 && (
+            <span
+              aria-hidden="true"
+              style={{
+                position: 'absolute',
+                top: 4,
+                right: 4,
+                minWidth: 17,
+                height: 17,
+                borderRadius: 9999,
+                fontSize: 9,
+                fontWeight: 700,
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                paddingLeft: 2,
+                paddingRight: 2,
+              }}
+              className="bg-primary text-black"
+            >
+              {unread > 9 ? '9+' : unread}
+            </span>
+          )}
+        </button>
+      </div>
+
+      {/* ── Row 2: search bar + filter button ─── */}
+      <div className="flex items-center gap-2" style={{ marginTop: 10 }}>
+        {/* Search bar — taps open full-screen overlay */}
+        <button
+          onClick={() => setSearchOpen(true)}
+          aria-label="Search for items or members"
+          className="h-11 flex-1 rounded-xl border border-white/10 bg-white/[0.07] px-3.5 text-left flex items-center gap-2.5 cursor-pointer"
+        >
+          <Search
+            style={{ width: 18, height: 18, flexShrink: 0 }} className="text-white/45"
+            aria-hidden="true"
+          />
+          <span
+            className="text-foreground/55"
+            style={{
+              fontSize: 14,
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+              flex: 1,
+            }}
+          >
+            Search for items or members
+          </span>
+          <Camera
+            style={{ width: 18, height: 18, flexShrink: 0 }} className="text-white/45"
+            aria-hidden="true"
+          />
+        </button>
+
+        {/* Filter button */}
+        <button
+          aria-label="Filter"
+          onClick={() => navigate('/catalog')}
+          className="h-11 w-11 shrink-0 rounded-xl border border-[#f2b84b66] bg-[#1c1400] flex items-center justify-center cursor-pointer"
+        >
+          <Filter
+            style={{ width: 18, height: 18 }}
+            className="text-primary"
+            aria-hidden="true"
+          />
+        </button>
+      </div>
+    </header>
+
+    {/* Full-screen search overlay — rendered outside the header flow */}
+    {searchOpen && <MobileSearchOverlay onClose={() => setSearchOpen(false)} />}
+  </>
   );
 }

--- a/src/components/MobileAppHeader.tsx
+++ b/src/components/MobileAppHeader.tsx
@@ -3,6 +3,10 @@
  *
  * Shows: M logo + branding (left) | Bell notification icon (right)
  *        Inline search bar + filter button (second row)
+ *
+ * Top safe-area ownership belongs to MobileAppLayout.  Keeping the inset in one
+ * place prevents double padding at rest and prevents content from scrolling
+ * underneath the Android status bar.
  */
 
 import { useEffect, useState } from 'react';
@@ -36,145 +40,146 @@ export default function MobileAppHeader() {
     })();
     return () => { cancelled = true; };
   }, [user?.id]);
+
   return (
     <>
-    <header
-      style={{
-        paddingTop: 'calc(0.75rem + env(safe-area-inset-top, 0px))',
-        paddingBottom: '0.75rem',
-        paddingLeft: 16,
-        paddingRight: 16,
-      }}
-      className="bg-background"
-    >
-      {/* ── Row 1: logo + brand name (left) | bell (right) ─── */}
-      <div className="flex items-center justify-between">
-        {/* Left: logo + brand */}
-        <div className="flex items-center gap-2.5" style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
-          {/* Logo */}
-          <img
-            src={logo}
-            alt=""
-            aria-hidden="true"
-            width={38}
-            height={38}
-            style={{ width: 38, height: 38, flexShrink: 0 }}
-          />
+      <header
+        style={{
+          paddingTop: '0.75rem',
+          paddingBottom: '0.75rem',
+          paddingLeft: 16,
+          paddingRight: 16,
+        }}
+        className="bg-background"
+      >
+        {/* ── Row 1: logo + brand name (left) | bell (right) ─── */}
+        <div className="flex items-center justify-between">
+          {/* Left: logo + brand */}
+          <div className="flex items-center gap-2.5" style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+            {/* Logo */}
+            <img
+              src={logo}
+              alt=""
+              aria-hidden="true"
+              width={38}
+              height={38}
+              style={{ width: 38, height: 38, flexShrink: 0 }}
+            />
 
-          {/* Brand text */}
-          <div className="flex flex-col leading-none" style={{ minWidth: 0, gap: 2 }}>
-            <span
-              className="text-foreground"
-              style={{
-                fontSize: 'clamp(14px, 4.2vw, 19px)',
-                fontWeight: 800,
-                letterSpacing: 'clamp(0.5px, 0.2vw, 1px)',
-                lineHeight: 1,
-                fontFamily: 'var(--font-display)',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              Loadify
-            </span>
-            <span
-              style={{
-                fontSize: 'clamp(10px, 2.8vw, 13px)',
-                fontWeight: 800,
-                letterSpacing: 'clamp(0.5px, 0.3vw, 1.5px)',
-                lineHeight: 1,
-                fontFamily: 'var(--font-display)',
-                whiteSpace: 'nowrap',
-              }}
-              className="text-primary"
-            >
-              MARKET
-            </span>
+            {/* Brand text */}
+            <div className="flex flex-col leading-none" style={{ minWidth: 0, gap: 2 }}>
+              <span
+                className="text-foreground"
+                style={{
+                  fontSize: 'clamp(14px, 4.2vw, 19px)',
+                  fontWeight: 800,
+                  letterSpacing: 'clamp(0.5px, 0.2vw, 1px)',
+                  lineHeight: 1,
+                  fontFamily: 'var(--font-display)',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                Loadify
+              </span>
+              <span
+                style={{
+                  fontSize: 'clamp(10px, 2.8vw, 13px)',
+                  fontWeight: 800,
+                  letterSpacing: 'clamp(0.5px, 0.3vw, 1.5px)',
+                  lineHeight: 1,
+                  fontFamily: 'var(--font-display)',
+                  whiteSpace: 'nowrap',
+                }}
+                className="text-primary"
+              >
+                MARKET
+              </span>
+            </div>
           </div>
+
+          {/* Right: bell */}
+          <button
+            onClick={() => navigate('/inbox')}
+            aria-label={`Notifications${unread > 0 ? `, ${unread} unread` : ''}`}
+            className="relative h-11 w-11 shrink-0 cursor-pointer border-0 bg-transparent p-0 flex items-center justify-center"
+          >
+            <Bell
+              style={{ width: 22, height: 22 }} className="text-white"
+              aria-hidden="true"
+            />
+            {unread > 0 && (
+              <span
+                aria-hidden="true"
+                style={{
+                  position: 'absolute',
+                  top: 4,
+                  right: 4,
+                  minWidth: 17,
+                  height: 17,
+                  borderRadius: 9999,
+                  fontSize: 9,
+                  fontWeight: 700,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  paddingLeft: 2,
+                  paddingRight: 2,
+                }}
+                className="bg-primary text-black"
+              >
+                {unread > 9 ? '9+' : unread}
+              </span>
+            )}
+          </button>
         </div>
 
-        {/* Right: bell */}
-        <button
-          onClick={() => navigate('/inbox')}
-          aria-label={`Notifications${unread > 0 ? `, ${unread} unread` : ''}`}
-          className="relative h-11 w-11 shrink-0 cursor-pointer border-0 bg-transparent p-0 flex items-center justify-center"
-        >
-          <Bell
-            style={{ width: 22, height: 22 }} className="text-white"
-            aria-hidden="true"
-          />
-          {unread > 0 && (
-            <span
-              aria-hidden="true"
-              style={{
-                position: 'absolute',
-                top: 4,
-                right: 4,
-                minWidth: 17,
-                height: 17,
-                borderRadius: 9999,
-                fontSize: 9,
-                fontWeight: 700,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                paddingLeft: 2,
-                paddingRight: 2,
-              }}
-              className="bg-primary text-black"
-            >
-              {unread > 9 ? '9+' : unread}
-            </span>
-          )}
-        </button>
-      </div>
-
-      {/* ── Row 2: search bar + filter button ─── */}
-      <div className="flex items-center gap-2" style={{ marginTop: 10 }}>
-        {/* Search bar — taps open full-screen overlay */}
-        <button
-          onClick={() => setSearchOpen(true)}
-          aria-label="Search for items or members"
-          className="h-11 flex-1 rounded-xl border border-white/10 bg-white/[0.07] px-3.5 text-left flex items-center gap-2.5 cursor-pointer"
-        >
-          <Search
-            style={{ width: 18, height: 18, flexShrink: 0 }} className="text-white/45"
-            aria-hidden="true"
-          />
-          <span
-            className="text-foreground/55"
-            style={{
-              fontSize: 14,
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              flex: 1,
-            }}
+        {/* ── Row 2: search bar + filter button ─── */}
+        <div className="flex items-center gap-2" style={{ marginTop: 10 }}>
+          {/* Search bar — taps open full-screen overlay */}
+          <button
+            onClick={() => setSearchOpen(true)}
+            aria-label="Search for items or members"
+            className="h-11 flex-1 rounded-xl border border-white/10 bg-white/[0.07] px-3.5 text-left flex items-center gap-2.5 cursor-pointer"
           >
-            Search for items or members
-          </span>
-          <Camera
-            style={{ width: 18, height: 18, flexShrink: 0 }} className="text-white/45"
-            aria-hidden="true"
-          />
-        </button>
+            <Search
+              style={{ width: 18, height: 18, flexShrink: 0 }} className="text-white/45"
+              aria-hidden="true"
+            />
+            <span
+              className="text-foreground/55"
+              style={{
+                fontSize: 14,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                flex: 1,
+              }}
+            >
+              Search for items or members
+            </span>
+            <Camera
+              style={{ width: 18, height: 18, flexShrink: 0 }} className="text-white/45"
+              aria-hidden="true"
+            />
+          </button>
 
-        {/* Filter button */}
-        <button
-          aria-label="Filter"
-          onClick={() => navigate('/catalog')}
-          className="h-11 w-11 shrink-0 rounded-xl border border-[#f2b84b66] bg-[#1c1400] flex items-center justify-center cursor-pointer"
-        >
-          <Filter
-            style={{ width: 18, height: 18 }}
-            className="text-primary"
-            aria-hidden="true"
-          />
-        </button>
-      </div>
-    </header>
+          {/* Filter button */}
+          <button
+            aria-label="Filter"
+            onClick={() => navigate('/catalog')}
+            className="h-11 w-11 shrink-0 rounded-xl border border-[#f2b84b66] bg-[#1c1400] flex items-center justify-center cursor-pointer"
+          >
+            <Filter
+              style={{ width: 18, height: 18 }}
+              className="text-primary"
+              aria-hidden="true"
+            />
+          </button>
+        </div>
+      </header>
 
-    {/* Full-screen search overlay — rendered outside the header flow */}
-    {searchOpen && <MobileSearchOverlay onClose={() => setSearchOpen(false)} />}
-  </>
+      {/* Full-screen search overlay — rendered outside the header flow */}
+      {searchOpen && <MobileSearchOverlay onClose={() => setSearchOpen(false)} />}
+    </>
   );
 }

--- a/src/layouts/MobileAppLayout.tsx
+++ b/src/layouts/MobileAppLayout.tsx
@@ -1,18 +1,19 @@
 /**
  * MobileAppLayout — mobile-first shell used on viewports < 768 px.
  *
+ * The shell owns the Android/mobile viewport instead of letting the document
+ * body scroll underneath the OS status/navigation bars.  This gives every page
+ * one predictable scroll region and one owner for the top safe-area inset.
+ *
  * Provides:
- *  - Dark app background (#0A0E1A) consistent with the APK
- *  - Bottom safe-area padding so content is never hidden behind the nav bar
+ *  - 100dvh application viewport
+ *  - Top safe-area ownership for edge-to-edge Android windows
+ *  - A dedicated vertical scroll region for page content
+ *  - Bottom reachability above MobileBottomNav
  *  - MobileBottomNav fixed at the bottom
- *  - A spacer element above MobileBottomNav so the last piece of content is reachable
  *
- * Does NOT include:
- *  - The desktop Header (hidden on mobile via Header's own `hidden md:block` class)
- *  - The desktop Footer
- *
- * Individual pages are responsible for their own page-level header on mobile
- * (e.g. MobileAppHeader on the home page, a back-button bar on product detail).
+ * Individual pages still own their page-level headers/content.  They must not
+ * add a second top safe-area inset when rendered inside this shell.
  */
 
 import type { ReactNode } from "react";
@@ -24,7 +25,10 @@ interface MobileAppLayoutProps {
 
 export default function MobileAppLayout({ children }: MobileAppLayoutProps) {
   return (
-    <div className="min-h-screen bg-background">
+    <div
+      className="flex h-[100dvh] min-h-[100dvh] flex-col overflow-hidden bg-background"
+      style={{ paddingTop: 'env(safe-area-inset-top, 0px)' }}
+    >
       {/* Skip-to-content link — visible only on keyboard focus (WCAG 2.1 SC 2.4.1) */}
       <a
         href="#main-content"
@@ -33,10 +37,25 @@ export default function MobileAppLayout({ children }: MobileAppLayoutProps) {
         Skip to main content
       </a>
 
-      {children}
+      <div
+        className="min-h-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-y-contain"
+        style={{ WebkitOverflowScrolling: 'touch' }}
+        data-mobile-scroll-region
+      >
+        {children}
 
-      {/* Spacer so the last content row isn't hidden behind the fixed bottom nav */}
-      <div className="h-[70px]" aria-hidden="true" />
+        {/*
+         * Keep the final content reachable above the fixed navigation bar.
+         * The nav itself owns the bottom safe-area padding; this spacer mirrors
+         * only the occupied visual space so pages do not need magic 70px pads.
+         */}
+        <div
+          style={{
+            height: 'calc(var(--mob-nav-h, 68px) + env(safe-area-inset-bottom, 0px))',
+          }}
+          aria-hidden="true"
+        />
+      </div>
 
       <MobileBottomNav />
     </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -53,7 +53,7 @@ function MobileHome() {
   }, [loadMore]);
 
   return (
-    <div className="md:hidden min-h-screen bg-background">
+    <div className="md:hidden bg-background">
       <MobileAppHeader />
       <MobileCategoryShortcuts />
       <MobileHeroBanner />
@@ -63,7 +63,7 @@ function MobileHome() {
         style={{
           paddingInline: 'var(--mob-side, 16px)',
           paddingTop: 12,
-          paddingBottom: 'calc(var(--mob-nav-h, 68px) + env(safe-area-inset-bottom, 0px) + 20px)',
+          paddingBottom: 20,
         }}
       >
         <div

--- a/src/pages/MobileCategoriesPage.tsx
+++ b/src/pages/MobileCategoriesPage.tsx
@@ -71,7 +71,7 @@ export default function MobileCategoriesPage() {
 
   return (
     <div
-      className="min-h-screen flex flex-col bg-background"
+      className="h-[100dvh] min-h-0 overflow-hidden flex flex-col bg-background"
     >
       {/* ── Sticky header ── */}
       <div
@@ -99,7 +99,7 @@ export default function MobileCategoriesPage() {
 
       {/* ── Category rows ── */}
       <div
-        className="flex-1 overflow-y-auto"
+        className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain"
         style={{ paddingBottom: 'calc(80px + env(safe-area-inset-bottom, 0px))' }}
       >
         {/* "All Categories" is always the first row */}

--- a/src/pages/MobileInboxPage.tsx
+++ b/src/pages/MobileInboxPage.tsx
@@ -340,14 +340,14 @@ export default function MobileInboxPage() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
+      <div className="h-[100dvh] bg-background flex items-center justify-center">
         <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary" />
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen flex flex-col bg-background">
+    <div className="h-[100dvh] min-h-0 overflow-hidden flex flex-col bg-background">
       {/* ── Header ── */}
       <div
         className="shrink-0 sticky top-0 z-40 bg-background/[0.97]"
@@ -459,7 +459,10 @@ export default function MobileInboxPage() {
       )}
 
       {/* ── List ── */}
-      <div style={{ flex: 1, paddingBottom: "calc(80px + env(safe-area-inset-bottom, 0px))" }}>
+      <div
+        className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain"
+        style={{ paddingBottom: "calc(80px + env(safe-area-inset-bottom, 0px))" }}
+      >
         {loading ? (
           <div style={{ padding: "16px", display: "flex", flexDirection: "column", gap: "12px" }}>
             {[...Array(6)].map((_, i) => (

--- a/src/pages/MobileOrdersPage.tsx
+++ b/src/pages/MobileOrdersPage.tsx
@@ -254,7 +254,7 @@ export default function MobileOrdersPage() {
 
   return (
     <div
-      className="min-h-screen flex flex-col bg-background"
+      className="h-[100dvh] min-h-0 overflow-hidden flex flex-col bg-background"
     >
       {/* ── Header ── */}
       <div
@@ -300,7 +300,7 @@ export default function MobileOrdersPage() {
 
       {/* ── Content ── */}
       <div
-        className="flex-1 overflow-y-auto px-4 py-4"
+        className="min-h-0 flex-1 overflow-y-auto overscroll-y-contain px-4 py-4"
         style={{ paddingBottom: "calc(80px + env(safe-area-inset-bottom, 0px))" }}
       >
         {loading ? (

--- a/src/pages/MobileProfilePage.tsx
+++ b/src/pages/MobileProfilePage.tsx
@@ -231,7 +231,7 @@ export default function MobileProfilePage() {
 
   return (
     <div
-      className="md:hidden min-h-screen bg-background"
+      className="md:hidden h-[100dvh] overflow-y-auto overscroll-y-contain bg-background"
       style={{
         paddingTop: 'env(safe-area-inset-top, 0px)',
         paddingBottom: 'calc(var(--mob-nav-h, 68px) + env(safe-area-inset-bottom, 0px))',


### PR DESCRIPTION
## Purpose
Start the Mobile Production Hardening Program from the verified `main` baseline `22e13a6933c7c7a3bc423bffbd0364eb34f35a04`.

## Current phase
P1.1 — application shell / Android edge-to-edge groundwork.

## Changes
- add the engineering master remediation plan and release gates;
- make `MobileAppLayout` own a `100dvh` viewport and dedicated scroll region;
- reserve the Android top safe-area outside the scroll region so content cannot scroll under the status bar;
- remove duplicate top inset from `MobileAppHeader`;
- remove Home-specific duplicate viewport/bottom-nav compensation.

## Branch Guard constraints
- no marketplace lifecycle changes;
- no payment/auth/RLS/permissions changes;
- no API/schema changes;
- no dependency changes;
- no production merge before CI and device-level verification of the shell behaviour.

## Required validation
- CI lint/typecheck/tests/build;
- diff review against baseline;
- Android device smoke: initial Home state, long scroll, search overlay, bottom navigation, gesture navigation, keyboard paths.
