### PR TITLE
SUPERSEDED — Mobile seller media hardening

### DIFF
--- a/src/lib/productImageStorage.test.ts
+++ b/src/lib/productImageStorage.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const storageMocks = vi.hoisted(() => ({
+  upload: vi.fn(),
+  remove: vi.fn(),
+  getPublicUrl: vi.fn(),
+  from: vi.fn(),
+}));
+
+vi.mock('@/lib/supabase', () => ({
+  supabase: {
+    storage: {
+      from: storageMocks.from,
+    },
+  },
+}));
+
+import {
+  MAX_PRODUCT_IMAGE_SIZE,
+  ProductImageStorageError,
+  resolveProductImageMetadata,
+  uploadProductImageBatch,
+} from '@/lib/productImageStorage';
+
+function makeFile(name: string, type: string, size = 32): File {
+  return new File([new Uint8Array(size)], name, { type });
+}
+
+describe('productImageStorage', () => {
+  beforeEach(() => {
+    storageMocks.upload.mockReset();
+    storageMocks.remove.mockReset();
+    storageMocks.getPublicUrl.mockReset();
+    storageMocks.from.mockReset();
+
+    storageMocks.from.mockReturnValue({
+      upload: storageMocks.upload,
+      remove: storageMocks.remove,
+      getPublicUrl: storageMocks.getPublicUrl,
+    });
+    storageMocks.remove.mockResolvedValue({ data: [], error: null });
+    storageMocks.getPublicUrl.mockImplementation((path: string) => ({
+      data: { publicUrl: `https://cdn.example.test/${path}` },
+    }));
+  });
+
+  it('uses MIME as the source of truth for deterministic extension handling', () => {
+    const metadata = resolveProductImageMetadata(makeFile('camera.weird', 'image/jpeg'));
+    expect(metadata).toEqual({ contentType: 'image/jpeg', extension: 'jpg' });
+  });
+
+  it('falls back to a known filename extension only when the browser supplies no MIME', () => {
+    const metadata = resolveProductImageMetadata(makeFile('gallery.PNG', ''));
+    expect(metadata).toEqual({ contentType: 'image/png', extension: 'png' });
+  });
+
+  it('rejects unsupported formats before upload', () => {
+    expect(() => resolveProductImageMetadata(makeFile('photo.heic', 'image/heic'))).toThrow(
+      ProductImageStorageError,
+    );
+  });
+
+  it('rejects oversized files before upload', () => {
+    const file = makeFile('large.jpg', 'image/jpeg', MAX_PRODUCT_IMAGE_SIZE + 1);
+    expect(() => resolveProductImageMetadata(file)).toThrow(/up to 5MB/i);
+  });
+
+  it('rolls back successful objects when another file in the same batch fails', async () => {
+    storageMocks.upload
+      .mockResolvedValueOnce({ data: {}, error: null })
+      .mockResolvedValueOnce({ data: null, error: { message: 'network failure' } });
+
+    await expect(
+      uploadProductImageBatch(
+        [makeFile('one.jpg', 'image/jpeg'), makeFile('two.png', 'image/png')],
+        'seller-123',
+      ),
+    ).rejects.toMatchObject({ code: 'UPLOAD_FAILED' });
+
+    expect(storageMocks.remove).toHaveBeenCalledTimes(1);
+    const [paths] = storageMocks.remove.mock.calls[0] as [string[]];
+    expect(paths).toHaveLength(1);
+    expect(paths[0]).toMatch(/^sellers\/seller-123\/.+\.jpg$/);
+  });
+
+  it('does not start network uploads when the selection contains a known-invalid file', async () => {
+    await expect(
+      uploadProductImageBatch(
+        [makeFile('valid.jpg', 'image/jpeg'), makeFile('invalid.heic', 'image/heic')],
+        'seller-123',
+      ),
+    ).rejects.toMatchObject({ code: 'UNSUPPORTED_TYPE' });
+
+    expect(storageMocks.upload).not.toHaveBeenCalled();
+    expect(storageMocks.remove).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/productImageStorage.test.ts
+++ b/src/lib/productImageStorage.test.ts
@@ -60,6 +60,12 @@ describe('productImageStorage', () => {
     );
   });
 
+  it('does not trust a supported filename extension when the browser reports an unsupported MIME', () => {
+    expect(() => resolveProductImageMetadata(makeFile('renamed.jpg', 'image/heic'))).toThrow(
+      ProductImageStorageError,
+    );
+  });
+
   it('rejects oversized files before upload', () => {
     const file = makeFile('large.jpg', 'image/jpeg', MAX_PRODUCT_IMAGE_SIZE + 1);
     expect(() => resolveProductImageMetadata(file)).toThrow(/up to 5MB/i);

--- a/src/lib/productImageStorage.ts
+++ b/src/lib/productImageStorage.ts
@@ -1,0 +1,172 @@
+import { supabase } from '@/lib/supabase';
+
+export const PRODUCT_IMAGE_BUCKET = 'product-images';
+export const MAX_PRODUCT_IMAGE_SIZE = 5 * 1024 * 1024;
+
+export type SupportedProductImageMime = 'image/jpeg' | 'image/png' | 'image/webp';
+
+export interface ProductImageAsset {
+  url: string;
+  path: string;
+  contentType: SupportedProductImageMime;
+}
+
+export type ProductImageErrorCode =
+  | 'EMPTY_FILE'
+  | 'FILE_TOO_LARGE'
+  | 'UNSUPPORTED_TYPE'
+  | 'UPLOAD_FAILED'
+  | 'DELETE_FAILED';
+
+export class ProductImageStorageError extends Error {
+  readonly code: ProductImageErrorCode;
+  readonly cleanupFailedPaths: string[];
+
+  constructor(code: ProductImageErrorCode, message: string, cleanupFailedPaths: string[] = []) {
+    super(message);
+    this.name = 'ProductImageStorageError';
+    this.code = code;
+    this.cleanupFailedPaths = cleanupFailedPaths;
+  }
+}
+
+const MIME_TO_EXTENSION: Record<SupportedProductImageMime, string> = {
+  'image/jpeg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+};
+
+const EXTENSION_TO_MIME: Record<string, SupportedProductImageMime> = {
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  png: 'image/png',
+  webp: 'image/webp',
+};
+
+function normalizeMime(value: string): SupportedProductImageMime | null {
+  const mime = value.trim().toLowerCase().split(';', 1)[0];
+  if (mime === 'image/jpg') return 'image/jpeg';
+  if (mime === 'image/jpeg' || mime === 'image/png' || mime === 'image/webp') return mime;
+  return null;
+}
+
+function mimeFromFilename(filename: string): SupportedProductImageMime | null {
+  const extension = filename.trim().toLowerCase().split('.').pop();
+  if (!extension || extension === filename.trim().toLowerCase()) return null;
+  return EXTENSION_TO_MIME[extension] ?? null;
+}
+
+export function resolveProductImageMetadata(file: File): {
+  contentType: SupportedProductImageMime;
+  extension: string;
+} {
+  if (file.size <= 0) {
+    throw new ProductImageStorageError('EMPTY_FILE', 'The selected photo is empty. Please choose another image.');
+  }
+
+  if (file.size > MAX_PRODUCT_IMAGE_SIZE) {
+    throw new ProductImageStorageError(
+      'FILE_TOO_LARGE',
+      'Photo is too large. Please choose a JPG, PNG or WebP image up to 5MB.',
+    );
+  }
+
+  const contentType = normalizeMime(file.type) ?? mimeFromFilename(file.name);
+  if (!contentType) {
+    throw new ProductImageStorageError(
+      'UNSUPPORTED_TYPE',
+      'Unsupported photo format. Please use JPG, PNG or WebP.',
+    );
+  }
+
+  return {
+    contentType,
+    extension: MIME_TO_EXTENSION[contentType],
+  };
+}
+
+function buildProductImagePath(userId: string, extension: string): string {
+  const timestamp = Date.now();
+  const random = Math.random().toString(36).slice(2, 10);
+  return `sellers/${userId}/${timestamp}-${random}.${extension}`;
+}
+
+export async function uploadProductImage(file: File, userId: string): Promise<ProductImageAsset> {
+  const metadata = resolveProductImageMetadata(file);
+  const path = buildProductImagePath(userId, metadata.extension);
+  const bucket = supabase.storage.from(PRODUCT_IMAGE_BUCKET);
+
+  const { error } = await bucket.upload(path, file, {
+    cacheControl: '3600',
+    upsert: false,
+    contentType: metadata.contentType,
+  });
+
+  if (error) {
+    throw new ProductImageStorageError(
+      'UPLOAD_FAILED',
+      'Photo upload failed. Check your connection and try again.',
+    );
+  }
+
+  const { data } = bucket.getPublicUrl(path);
+  return {
+    url: data.publicUrl,
+    path,
+    contentType: metadata.contentType,
+  };
+}
+
+export async function deleteProductImages(paths: string[]): Promise<string[]> {
+  const uniquePaths = [...new Set(paths.filter(Boolean))];
+  if (uniquePaths.length === 0) return [];
+
+  const { error } = await supabase.storage.from(PRODUCT_IMAGE_BUCKET).remove(uniquePaths);
+  return error ? uniquePaths : [];
+}
+
+export async function deleteProductImage(path: string): Promise<void> {
+  const failedPaths = await deleteProductImages([path]);
+  if (failedPaths.length > 0) {
+    throw new ProductImageStorageError(
+      'DELETE_FAILED',
+      'Could not remove the photo. Please check your connection and try again.',
+      failedPaths,
+    );
+  }
+}
+
+export async function uploadProductImageBatch(
+  files: File[],
+  userId: string,
+): Promise<ProductImageAsset[]> {
+  if (files.length === 0) return [];
+
+  // Validate the entire selection before the first network request so a known-invalid
+  // file cannot leave earlier files from the same selection stranded in Storage.
+  files.forEach(resolveProductImageMetadata);
+
+  const settled = await Promise.allSettled(files.map((file) => uploadProductImage(file, userId)));
+  const uploaded = settled.flatMap((result) => (result.status === 'fulfilled' ? [result.value] : []));
+  const failed = settled.find((result) => result.status === 'rejected');
+
+  if (!failed) return uploaded;
+
+  const cleanupFailedPaths = await deleteProductImages(uploaded.map((image) => image.path));
+  const reason = failed.reason;
+
+  if (reason instanceof ProductImageStorageError) {
+    throw new ProductImageStorageError(reason.code, reason.message, cleanupFailedPaths);
+  }
+
+  throw new ProductImageStorageError(
+    'UPLOAD_FAILED',
+    'Photo upload failed. Check your connection and try again.',
+    cleanupFailedPaths,
+  );
+}
+
+export function getProductImageErrorMessage(error: unknown): string {
+  if (error instanceof ProductImageStorageError) return error.message;
+  return 'Photo upload failed. Please try again.';
+}

--- a/src/lib/productImageStorage.ts
+++ b/src/lib/productImageStorage.ts
@@ -71,7 +71,8 @@ export function resolveProductImageMetadata(file: File): {
     );
   }
 
-  const contentType = normalizeMime(file.type) ?? mimeFromFilename(file.name);
+  const suppliedMime = file.type.trim();
+  const contentType = suppliedMime ? normalizeMime(suppliedMime) : mimeFromFilename(file.name);
   if (!contentType) {
     throw new ProductImageStorageError(
       'UNSUPPORTED_TYPE',

--- a/src/pages/MobileSellWizard.tsx
+++ b/src/pages/MobileSellWizard.tsx
@@ -11,7 +11,7 @@
  * Defaults: listingContext=product, stockQuantity=1, seller-selected shipping methods.
  */
 
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   ArrowLeft,
@@ -22,16 +22,22 @@ import {
   ChevronRight,
   ChevronDown,
 } from 'lucide-react';
-import { supabase } from '@/lib/supabase';
 import { useAuthStore } from '@/store';
 import { authorizedFetch } from '@/lib/authorizedFetch';
 import { trackStartListing, trackPublishListing } from '@/lib/analytics';
+import {
+  deleteProductImage,
+  deleteProductImages,
+  getProductImageErrorMessage,
+  ProductImageStorageError,
+  type ProductImageAsset,
+  uploadProductImageBatch,
+} from '@/lib/productImageStorage';
 import CategorySelector from '@/components/CategorySelector';
 import ShippingMethodSelector from '@/components/ShippingMethodSelector';
 
 // ── Constants ──────────────────────────────────────────────────────────────────
 
-const STORAGE_BUCKET = 'product-images';
 const MAX_PHOTOS = 6;
 
 const CONDITION_OPTIONS = [
@@ -42,23 +48,6 @@ const CONDITION_OPTIONS = [
   { value: 'fair', label: 'Fair' },
   { value: 'poor', label: 'Poor' },
 ] as const;
-
-// ── Upload helper ──────────────────────────────────────────────────────────────
-
-async function uploadPhoto(file: File, userId: string): Promise<string> {
-  const ts = Date.now();
-  const rand = Math.random().toString(36).slice(2, 8);
-  const ext = file.name.split('.').pop()?.toLowerCase() ?? 'jpg';
-  const path = `sellers/${userId}/${ts}-${rand}.${ext}`;
-
-  const { error } = await supabase.storage
-    .from(STORAGE_BUCKET)
-    .upload(path, file, { cacheControl: '3600', upsert: false });
-
-  if (error) throw error;
-
-  return supabase.storage.from(STORAGE_BUCKET).getPublicUrl(path).data.publicUrl;
-}
 
 // ── Input primitive ────────────────────────────────────────────────────────────
 
@@ -263,7 +252,7 @@ function SuccessSheet({
 // ── Form state ─────────────────────────────────────────────────────────────────
 
 interface FormState {
-  photos: string[];
+  photos: ProductImageAsset[];
   title: string;
   price: string;
   description: string;
@@ -288,9 +277,11 @@ export default function MobileSellWizard() {
   const navigate = useNavigate();
   const { user } = useAuthStore();
   const photoInputRef = useRef<HTMLInputElement>(null);
+  const stagedPhotoPathsRef = useRef<Set<string>>(new Set());
 
   const [form, setForm] = useState<FormState>(INITIAL_FORM);
   const [photoUploading, setPhotoUploading] = useState(false);
+  const [photoRemovingPath, setPhotoRemovingPath] = useState<string | null>(null);
   const [photoError, setPhotoError] = useState<string | null>(null);
   const [publishing, setPublishing] = useState(false);
   const [publishError, setPublishError] = useState<string | null>(null);
@@ -299,6 +290,14 @@ export default function MobileSellWizard() {
   const [selectedShippingMethodIds, setSelectedShippingMethodIds] = useState<string[]>([]);
   const [dispatchTime, setDispatchTime] = useState('');
   const [moreDetailsOpen, setMoreDetailsOpen] = useState(false);
+
+  useEffect(() => {
+    return () => {
+      const stagedPaths = [...stagedPhotoPathsRef.current];
+      stagedPhotoPathsRef.current.clear();
+      if (stagedPaths.length > 0) void deleteProductImages(stagedPaths);
+    };
+  }, []);
 
   // Track listing start once
   const startTrackedRef = useRef(false);
@@ -310,24 +309,57 @@ export default function MobileSellWizard() {
   // ── Photo handlers ────────────────────────────────────────────────────────
 
   const handleAddPhotos = async (files: FileList) => {
-    if (!user?.id) return;
+    if (!user?.id) {
+      setPhotoError('You must be signed in as a seller to upload photos.');
+      return;
+    }
+
+    const remaining = MAX_PHOTOS - form.photos.length;
+    if (remaining <= 0) return;
+
+    const batch = Array.from(files).slice(0, remaining);
+    if (batch.length === 0) return;
+
     setPhotoUploading(true);
     setPhotoError(null);
     if (fieldErrors.photos) setFieldErrors((e) => ({ ...e, photos: undefined }));
+
     try {
-      const remaining = MAX_PHOTOS - form.photos.length;
-      const batch = Array.from(files).slice(0, remaining);
-      const urls = await Promise.all(batch.map((f) => uploadPhoto(f, user.id)));
-      setForm((prev) => ({ ...prev, photos: [...prev.photos, ...urls].slice(0, MAX_PHOTOS) }));
-    } catch {
-      setPhotoError('Photo upload failed. Please try again.');
+      const uploaded = await uploadProductImageBatch(batch, user.id);
+      uploaded.forEach((photo) => stagedPhotoPathsRef.current.add(photo.path));
+      setForm((prev) => ({
+        ...prev,
+        photos: [...prev.photos, ...uploaded].slice(0, MAX_PHOTOS),
+      }));
+    } catch (error) {
+      if (error instanceof ProductImageStorageError) {
+        error.cleanupFailedPaths.forEach((path) => stagedPhotoPathsRef.current.add(path));
+      }
+      setPhotoError(getProductImageErrorMessage(error));
     } finally {
       setPhotoUploading(false);
     }
   };
 
-  const handleRemovePhoto = (idx: number) => {
-    setForm((prev) => ({ ...prev, photos: prev.photos.filter((_, i) => i !== idx) }));
+  const handleRemovePhoto = async (idx: number) => {
+    const photo = form.photos[idx];
+    if (!photo) return;
+
+    setPhotoRemovingPath(photo.path);
+    setPhotoError(null);
+
+    try {
+      await deleteProductImage(photo.path);
+      stagedPhotoPathsRef.current.delete(photo.path);
+      setForm((prev) => ({
+        ...prev,
+        photos: prev.photos.filter((item) => item.path !== photo.path),
+      }));
+    } catch (error) {
+      setPhotoError(getProductImageErrorMessage(error));
+    } finally {
+      setPhotoRemovingPath(null);
+    }
   };
 
   // ── Publish ───────────────────────────────────────────────────────────────
@@ -357,7 +389,7 @@ export default function MobileSellWizard() {
         title: form.title.trim(),
         description: form.description.trim() || form.title.trim(),
         price,
-        images: form.photos,
+        images: form.photos.map((photo) => photo.url),
         categoryId: form.categoryId || null,
         subcategoryId: form.subcategoryId || null,
         specifications: Object.keys(specs).length > 0 ? specs : undefined,
@@ -380,6 +412,7 @@ export default function MobileSellWizard() {
       }
 
       const created = await res.json() as { id: string };
+      stagedPhotoPathsRef.current.clear();
       trackPublishListing(created.id, form.title.trim());
       setPublishedId(created.id);
     } catch (err) {
@@ -400,6 +433,7 @@ export default function MobileSellWizard() {
     setDispatchTime('');
     setPublishedId(null);
     setPublishError(null);
+    setPhotoError(null);
     setMoreDetailsOpen(false);
   };
 
@@ -409,7 +443,7 @@ export default function MobileSellWizard() {
     return <SuccessSheet productId={publishedId} onSellAnother={handleSellAnother} />;
   }
 
-  const busy = publishing || photoUploading;
+  const busy = publishing || photoUploading || photoRemovingPath !== null;
 
   return (
     <div className="bg-background" style={{ minHeight: '100dvh', display: 'flex', flexDirection: 'column' }}>
@@ -472,27 +506,36 @@ export default function MobileSellWizard() {
             Photos <span className="text-primary">*</span>
           </label>
           <div style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: '10px' }}>
-            {form.photos.map((url, idx) => (
+            {form.photos.map((photo, idx) => (
               <div
-                key={idx}
+                key={photo.path}
                 style={{
                   position: 'relative',
                   aspectRatio: '1',
                   borderRadius: '14px',
                   overflow: 'hidden',
                 }}
-                className="bg-surface"              >
+                className="bg-surface"
+              >
                 <img
-                  src={url}
+                  src={photo.url}
                   alt={`Photo ${idx + 1}`}
                   style={{ width: '100%', height: '100%', objectFit: 'cover' }}
                 />
                 <button
                   className="absolute top-1.5 right-1.5 w-6 h-6 rounded-full bg-black/70 border-none flex items-center justify-center cursor-pointer"
                   aria-label={`Remove photo ${idx + 1}`}
-                  onClick={() => handleRemovePhoto(idx)}
+                  onClick={() => void handleRemovePhoto(idx)}
+                  disabled={busy}
                 >
-                  <X className="text-foreground" style={{ width: '14px', height: '14px' }} />
+                  {photoRemovingPath === photo.path ? (
+                    <Loader2
+                      className="text-foreground"
+                      style={{ width: '14px', height: '14px', animation: 'spin 1s linear infinite' }}
+                    />
+                  ) : (
+                    <X className="text-foreground" style={{ width: '14px', height: '14px' }} />
+                  )}
                 </button>
               </div>
             ))}
@@ -501,7 +544,7 @@ export default function MobileSellWizard() {
               <button
                 aria-label="Add photo"
                 onClick={() => photoInputRef.current?.click()}
-                disabled={photoUploading}
+                disabled={busy}
                 style={{
                   aspectRatio: '1',
                   borderRadius: '14px',
@@ -511,8 +554,8 @@ export default function MobileSellWizard() {
                   alignItems: 'center',
                   justifyContent: 'center',
                   gap: '6px',
-                  cursor: photoUploading ? 'not-allowed' : 'pointer',
-                  opacity: photoUploading ? 0.6 : 1,
+                  cursor: busy ? 'not-allowed' : 'pointer',
+                  opacity: busy ? 0.6 : 1,
                 }}
                 className={fieldErrors.photos ? 'bg-danger/[0.04]' : 'bg-primary/[0.04]'}
               >
@@ -521,7 +564,6 @@ export default function MobileSellWizard() {
                     style={{
                       width: '24px',
                       height: '24px',
-                      
                       animation: 'spin 1s linear infinite',
                     }}
                   />
@@ -554,16 +596,19 @@ export default function MobileSellWizard() {
               {photoError}
             </p>
           )}
+          <p className="text-foreground/40" style={{ fontSize: '12px', margin: 0 }}>
+            JPG, PNG or WebP. Up to 5MB per photo.
+          </p>
 
           <input
             ref={photoInputRef}
             type="file"
-            accept="image/*"
+            accept="image/jpeg,image/png,image/webp"
             multiple
             capture="environment"
             style={{ display: 'none' }}
             onChange={(e) => {
-              if (e.target.files && e.target.files.length > 0) handleAddPhotos(e.target.files);
+              if (e.target.files && e.target.files.length > 0) void handleAddPhotos(e.target.files);
               e.target.value = '';
             }}
           />

--- a/src/pages/MobileSellWizard.tsx
+++ b/src/pages/MobileSellWizard.tsx
@@ -16,6 +16,7 @@ import { useNavigate } from 'react-router-dom';
 import {
   ArrowLeft,
   Camera,
+  Images,
   X,
   Loader2,
   CheckCircle2,
@@ -274,7 +275,8 @@ const INITIAL_FORM: FormState = {
 export default function MobileSellWizard() {
   const navigate = useNavigate();
   const { user } = useAuthStore();
-  const photoInputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
+  const galleryInputRef = useRef<HTMLInputElement>(null);
 
   const [form, setForm] = useState<FormState>(INITIAL_FORM);
   const [photoUploading, setPhotoUploading] = useState(false);
@@ -524,41 +526,67 @@ export default function MobileSellWizard() {
             ))}
 
             {form.photos.length < MAX_PHOTOS && (
-              <button
-                aria-label="Add photo"
-                onClick={() => photoInputRef.current?.click()}
-                disabled={busy}
-                style={{
-                  aspectRatio: '1',
-                  borderRadius: '14px',
-                  border: `2px dashed ${fieldErrors.photos ? 'hsl(var(--danger))' : 'rgba(212,175,55,0.35)'}`,
-                  display: 'flex',
-                  flexDirection: 'column',
-                  alignItems: 'center',
-                  justifyContent: 'center',
-                  gap: '6px',
-                  cursor: busy ? 'not-allowed' : 'pointer',
-                  opacity: busy ? 0.6 : 1,
-                }}
-                className={fieldErrors.photos ? 'bg-danger/[0.04]' : 'bg-primary/[0.04]'}
-              >
-                {photoUploading ? (
-                  <Loader2
-                    style={{
-                      width: '24px',
-                      height: '24px',
-                      animation: 'spin 1s linear infinite',
-                    }}
-                  />
-                ) : (
-                  <>
-                    <Camera className={fieldErrors.photos ? 'text-danger' : 'text-primary'} style={{ width: '24px', height: '24px' }} />
-                    <span className={fieldErrors.photos ? 'text-danger' : 'text-primary'} style={{ fontSize: '11px', fontWeight: 600 }}>
-                      Add photo
-                    </span>
-                  </>
-                )}
-              </button>
+              <>
+                <button
+                  aria-label="Take photo"
+                  onClick={() => cameraInputRef.current?.click()}
+                  disabled={busy}
+                  style={{
+                    aspectRatio: '1',
+                    borderRadius: '14px',
+                    border: `2px dashed ${fieldErrors.photos ? 'hsl(var(--danger))' : 'rgba(212,175,55,0.35)'}`,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '6px',
+                    cursor: busy ? 'not-allowed' : 'pointer',
+                    opacity: busy ? 0.6 : 1,
+                  }}
+                  className={fieldErrors.photos ? 'bg-danger/[0.04]' : 'bg-primary/[0.04]'}
+                >
+                  {photoUploading ? (
+                    <Loader2
+                      style={{
+                        width: '24px',
+                        height: '24px',
+                        animation: 'spin 1s linear infinite',
+                      }}
+                    />
+                  ) : (
+                    <>
+                      <Camera className={fieldErrors.photos ? 'text-danger' : 'text-primary'} style={{ width: '24px', height: '24px' }} />
+                      <span className={fieldErrors.photos ? 'text-danger' : 'text-primary'} style={{ fontSize: '11px', fontWeight: 600 }}>
+                        Take photo
+                      </span>
+                    </>
+                  )}
+                </button>
+
+                <button
+                  aria-label="Choose photos from gallery"
+                  onClick={() => galleryInputRef.current?.click()}
+                  disabled={busy}
+                  style={{
+                    aspectRatio: '1',
+                    borderRadius: '14px',
+                    border: `2px dashed ${fieldErrors.photos ? 'hsl(var(--danger))' : 'rgba(212,175,55,0.35)'}`,
+                    display: 'flex',
+                    flexDirection: 'column',
+                    alignItems: 'center',
+                    justifyContent: 'center',
+                    gap: '6px',
+                    cursor: busy ? 'not-allowed' : 'pointer',
+                    opacity: busy ? 0.6 : 1,
+                  }}
+                  className={fieldErrors.photos ? 'bg-danger/[0.04]' : 'bg-primary/[0.04]'}
+                >
+                  <Images className={fieldErrors.photos ? 'text-danger' : 'text-primary'} style={{ width: '24px', height: '24px' }} />
+                  <span className={fieldErrors.photos ? 'text-danger' : 'text-primary'} style={{ fontSize: '11px', fontWeight: 600 }}>
+                    Gallery
+                  </span>
+                </button>
+              </>
             )}
           </div>
 
@@ -580,15 +608,26 @@ export default function MobileSellWizard() {
             </p>
           )}
           <p className="text-foreground/40" style={{ fontSize: '12px', margin: 0 }}>
-            JPG, PNG or WebP. Up to 5MB per photo.
+            Take a new photo or choose JPG, PNG or WebP from your gallery. Up to 5MB per photo.
           </p>
 
           <input
-            ref={photoInputRef}
+            ref={cameraInputRef}
+            type="file"
+            accept="image/*"
+            capture="environment"
+            style={{ display: 'none' }}
+            onChange={(e) => {
+              if (e.target.files && e.target.files.length > 0) void handleAddPhotos(e.target.files);
+              e.target.value = '';
+            }}
+          />
+
+          <input
+            ref={galleryInputRef}
             type="file"
             accept="image/jpeg,image/png,image/webp"
             multiple
-            capture="environment"
             style={{ display: 'none' }}
             onChange={(e) => {
               if (e.target.files && e.target.files.length > 0) void handleAddPhotos(e.target.files);

--- a/src/pages/MobileSellWizard.tsx
+++ b/src/pages/MobileSellWizard.tsx
@@ -11,7 +11,7 @@
  * Defaults: listingContext=product, stockQuantity=1, seller-selected shipping methods.
  */
 
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   ArrowLeft,
@@ -27,9 +27,7 @@ import { authorizedFetch } from '@/lib/authorizedFetch';
 import { trackStartListing, trackPublishListing } from '@/lib/analytics';
 import {
   deleteProductImage,
-  deleteProductImages,
   getProductImageErrorMessage,
-  ProductImageStorageError,
   type ProductImageAsset,
   uploadProductImageBatch,
 } from '@/lib/productImageStorage';
@@ -277,7 +275,6 @@ export default function MobileSellWizard() {
   const navigate = useNavigate();
   const { user } = useAuthStore();
   const photoInputRef = useRef<HTMLInputElement>(null);
-  const stagedPhotoPathsRef = useRef<Set<string>>(new Set());
 
   const [form, setForm] = useState<FormState>(INITIAL_FORM);
   const [photoUploading, setPhotoUploading] = useState(false);
@@ -290,14 +287,6 @@ export default function MobileSellWizard() {
   const [selectedShippingMethodIds, setSelectedShippingMethodIds] = useState<string[]>([]);
   const [dispatchTime, setDispatchTime] = useState('');
   const [moreDetailsOpen, setMoreDetailsOpen] = useState(false);
-
-  useEffect(() => {
-    return () => {
-      const stagedPaths = [...stagedPhotoPathsRef.current];
-      stagedPhotoPathsRef.current.clear();
-      if (stagedPaths.length > 0) void deleteProductImages(stagedPaths);
-    };
-  }, []);
 
   // Track listing start once
   const startTrackedRef = useRef(false);
@@ -326,15 +315,11 @@ export default function MobileSellWizard() {
 
     try {
       const uploaded = await uploadProductImageBatch(batch, user.id);
-      uploaded.forEach((photo) => stagedPhotoPathsRef.current.add(photo.path));
       setForm((prev) => ({
         ...prev,
         photos: [...prev.photos, ...uploaded].slice(0, MAX_PHOTOS),
       }));
     } catch (error) {
-      if (error instanceof ProductImageStorageError) {
-        error.cleanupFailedPaths.forEach((path) => stagedPhotoPathsRef.current.add(path));
-      }
       setPhotoError(getProductImageErrorMessage(error));
     } finally {
       setPhotoUploading(false);
@@ -350,7 +335,6 @@ export default function MobileSellWizard() {
 
     try {
       await deleteProductImage(photo.path);
-      stagedPhotoPathsRef.current.delete(photo.path);
       setForm((prev) => ({
         ...prev,
         photos: prev.photos.filter((item) => item.path !== photo.path),
@@ -412,7 +396,6 @@ export default function MobileSellWizard() {
       }
 
       const created = await res.json() as { id: string };
-      stagedPhotoPathsRef.current.clear();
       trackPublishListing(created.id, form.title.trim());
       setPublishedId(created.id);
     } catch (err) {


### PR DESCRIPTION
SUPERSEDED by PR #486 (`agent/seller-products-dashboard-hardening`).

The Seller Products branch now contains the hardened product-image storage helper, separate Take photo / Gallery inputs, batch rollback, durable draft persistence, canonical listing state, staged publication, and the associated regression coverage. Its full software gate has passed, including `npx cap sync android`.

This PR must not be merged separately because doing so would duplicate/overlap the mobile seller-media implementation. Historical real-device camera findings remain useful evidence for the final Android device gate on PR #486.