### PR TITLE
[SUPERSEDED] Remove mandatory product approval and separate moderation enforcement

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,9 @@ Independent and company UK sellers list and sell physical products across all co
 
 ### Sellers
 - List physical products across all supported categories, with optional listing attributes including condition (new, used, refurbished), stock quantity, weight, dimensions, and pallet or lot-specific fields
-- Seller account lifecycle: `draft` → `submitted` → `active` → `suspended` (admin-approved)
+- Seller account lifecycle: `draft` → `submitted` → `active` → `suspended` (admin-approved account lifecycle; separate from product publication)
+- Eligible active sellers publish listings directly without mandatory per-product admin approval
+- Seller is responsible for listing accuracy, product description/photos, price, ownership/right to sell and compliance with marketplace rules
 - Order management dashboard — status progression: `paid` → `packed` → `shipped` → `delivered`
 - Shipment creation with courier name, tracking number, and dispatch date
 - Respond to buyer RFQ requests via the quote inbox
@@ -41,8 +43,8 @@ Independent and company UK sellers list and sell physical products across all co
 - Pause account (deactivates all listings) or delete seller account
 
 ### Admin
-- Seller approval and suspension workflow
-- Product listing moderation (approve, deactivate, review flagged listings)
+- Seller approval and suspension workflow (seller/account verification, not product certification)
+- Post-publication product moderation and enforcement — review reports/flagged listings and hide or remove listings that breach marketplace rules
 - Platform-wide order and user management
 - Dispute resolution with refund amount control
 - Support ticket inbox
@@ -52,7 +54,9 @@ Independent and company UK sellers list and sell physical products across all co
 
 ## 💰 Business Model
 
-The platform charges a **7% commission** on each completed transaction, deducted before the seller's payout is processed via Stripe Connect. The platform acts solely as an intermediary — it does not own products, hold inventory, or operate a fulfilment depot. Sellers are responsible for their own inventory management and order fulfilment.
+The platform charges a **7% commission** on each completed transaction, deducted before the seller's payout is processed via Stripe Connect. The platform acts solely as an intermediary — it does not own products, hold inventory, or operate a fulfilment depot. Sellers are responsible for their own inventory management, listing accuracy and order fulfilment.
+
+Loadify does **not** manually certify the truth, quality or physical condition of every product before publication. Eligible sellers may publish directly, while Loadify retains post-publication moderation and enforcement powers for prohibited content, fraud/spam, marketplace-rule violations, reports and suspicious activity.
 
 > **Launch promotion:** 0% commission on all transactions until **31 December 2026 23:59:59 UTC**. The standard 7% rate resumes automatically after that date.
 
@@ -207,6 +211,7 @@ For detailed instructions see the [Netlify documentation](https://docs.netlify.c
 - Supabase JWT with short-lived access tokens and refresh tokens.
 - Rate limiting on registration, Stripe Connect onboarding, email, and error-reporting endpoints.
 - Content-Security-Policy with violation reporting.
+- Product publication eligibility is enforced server-side; the client cannot supply or override the compatibility `isApproved` field.
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,6 +1,6 @@
 # Loadify Market — Status & Roadmap
 
-_Last updated: April 2026_
+_Last updated: 16 August 2026_
 
 This document reflects the actual completed state of the platform and remaining work.
 
@@ -26,8 +26,9 @@ This document reflects the actual completed state of the platform and remaining 
 - [x] Product Catalog page (grid/list, filters, sort, pagination, search)
 - [x] Product Detail page (image gallery, specs, seller info, reviews, add to cart/wishlist)
 - [x] Product Creation/Edit (multi-image upload, description, category, VAT calculator, stock)
-- [x] Product approval flow (admin approves / autoApprove feature flag)
-- [x] Products go through serverless functions (`create-product.ts`, `update-product.ts`)
+- [x] Seller self-publish flow: eligible sellers publish listings live without mandatory per-product admin approval
+- [x] Post-publication product moderation/enforcement remains available to admins for marketplace-rule violations, reports, fraud/spam and prohibited content
+- [x] Products go through serverless functions (`create-product.ts`, `update-product.ts`), which own publication eligibility server-side
 - [x] Service listings (listingContext=service skips stock/shipping)
 - [x] Featured categories on homepage
 
@@ -90,8 +91,8 @@ This document reflects the actual completed state of the platform and remaining 
 #### Admin Panel ✅
 - [x] User management (view, suspend, edit roles)
 - [x] Buyer management
-- [x] Seller approvals (list, force-activate, suspend, warn, reactivate)
-- [x] Product moderation (approve/reject, `autoApproveProducts` flag)
+- [x] Seller approvals (list, force-activate, suspend, warn, reactivate) — seller verification/account control, not product approval
+- [x] Post-publication product moderation (view, hide/deactivate, review flagged listings); no mandatory product approval queue
 - [x] Order oversight (view all, force status)
 - [x] Payout requests (approve, reject, complete)
 - [x] Stripe Connect events viewer
@@ -133,7 +134,8 @@ This document reflects the actual completed state of the platform and remaining 
 - [x] CSRF-equivalent protection (internal secret header on function-to-function calls)
 - [x] Secure headers (netlify.toml: CSP, X-Frame-Options, HSTS, etc.)
 - [x] Role escalation prevention (migration 410, RLS policies)
-- [x] Feature flags (sellerRegistration, buyerRegistration, rfqSystem, reviewSystem, autoApproveProducts, maintenanceMode)
+- [x] Feature flags (sellerRegistration, buyerRegistration, rfqSystem, reviewSystem, maintenanceMode)
+- [x] Product publication eligibility enforced server-side; clients cannot supply `isApproved`
 - [x] Maintenance mode gate (frontend + backend 503)
 
 ### 5.2 Performance
@@ -197,10 +199,19 @@ This document reflects the actual completed state of the platform and remaining 
 
 ---
 
+## Product publication business contract
+
+- Seller/account verification and product moderation are separate concerns.
+- An eligible seller may publish a valid listing directly; Loadify does not manually certify the truth or physical condition of each product before publication.
+- The seller remains responsible for listing accuracy, product description, photos, price, ownership/right to sell and compliance with marketplace rules.
+- Loadify retains post-publication moderation and enforcement powers, including reviewing reports and suspicious activity and hiding/removing listings or restricting seller accounts where appropriate.
+- Drafts remain seller-controlled and are not published by admin merely because they exist.
+- Seller publication eligibility remains enforced by the existing seller-status, Stripe activation, pause-state, listing-limit and listing/shipping requirements.
+
 ## Notes
 
 - All core marketplace flows (browse → cart → checkout → orders → returns → disputes) are fully functional
 - Database schema is complete with 50+ migrations applied
 - All serverless functions use service-role Supabase client where needed and JWT verification for protected endpoints
-- Feature flags allow gradual rollout / emergency disabling of any subsystem without a deployment
+- Feature flags remain available for actual optional subsystems; mandatory product approval is not a feature toggle
 - PostCSS and all direct dependencies have no known vulnerabilities (`npm audit` clean)

--- a/netlify/functions/__tests__/create-product-self-publish.test.ts
+++ b/netlify/functions/__tests__/create-product-self-publish.test.ts
@@ -1,0 +1,197 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HandlerEvent } from '@netlify/functions';
+
+function makeEvent(body: Record<string, unknown>): HandlerEvent {
+  return {
+    httpMethod: 'POST',
+    body: JSON.stringify(body),
+    headers: { authorization: 'Bearer valid-token' },
+    multiValueHeaders: {},
+    isBase64Encoded: false,
+    path: '/.netlify/functions/create-product',
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    rawQuery: '',
+    rawUrl: 'http://localhost/.netlify/functions/create-product',
+  };
+}
+
+describe('create-product seller self-publish contract', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  function mockSupabase(profile?: Partial<{
+    sellerStatus: string;
+    stripeConnectStatus: string;
+    isPaused: boolean;
+    listingLimit: number | null;
+  }>) {
+    const insertedProducts: Array<Record<string, unknown>> = [];
+    const shippingRows: Array<Record<string, unknown>> = [];
+
+    const sellerProfile = {
+      sellerStatus: 'active',
+      stripeConnectStatus: 'active',
+      isPaused: false,
+      listingLimit: null,
+      ...profile,
+    };
+
+    const productsTable = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ count: 0, error: null }),
+      insert: vi.fn((rows: Array<Record<string, unknown>>) => {
+        insertedProducts.push(...rows);
+        return {
+          select: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: { id: 'product-1' }, error: null }),
+          }),
+        };
+      }),
+      update: vi.fn().mockReturnValue({
+        eq: vi.fn().mockResolvedValue({ error: null }),
+      }),
+    };
+
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: 'seller-1' } },
+          error: null,
+        }),
+      },
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: { role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'seller_profiles') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: sellerProfile, error: null }),
+          };
+        }
+        if (table === 'products') return productsTable;
+        if (table === 'product_shipping') {
+          return {
+            insert: vi.fn((rows: Array<Record<string, unknown>>) => {
+              shippingRows.push(...rows);
+              return Promise.resolve({ error: null });
+            }),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+        };
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: vi.fn(() => supabase),
+    }));
+    vi.doMock('../_shared/platformFlags', () => ({
+      isMaintenanceMode: vi.fn().mockResolvedValue(false),
+    }));
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+
+    return { insertedProducts, shippingRows };
+  }
+
+  const validPublishBody = {
+    title: 'Seller product',
+    price: 120,
+    isActive: true,
+    listingContext: 'product',
+    stockQuantity: 4,
+    shippingMethodIds: ['shipping-1'],
+    dispatchTime: '1-2 working days',
+  };
+
+  it('publishes an eligible seller listing live without manual product approval', async () => {
+    const { insertedProducts, shippingRows } = mockSupabase();
+    const { handler } = await import('../create-product');
+
+    const res = await handler(makeEvent(validPublishBody), {} as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(insertedProducts).toHaveLength(1);
+    expect(insertedProducts[0]).toMatchObject({
+      sellerId: 'seller-1',
+      isActive: true,
+      isApproved: true,
+      listingContext: 'product',
+      stockQuantity: 4,
+      stockStatus: 'low_stock',
+    });
+    expect(shippingRows).toHaveLength(1);
+    expect(JSON.parse(res.body as string)).toMatchObject({
+      id: 'product-1',
+      isActive: true,
+      isApproved: true,
+    });
+  });
+
+  it('does not allow the client to override the server-owned approval marker', async () => {
+    const { insertedProducts } = mockSupabase();
+    const { handler } = await import('../create-product');
+
+    const res = await handler(
+      makeEvent({ ...validPublishBody, isApproved: false }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(insertedProducts[0]?.isApproved).toBe(true);
+  });
+
+  it('rejects public publication when the seller is paused', async () => {
+    const { insertedProducts } = mockSupabase({ isPaused: true });
+    const { handler } = await import('../create-product');
+
+    const res = await handler(makeEvent(validPublishBody), {} as never);
+
+    expect(res.statusCode).toBe(409);
+    expect(insertedProducts).toHaveLength(0);
+    expect(JSON.parse(res.body as string).error).toMatch(/seller setup|stripe payments/i);
+  });
+
+  it('keeps a seller draft inactive without requiring an admin review step', async () => {
+    const { insertedProducts } = mockSupabase();
+    const { handler } = await import('../create-product');
+
+    const res = await handler(
+      makeEvent({
+        title: 'Draft product',
+        price: 50,
+        isActive: false,
+        listingContext: 'product',
+        stockQuantity: 1,
+      }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(insertedProducts[0]).toMatchObject({
+      isActive: false,
+      sellerId: 'seller-1',
+    });
+  });
+});

--- a/netlify/functions/__tests__/create-product-self-publish.test.ts
+++ b/netlify/functions/__tests__/create-product-self-publish.test.ts
@@ -149,7 +149,7 @@ describe('create-product seller self-publish contract', () => {
     });
   });
 
-  it('does not allow the client to override the server-owned approval marker', async () => {
+  it('does not allow the client to override the server-owned moderation marker', async () => {
     const { insertedProducts } = mockSupabase();
     const { handler } = await import('../create-product');
 
@@ -173,7 +173,7 @@ describe('create-product seller self-publish contract', () => {
     expect(JSON.parse(res.body as string).error).toMatch(/seller setup|stripe payments/i);
   });
 
-  it('keeps a seller draft inactive without requiring an admin review step', async () => {
+  it('keeps a seller draft inactive without putting it on moderation hold', async () => {
     const { insertedProducts } = mockSupabase();
     const { handler } = await import('../create-product');
 
@@ -191,6 +191,7 @@ describe('create-product seller self-publish contract', () => {
     expect(res.statusCode).toBe(200);
     expect(insertedProducts[0]).toMatchObject({
       isActive: false,
+      isApproved: true,
       sellerId: 'seller-1',
     });
   });

--- a/netlify/functions/__tests__/save-admin-settings.test.ts
+++ b/netlify/functions/__tests__/save-admin-settings.test.ts
@@ -1,0 +1,97 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HandlerEvent } from '@netlify/functions';
+
+function makeEvent(body: unknown): HandlerEvent {
+  return {
+    httpMethod: 'POST',
+    body: JSON.stringify(body),
+    headers: { authorization: 'Bearer admin-token' },
+    multiValueHeaders: {},
+    isBase64Encoded: false,
+    path: '/.netlify/functions/save-admin-settings',
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    rawQuery: '',
+    rawUrl: 'http://localhost/.netlify/functions/save-admin-settings',
+  };
+}
+
+describe('save-admin-settings product approval cleanup', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('strips autoApproveProducts while preserving real feature flags', async () => {
+    const upserts: Array<{ key: string; value: unknown }> = [];
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: {
+            user: {
+              id: 'admin-1',
+              app_metadata: { role: 'admin' },
+            },
+          },
+          error: null,
+        }),
+      },
+      from: vi.fn((table: string) => {
+        if (table === 'platform_settings') {
+          return {
+            upsert: vi.fn((payload: { key: string; value: unknown }) => {
+              upserts.push(payload);
+              return Promise.resolve({ error: null });
+            }),
+          };
+        }
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: { role: 'admin' }, error: null }),
+        };
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: vi.fn(() => supabase),
+    }));
+
+    const { handler } = await import('../save-admin-settings');
+    const res = await handler(
+      makeEvent({
+        settings: [
+          {
+            key: 'feature_flags',
+            value: {
+              sellerRegistration: true,
+              reviewSystem: true,
+              requireCompanyApproval: false,
+              autoApproveProducts: false,
+            },
+          },
+        ],
+      }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(upserts).toHaveLength(1);
+    expect(upserts[0]).toEqual({
+      key: 'feature_flags',
+      value: {
+        sellerRegistration: true,
+        reviewSystem: true,
+        requireCompanyApproval: false,
+      },
+    });
+  });
+});

--- a/netlify/functions/__tests__/update-product.test.ts
+++ b/netlify/functions/__tests__/update-product.test.ts
@@ -44,6 +44,7 @@ describe('update-product', () => {
       stockStatus: string | null;
       listingStatus: string | null;
       reservedUntil: string | null;
+      isActive: boolean;
     }>;
   }) {
     const productUpdates: Array<Record<string, unknown>> = [];
@@ -58,6 +59,7 @@ describe('update-product', () => {
       stockStatus: 'out_of_stock',
       listingStatus: 'active',
       reservedUntil: null,
+      isActive: false,
       ...args?.productRow,
     };
 
@@ -125,6 +127,8 @@ describe('update-product', () => {
 
         if (table === 'product_shipping') {
           return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockResolvedValue({ count: 1, data: [], error: null }),
             delete: vi.fn().mockReturnValue({
               eq: vi.fn().mockResolvedValue({ error: null }),
             }),
@@ -279,5 +283,33 @@ describe('update-product', () => {
     expect(body.code).toBe('LISTING_LOCKED');
     expect(body.error).toMatch(/critical listing fields are locked/i);
     expect(body.locks?.[0]?.orderLabel).toBe('LM-1000001');
+  });
+
+  it('publishes an existing eligible seller draft and clears the legacy manual-approval blocker', async () => {
+    const { productUpdates } = mockSupabase({
+      productRow: {
+        isActive: false,
+        listingContext: 'product',
+        stockQuantity: 5,
+        stockStatus: 'low_stock',
+      },
+    });
+    const { handler } = await import('../update-product');
+
+    const res = await handler(
+      makeEvent({
+        id: 'product-1',
+        isActive: true,
+        isApproved: false,
+      }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(productUpdates).toHaveLength(1);
+    expect(productUpdates[0]).toMatchObject({
+      isActive: true,
+      isApproved: true,
+    });
   });
 });

--- a/netlify/functions/__tests__/update-product.test.ts
+++ b/netlify/functions/__tests__/update-product.test.ts
@@ -45,6 +45,7 @@ describe('update-product', () => {
       listingStatus: string | null;
       reservedUntil: string | null;
       isActive: boolean;
+      isApproved: boolean | null;
     }>;
   }) {
     const productUpdates: Array<Record<string, unknown>> = [];
@@ -60,6 +61,7 @@ describe('update-product', () => {
       listingStatus: 'active',
       reservedUntil: null,
       isActive: false,
+      isApproved: true,
       ...args?.productRow,
     };
 
@@ -285,10 +287,11 @@ describe('update-product', () => {
     expect(body.locks?.[0]?.orderLabel).toBe('LM-1000001');
   });
 
-  it('publishes an existing eligible seller draft and clears the legacy manual-approval blocker', async () => {
+  it('publishes an eligible seller draft without an admin approval step', async () => {
     const { productUpdates } = mockSupabase({
       productRow: {
         isActive: false,
+        isApproved: true,
         listingContext: 'product',
         stockQuantity: 5,
         stockStatus: 'low_stock',
@@ -307,9 +310,31 @@ describe('update-product', () => {
 
     expect(res.statusCode).toBe(200);
     expect(productUpdates).toHaveLength(1);
-    expect(productUpdates[0]).toMatchObject({
-      isActive: true,
-      isApproved: true,
+    expect(productUpdates[0]).toMatchObject({ isActive: true });
+    expect(productUpdates[0]).not.toHaveProperty('isApproved');
+  });
+
+  it('blocks a seller from republishing a listing placed on moderation hold', async () => {
+    const { productUpdates } = mockSupabase({
+      productRow: {
+        isActive: false,
+        isApproved: false,
+        listingContext: 'product',
+        stockQuantity: 5,
+        stockStatus: 'low_stock',
+      },
     });
+    const { handler } = await import('../update-product');
+
+    const res = await handler(
+      makeEvent({ id: 'product-1', isActive: true }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(409);
+    expect(productUpdates).toHaveLength(0);
+    const body = JSON.parse(res.body as string) as { code?: string; error?: string };
+    expect(body.code).toBe('LISTING_MODERATION_HOLD');
+    expect(body.error).toMatch(/platform moderation/i);
   });
 });

--- a/netlify/functions/_shared/platformFlags.ts
+++ b/netlify/functions/_shared/platformFlags.ts
@@ -11,8 +11,7 @@
  * │ key                │ value (JSONB)                                        │
  * ├────────────────────┼─────────────────────────────────────────────────────┤
  * │ feature_flags      │ { sellerRegistration, buyerRegistration, rfqSystem, │
- * │                    │   reviewSystem, autoApproveProducts,                 │
- * │                    │   requireCompanyApproval }                           │
+ * │                    │   reviewSystem, requireCompanyApproval }             │
  * │ maintenance_mode   │ true | false                                        │
  * └────────────────────┴─────────────────────────────────────────────────────┘
  */
@@ -24,7 +23,6 @@ export interface FeatureFlags {
   buyerRegistration: boolean;
   rfqSystem: boolean;
   reviewSystem: boolean;
-  autoApproveProducts: boolean;
   /**
    * When true, newly registered company sellers (sellerType='company') are
    * flagged with requiresAdminApproval=true and cannot auto-activate via
@@ -34,13 +32,12 @@ export interface FeatureFlags {
   requireCompanyApproval: boolean;
 }
 
-/** Safe defaults — everything enabled except auto-approve and company gate. */
+/** Safe defaults for platform capabilities. Product publication is not approval-gated. */
 const FLAG_DEFAULTS: FeatureFlags = {
   sellerRegistration: true,
   buyerRegistration: true,
   rfqSystem: false,
   reviewSystem: true,
-  autoApproveProducts: false,
   requireCompanyApproval: false,
 };
 

--- a/netlify/functions/create-product.ts
+++ b/netlify/functions/create-product.ts
@@ -2,16 +2,17 @@
  * create-product
  *
  * Serverless function responsible for all new product/listing inserts.
- * Moving this out of the client enforces platform flags server-side:
+ * Marketplace publication is controlled by seller eligibility, not mandatory
+ * per-product admin approval. Admin moderation/enforcement remains separate.
  *
- *  - maintenanceMode  → 503 for non-admin sellers
- *  - autoApproveProducts → backend sets isApproved (client cannot override)
+ *  - maintenanceMode → 503 for non-admin sellers
  *  - seller activation → only fully active sellers may publish public listings
+ *  - approval state → eligible sellers/admins publish without a manual review gate
  */
 
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
-import { isMaintenanceMode, getFeatureFlags } from './_shared/platformFlags';
+import { isMaintenanceMode } from './_shared/platformFlags';
 import { checkRateLimit } from './_shared/rateLimiter';
 
 const CREATE_ALLOWED_FIELDS = [
@@ -209,10 +210,10 @@ export const handler: Handler = async (event) => {
     }
   }
 
-  const flags = await getFeatureFlags(supabase);
-  const isApproved: boolean = isAdmin
-    ? true
-    : sellerCanPublish && Boolean(flags.autoApproveProducts);
+  // Product truth is the seller's responsibility. Loadify does not certify each
+  // listing before publication. Eligibility still gates public publication, while
+  // admin moderation/enforcement can hide or remove listings after publication.
+  const isApproved = isAdmin || sellerCanPublish;
 
   if (!isAdmin) {
     const countRes = await supabase

--- a/netlify/functions/create-product.ts
+++ b/netlify/functions/create-product.ts
@@ -7,7 +7,7 @@
  *
  *  - maintenanceMode → 503 for non-admin sellers
  *  - seller activation → only fully active sellers may publish public listings
- *  - approval state → eligible sellers/admins publish without a manual review gate
+ *  - moderation marker → new listings are not held for manual review
  */
 
 import type { Handler } from '@netlify/functions';
@@ -210,10 +210,11 @@ export const handler: Handler = async (event) => {
     }
   }
 
-  // Product truth is the seller's responsibility. Loadify does not certify each
-  // listing before publication. Eligibility still gates public publication, while
-  // admin moderation/enforcement can hide or remove listings after publication.
-  const isApproved = isAdmin || sellerCanPublish;
+  // Legacy column compatibility: true now means "not held by moderation", not
+  // "manually approved by admin". New listings and drafts therefore start true.
+  // Publication visibility remains controlled independently by isActive plus
+  // seller eligibility; admin enforcement may later place a listing on hold.
+  const isApproved = true;
 
   if (!isAdmin) {
     const countRes = await supabase

--- a/netlify/functions/save-admin-settings.ts
+++ b/netlify/functions/save-admin-settings.ts
@@ -33,7 +33,8 @@ function sanitizeSettingValue(key: string, value: unknown): unknown {
   // Mandatory per-product approval is no longer part of the business contract.
   // Strip the legacy flag at the trusted server boundary so an older admin UI
   // cannot silently reintroduce it when saving unrelated platform settings.
-  const { autoApproveProducts: _legacyProductApprovalFlag, ...featureFlags } = value as Record<string, unknown>;
+  const featureFlags = { ...(value as Record<string, unknown>) };
+  delete featureFlags.autoApproveProducts;
   return featureFlags;
 }
 

--- a/netlify/functions/save-admin-settings.ts
+++ b/netlify/functions/save-admin-settings.ts
@@ -25,6 +25,18 @@ const METHODS = 'POST, OPTIONS';
 // Only these keys may be upserted via this endpoint.
 const ALLOWED_KEYS = new Set(['feature_flags', 'maintenance_mode', 'platform_config']);
 
+function sanitizeSettingValue(key: string, value: unknown): unknown {
+  if (key !== 'feature_flags' || value === null || typeof value !== 'object' || Array.isArray(value)) {
+    return value;
+  }
+
+  // Mandatory per-product approval is no longer part of the business contract.
+  // Strip the legacy flag at the trusted server boundary so an older admin UI
+  // cannot silently reintroduce it when saving unrelated platform settings.
+  const { autoApproveProducts: _legacyProductApprovalFlag, ...featureFlags } = value as Record<string, unknown>;
+  return featureFlags;
+}
+
 async function authenticateAdmin(event: HandlerEvent) {
   const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -102,7 +114,7 @@ export const handler: Handler = async (event) => {
   for (const row of settings) {
     const { error } = await supabase
       .from('platform_settings')
-      .upsert({ key: row.key, value: row.value }, { onConflict: 'key' });
+      .upsert({ key: row.key, value: sanitizeSettingValue(row.key, row.value) }, { onConflict: 'key' });
     if (error) errors.push(`${row.key}: ${error.message}`);
   }
 

--- a/netlify/functions/update-product.ts
+++ b/netlify/functions/update-product.ts
@@ -117,7 +117,7 @@ export const handler: Handler = async (event) => {
 
   const { data: existingProduct, error: fetchError } = await supabase
     .from('products')
-    .select('sellerId, title, type, condition, price, listingContext, stockQuantity, stockStatus, listingStatus, reservedUntil, isActive')
+    .select('sellerId, title, type, condition, price, listingContext, stockQuantity, stockStatus, listingStatus, reservedUntil, isActive, isApproved')
     .eq('id', productId)
     .maybeSingle<{
       sellerId: string;
@@ -131,6 +131,7 @@ export const handler: Handler = async (event) => {
       listingStatus: string | null;
       reservedUntil: string | null;
       isActive: boolean;
+      isApproved: boolean | null;
     }>();
   if (fetchError || !existingProduct) {
     return { statusCode: 404, body: JSON.stringify({ error: 'Product not found' }) };
@@ -190,9 +191,23 @@ export const handler: Handler = async (event) => {
     updateData.stockStatus = calculateStockStatus(nextContext, normalizedStockQuantity);
   }
 
-  const wantsPublished = updateData.isActive === true || (!hasOwn(updateData, 'isActive') && existingProduct.isActive);
+  const explicitlyPublishing = updateData.isActive === true;
+  const wantsPublished = explicitlyPublishing || (!hasOwn(updateData, 'isActive') && existingProduct.isActive);
   if (wantsPublished && !sellerCanPublish) {
     return { statusCode: 409, body: JSON.stringify({ error: 'Complete seller setup and activate Stripe payments before publishing.' }) };
+  }
+
+  // isApproved is retained as a legacy compatibility/moderation marker only.
+  // New listings start true; false means an admin has placed this listing on a
+  // moderation hold. Sellers may edit a held listing but cannot republish it.
+  if (!isAdmin && explicitlyPublishing && existingProduct.isApproved === false) {
+    return {
+      statusCode: 409,
+      body: JSON.stringify({
+        error: 'This listing is currently restricted by platform moderation and cannot be published. Contact support if you believe this is a mistake.',
+        code: 'LISTING_MODERATION_HOLD',
+      }),
+    };
   }
 
   if (wantsPublished && nextContext === 'product') {
@@ -261,14 +276,6 @@ export const handler: Handler = async (event) => {
     Object.keys(dataToUpdate).forEach((key) => {
       if (dataToUpdate[key] === undefined) delete dataToUpdate[key];
     });
-  }
-
-  // Mandatory per-product review is not part of the marketplace contract.
-  // When an eligible seller publishes (including an older draft that may have
-  // isApproved=false), the server marks the listing approved. The client still
-  // cannot submit or override isApproved directly.
-  if (wantsPublished && sellerCanPublish) {
-    dataToUpdate.isApproved = true;
   }
 
   // Save shipping first. If that fails, the listing itself remains unchanged.

--- a/netlify/functions/update-product.ts
+++ b/netlify/functions/update-product.ts
@@ -263,6 +263,14 @@ export const handler: Handler = async (event) => {
     });
   }
 
+  // Mandatory per-product review is not part of the marketplace contract.
+  // When an eligible seller publishes (including an older draft that may have
+  // isApproved=false), the server marks the listing approved. The client still
+  // cannot submit or override isApproved directly.
+  if (wantsPublished && sellerCanPublish) {
+    dataToUpdate.isApproved = true;
+  }
+
   // Save shipping first. If that fails, the listing itself remains unchanged.
   if (Array.isArray(shippingMethodIds)) {
     const { data: previousShipping, error: previousError } = await supabase

--- a/src/pages/ProductFormPage.numbering.test.ts
+++ b/src/pages/ProductFormPage.numbering.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const source = readFileSync(resolve(__dirname, 'ProductFormPage.tsx'), 'utf8');
+
+describe('ProductFormPage section numbering', () => {
+  it('derives numbering from the sections that are actually visible', () => {
+    expect(source).toContain("...(listingContext === 'product' ? ['inventory'] : [])");
+    expect(source).toContain("...(listingContext === 'product' ? ['shipping'] : [])");
+    expect(source).toContain("...(isBulkType ? ['typeDetails'] : [])");
+    expect(source).toContain('const sectionNumber = (section: string) => visibleSections.indexOf(section) + 1;');
+  });
+
+  it('uses the dynamic section number for every numbered form section', () => {
+    for (const key of ['basic', 'category', 'pricing', 'inventory', 'images', 'shipping', 'specifications', 'typeDetails', 'publish']) {
+      expect(source).toContain(`sectionNumber('${key}')`);
+    }
+
+    expect(source).not.toMatch(/<Section title=["']\d+\./);
+    expect(source).not.toContain("'9. Save Changes'");
+    expect(source).not.toContain("'9. Publish Listing'");
+  });
+});

--- a/src/pages/ProductFormPage.tsx
+++ b/src/pages/ProductFormPage.tsx
@@ -370,7 +370,7 @@ export default function ProductFormPage() {
       const isAdmin = user.role === 'admin';
       const specs = buildSpecs();
 
-      // Build the product payload (isApproved is now set server-side via create-product / update-product)
+      // Publication visibility fields are owned by create-product / update-product.
       const productData = {
         title: formData.title,
         description: formData.description,
@@ -439,7 +439,7 @@ export default function ProductFormPage() {
         }
         setSuccessMessage(publishMode ? 'Product updated and published.' : 'Draft saved successfully.');
       } else {
-        // Create new product via create-product (backend sets isApproved)
+        // Create new product via create-product; server owns publication state.
         const res = await authorizedFetch('/.netlify/functions/create-product', {
           method: 'POST',
           body: JSON.stringify({
@@ -453,7 +453,7 @@ export default function ProductFormPage() {
           const payload = await res.json().catch(() => ({}));
           throw new Error((payload as { error?: string }).error ?? `Server returned ${res.status}`);
         }
-        const created = await res.json() as { id: string; isApproved: boolean };
+        const created = await res.json() as { id: string; isActive: boolean };
 
         // Mark first product created for onboarding completion tracking.
         // Non-fatal: onboarding checklist will still derive this from product count.
@@ -505,12 +505,12 @@ export default function ProductFormPage() {
 
         setSuccessMessage(
           publishMode
-            ? (created.isApproved
+            ? (created.isActive
                 ? 'Product created and is now live!'
-                : 'Product created! It will be visible after admin approval.')
+                : 'Product created, but it is not live yet. Check seller eligibility and listing requirements.')
             : 'Draft saved. You can continue editing and publish when ready.'
         );
-        if (publishMode && created.id) {
+        if (publishMode && created.id && created.isActive) {
           setPublishedProductId(created.id);
           trackPublishListing(created.id, formData.title);
         }
@@ -595,6 +595,18 @@ export default function ProductFormPage() {
   }
 
   const isBulkType = BULK_PRODUCT_TYPES.includes(formData.type);
+  const visibleSections = [
+    'basic',
+    'category',
+    'pricing',
+    ...(listingContext === 'product' ? ['inventory'] : []),
+    'images',
+    ...(listingContext === 'product' ? ['shipping'] : []),
+    'specifications',
+    ...(isBulkType ? ['typeDetails'] : []),
+    'publish',
+  ];
+  const sectionNumber = (section: string) => visibleSections.indexOf(section) + 1;
 
   return (
     <div className="bg-background min-h-screen">
@@ -741,8 +753,8 @@ export default function ProductFormPage() {
               </div>
             )}
 
-            {/* ─── SECTION 1: Basic Information ─────────────────────────── */}
-            <Section title="1. Basic Information">
+            {/* ─── Basic Information ─────────────────────────────────────── */}
+            <Section title={`${sectionNumber('basic')}. Basic Information`}>
               <div className="mb-4">
                 <label className="block text-sm font-medium text-slate-300 mb-1 flex items-center gap-1">
                   Product Title {hasActiveOrders ? <Lock className="h-3.5 w-3.5 text-primary" /> : <span className="text-red-500">*</span>}
@@ -832,8 +844,8 @@ export default function ProductFormPage() {
               </div>
             </Section>
 
-            {/* ─── SECTION 2: Category ──────────────────────────────────── */}
-            <Section title="2. Category">
+            {/* ─── Category ──────────────────────────────────────────────── */}
+            <Section title={`${sectionNumber('category')}. Category`}>
               {errors.categoryId && (
                 <div className="mb-3 p-2 bg-red-950/30 border border-danger/30 rounded flex items-center gap-2">
                   <AlertCircle className="h-4 w-4 text-red-500 flex-shrink-0" />
@@ -850,8 +862,8 @@ export default function ProductFormPage() {
               />
             </Section>
 
-            {/* ─── SECTION 3: Pricing ───────────────────────────────────── */}
-            <Section title="3. Pricing">
+            {/* ─── Pricing ───────────────────────────────────────────────── */}
+            <Section title={`${sectionNumber('pricing')}. Pricing`}>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-slate-300 mb-1 flex items-center gap-1">
@@ -905,9 +917,9 @@ export default function ProductFormPage() {
               )}
             </Section>
 
-            {/* ─── SECTION 4: Inventory ─────────────────────────────────── */}
+            {/* ─── Inventory ─────────────────────────────────────────────── */}
             {listingContext === 'product' && (
-            <Section title="4. Inventory">
+            <Section title={`${sectionNumber('inventory')}. Inventory`}>
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
                   <label className="block text-sm font-medium text-slate-300 mb-1 flex items-center gap-1">
@@ -959,8 +971,8 @@ export default function ProductFormPage() {
             </Section>
             )} {/* end listingContext === 'product' — Inventory section */}
 
-            {/* ─── SECTION 5: Media ─────────────────────────────────────── */}
-            <Section title="5. Product Images">
+            {/* ─── Media ─────────────────────────────────────────────────── */}
+            <Section title={`${sectionNumber('images')}. Product Images`}>
               <p className="text-sm text-slate-400 mb-4">
                 Upload up to 10 images. The first image will be your main product photo.
                 Use clear, well-lit photos showing the actual product.
@@ -972,9 +984,9 @@ export default function ProductFormPage() {
               />
             </Section>
 
-            {/* ─── SECTION 6: Dimensions & Shipping ────────────────────── */}
+            {/* ─── Dimensions & Shipping ─────────────────────────────────── */}
             {listingContext === 'product' && (
-            <Section title="6. Dimensions &amp; Shipping">
+            <Section title={`${sectionNumber('shipping')}. Dimensions & Shipping`}>
               <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-4 mb-4">
                 <div>
                   <label className="block text-sm font-medium text-slate-300 mb-1">Length (cm)</label>
@@ -1107,8 +1119,8 @@ export default function ProductFormPage() {
             </Section>
             )} {/* end listingContext === 'product' — Dimensions & Shipping section */}
 
-            {/* ─── SECTION 7: Specifications ────────────────────────────── */}
-            <Section title="7. Specifications">
+            {/* ─── Specifications ────────────────────────────────────────── */}
+            <Section title={`${sectionNumber('specifications')}. Specifications`}>
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 mb-4">
                 <div>
                   <label className="block text-sm font-medium text-slate-300 mb-1">Brand</label>
@@ -1191,9 +1203,9 @@ export default function ProductFormPage() {
               </div>
             </Section>
 
-            {/* ─── SECTION 8: Listing Type Details (conditional) ─────────── */}
+            {/* ─── Listing Type Details (conditional) ───────────────────── */}
             {isBulkType && (
-              <Section title="8. Listing Type Details">
+              <Section title={`${sectionNumber('typeDetails')}. Listing Type Details`}>
                 {/* Pallet-specific fields */}
                 {formData.type === 'pallet' && (
                   <div className="mb-4">
@@ -1309,20 +1321,22 @@ export default function ProductFormPage() {
               </Section>
             )}
 
-            {/* ─── SECTION 9: Publish / Save ────────────────────────────── */}
+            {/* ─── Publish / Save ────────────────────────────────────────── */}
             <div className="bg-surface border border-white/10 rounded-xl p-6">
               <h2 className="text-lg font-semibold text-white mb-4 pb-3 border-b border-white/10">
-                {id ? '9. Save Changes' : '9. Publish Listing'}
+                {id
+                  ? `${sectionNumber('publish')}. Save Changes`
+                  : `${sectionNumber('publish')}. Publish Listing`}
               </h2>
 
               <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between gap-4">
                 <div className="text-sm text-slate-400">
                   {id ? (
-                    <p>Save your changes. Published listings require admin approval before going live.</p>
+                    <p>Save your changes. Eligible published listings remain live immediately; Loadify may moderate or remove listings that breach marketplace rules.</p>
                   ) : (
                     <>
                       <p className="font-medium text-slate-300 mb-1">Ready to list your product?</p>
-                      <p>Use <strong>Save as Draft</strong> to continue editing later, or <strong>Publish</strong> to submit for admin approval.</p>
+                      <p>Use <strong>Save as Draft</strong> to continue editing later, or <strong>Publish</strong> to make the listing live once seller eligibility and listing requirements are satisfied. Loadify moderates and enforces marketplace rules after publication.</p>
                     </>
                   )}
                 </div>

--- a/src/pages/pixel-perfect/admin/AdminProducts.tsx
+++ b/src/pages/pixel-perfect/admin/AdminProducts.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { Package, Search, Eye, Ban, MoreHorizontal, Loader2 } from "lucide-react";
+import { Package, Search, Eye, Ban, MoreHorizontal, Loader2, CheckCircle2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -20,6 +20,7 @@ interface Product {
   price: number;
   stockQuantity: number;
   isActive: boolean;
+  isApproved: boolean;
   createdAt: string;
 }
 
@@ -29,6 +30,7 @@ type ProductRow = {
   price: number | null;
   stockQuantity: number | null;
   isActive: boolean | null;
+  isApproved: boolean | null;
   createdAt: string | null;
   sellerId: string | null;
 };
@@ -57,22 +59,19 @@ const AdminProducts = () => {
     setLoading(true);
     setError(null);
     try {
-      // 1) Fetch products first (include sellerId)
       const { data: productsData, error: productsError } = await supabase
         .from("products")
-        .select("id,title,price,stockQuantity,isActive,createdAt,sellerId")
+        .select("id,title,price,stockQuantity,isActive,isApproved,createdAt,sellerId")
         .order("createdAt", { ascending: false })
         .limit(200);
 
       if (productsError) throw productsError;
 
       const productRows: ProductRow[] = (productsData || []) as ProductRow[];
-
       const sellerIds = Array.from(
         new Set(productRows.map((p) => p.sellerId).filter((id): id is string => Boolean(id)))
       );
 
-      // 2) Fetch seller_profiles by userId IN sellerIds
       const sellerProfilesByUserId = new Map<string, SellerProfileRow>();
       if (sellerIds.length > 0) {
         const { data: sellerProfiles, error: sellerProfilesError } = await supabase
@@ -81,14 +80,12 @@ const AdminProducts = () => {
           .in("userId", sellerIds);
 
         if (sellerProfilesError) throw sellerProfilesError;
-
         (sellerProfiles || []).forEach((sp) => {
           const row = sp as SellerProfileRow;
           if (row?.userId) sellerProfilesByUserId.set(row.userId, row);
         });
       }
 
-      // 3) Fetch users by id IN sellerIds
       const usersById = new Map<string, UserRow>();
       if (sellerIds.length > 0) {
         const { data: usersData, error: usersError } = await supabase
@@ -97,14 +94,12 @@ const AdminProducts = () => {
           .in("id", sellerIds);
 
         if (usersError) throw usersError;
-
         (usersData || []).forEach((u) => {
           const row = u as UserRow;
           if (row?.id) usersById.set(row.id, row);
         });
       }
 
-      // 4) Map seller display name in code
       const mapped: Product[] = productRows.map((p) => {
         const sellerId = p.sellerId;
         const sellerProfile = sellerId ? sellerProfilesByUserId.get(sellerId) : undefined;
@@ -124,7 +119,8 @@ const AdminProducts = () => {
           seller: sellerName,
           price: p.price ?? 0,
           stockQuantity: p.stockQuantity ?? 0,
-          isActive: p.isActive ?? true,
+          isActive: p.isActive ?? false,
+          isApproved: p.isApproved !== false,
           createdAt: p.createdAt
             ? new Date(p.createdAt).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
             : "—",
@@ -141,22 +137,41 @@ const AdminProducts = () => {
 
   useEffect(() => { fetchProducts(); }, [fetchProducts]);
 
-  // Product moderation is post-publication enforcement. Admin may hide a live
-  // listing, but this screen must not publish an inactive seller draft on the
-  // seller's behalf. A dedicated moderation state would be required to safely
-  // distinguish an admin-hidden listing from a seller-owned draft for restore.
-  const hideListing = async (id: string) => {
+  const placeModerationHold = async (id: string) => {
     setActionLoading(id);
     setError(null);
     try {
+      // Legacy isApproved is now a moderation marker, not a pre-publication
+      // approval queue. Setting both values makes enforcement immediate and
+      // prevents the seller from simply republishing through update-product.
       const { error } = await supabase
         .from("products")
-        .update({ isActive: false })
+        .update({ isActive: false, isApproved: false })
         .eq("id", id);
       if (error) throw error;
-      setProducts((prev) => prev.map((p) => p.id === id ? { ...p, isActive: false } : p));
+      setProducts((prev) => prev.map((p) => p.id === id ? { ...p, isActive: false, isApproved: false } : p));
     } catch (err: unknown) {
-      setError((err as Error).message || "Failed to hide listing");
+      setError((err as Error).message || "Failed to place listing on moderation hold");
+    } finally {
+      setActionLoading(null);
+    }
+  };
+
+  const releaseModerationHold = async (id: string) => {
+    setActionLoading(id);
+    setError(null);
+    try {
+      // Releasing a hold does not publish the seller's listing on their behalf.
+      // It only removes the enforcement block; the seller remains responsible
+      // for choosing to publish and must still pass normal eligibility gates.
+      const { error } = await supabase
+        .from("products")
+        .update({ isApproved: true })
+        .eq("id", id);
+      if (error) throw error;
+      setProducts((prev) => prev.map((p) => p.id === id ? { ...p, isApproved: true } : p));
+    } catch (err: unknown) {
+      setError((err as Error).message || "Failed to release moderation hold");
     } finally {
       setActionLoading(null);
     }
@@ -168,8 +183,9 @@ const AdminProducts = () => {
       p.seller.toLowerCase().includes(search.toLowerCase())
   );
 
-  const activeProducts = filtered.filter((p) => p.isActive);
-  const inactiveProducts = filtered.filter((p) => !p.isActive);
+  const publishedProducts = filtered.filter((p) => p.isActive && p.isApproved);
+  const moderationHolds = filtered.filter((p) => !p.isApproved);
+  const unpublishedProducts = filtered.filter((p) => !p.isActive && p.isApproved);
 
   const renderTable = (data: Product[]) => (
     <Table>
@@ -179,7 +195,7 @@ const AdminProducts = () => {
           <TableHead className="hidden sm:table-cell text-xs font-semibold tracking-wide uppercase text-muted-foreground/85">Seller</TableHead>
           <TableHead className="text-xs font-semibold tracking-wide uppercase text-muted-foreground/85">Price</TableHead>
           <TableHead className="hidden md:table-cell text-xs font-semibold tracking-wide uppercase text-muted-foreground/85">Stock</TableHead>
-          <TableHead className="text-xs font-semibold tracking-wide uppercase text-muted-foreground/85">Published</TableHead>
+          <TableHead className="text-xs font-semibold tracking-wide uppercase text-muted-foreground/85">Status</TableHead>
           <TableHead className="text-right text-xs font-semibold tracking-wide uppercase text-muted-foreground/85">Actions</TableHead>
         </TableRow>
       </TableHeader>
@@ -219,12 +235,14 @@ const AdminProducts = () => {
                 <Badge
                   variant="outline"
                   className={
-                    p.isActive
-                      ? "border-emerald-500/30 text-success bg-success/10"
-                      : "border-slate-200 text-slate-400"
+                    !p.isApproved
+                      ? "border-red-500/30 text-danger bg-danger/10"
+                      : p.isActive
+                        ? "border-emerald-500/30 text-success bg-success/10"
+                        : "border-slate-200 text-slate-400"
                   }
                 >
-                  {p.isActive ? "Published" : "Unpublished"}
+                  {!p.isApproved ? "Moderation Hold" : p.isActive ? "Published" : "Unpublished"}
                 </Badge>
               </TableCell>
               <TableCell className="text-right">
@@ -242,9 +260,14 @@ const AdminProducts = () => {
                     <DropdownMenuItem onClick={() => navigate(`/product/${p.id}`)}>
                       <Eye className="h-3.5 w-3.5 mr-2" /> View Listing
                     </DropdownMenuItem>
-                    {p.isActive && (
-                      <DropdownMenuItem onClick={() => hideListing(p.id)} className="text-destructive">
-                        <Ban className="h-3.5 w-3.5 mr-2" /> Hide Listing
+                    {p.isApproved && p.isActive && (
+                      <DropdownMenuItem onClick={() => placeModerationHold(p.id)} className="text-destructive">
+                        <Ban className="h-3.5 w-3.5 mr-2" /> Place Moderation Hold
+                      </DropdownMenuItem>
+                    )}
+                    {!p.isApproved && (
+                      <DropdownMenuItem onClick={() => releaseModerationHold(p.id)}>
+                        <CheckCircle2 className="h-3.5 w-3.5 mr-2" /> Release Moderation Hold
                       </DropdownMenuItem>
                     )}
                   </DropdownMenuContent>
@@ -262,10 +285,10 @@ const AdminProducts = () => {
       <div className="pb-2" style={{ borderBottom: "1px solid rgba(255,255,255,0.04)" }}>
         <h1 className="text-2xl font-bold text-white tracking-tight">Product Moderation</h1>
         <p className="text-sm mt-1 text-muted-foreground/85">
-          {products.length} total listings · {activeProducts.length} published · {inactiveProducts.length} unpublished
+          {products.length} total · {publishedProducts.length} published · {moderationHolds.length} moderation holds · {unpublishedProducts.length} unpublished
         </p>
         <p className="text-xs mt-1 text-muted-foreground/65">
-          Listings publish without mandatory product approval. Use moderation actions to review and hide live listings that breach marketplace rules.
+          Eligible sellers publish directly. Moderation holds are post-publication enforcement and prevent a held listing from being republished until the hold is released.
         </p>
       </div>
 
@@ -290,14 +313,23 @@ const AdminProducts = () => {
       <Tabs defaultValue="all">
         <TabsList style={{ background: "rgba(148,163,184,0.3)", border: "1px solid rgba(255,255,255,0.1)" }}>
           <TabsTrigger value="all" className="data-[state=active]:text-white data-[state=active]:bg-white/10 text-slate-500">All <Badge variant="outline" className="ml-2 text-xs border-white/20 text-slate-500">{filtered.length}</Badge></TabsTrigger>
-          <TabsTrigger value="active" className="data-[state=active]:text-white data-[state=active]:bg-white/10 text-slate-500">Published</TabsTrigger>
-          <TabsTrigger value="inactive" className="data-[state=active]:text-white data-[state=active]:bg-white/10 text-slate-500">Unpublished</TabsTrigger>
+          <TabsTrigger value="published" className="data-[state=active]:text-white data-[state=active]:bg-white/10 text-slate-500">Published</TabsTrigger>
+          <TabsTrigger value="holds" className="data-[state=active]:text-white data-[state=active]:bg-white/10 text-slate-500">Moderation Holds</TabsTrigger>
+          <TabsTrigger value="unpublished" className="data-[state=active]:text-white data-[state=active]:bg-white/10 text-slate-500">Unpublished</TabsTrigger>
         </TabsList>
-        {(["all", "active", "inactive"] as const).map((tab) => (
+        {(["all", "published", "holds", "unpublished"] as const).map((tab) => (
           <TabsContent key={tab} value={tab}>
             <div className="rounded-2xl overflow-hidden" style={{ border: "1px solid rgba(255,255,255,0.05)", boxShadow: "0 10px 40px rgba(0,0,0,0.6)" }}>
               <div className="px-2 py-2 overflow-x-auto">
-                {renderTable(tab === "all" ? filtered : tab === "active" ? activeProducts : inactiveProducts)}
+                {renderTable(
+                  tab === "all"
+                    ? filtered
+                    : tab === "published"
+                      ? publishedProducts
+                      : tab === "holds"
+                        ? moderationHolds
+                        : unpublishedProducts,
+                )}
               </div>
             </div>
           </TabsContent>

--- a/src/pages/pixel-perfect/admin/AdminProducts.tsx
+++ b/src/pages/pixel-perfect/admin/AdminProducts.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useCallback } from "react";
 import { useNavigate } from "react-router-dom";
-import { Package, Search, Eye, Ban, CheckCircle2, MoreHorizontal, Loader2, ShieldCheck, ShieldX } from "lucide-react";
+import { Package, Search, Eye, Ban, MoreHorizontal, Loader2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
@@ -20,7 +20,6 @@ interface Product {
   price: number;
   stockQuantity: number;
   isActive: boolean;
-  isApproved: boolean;
   createdAt: string;
 }
 
@@ -30,7 +29,6 @@ type ProductRow = {
   price: number | null;
   stockQuantity: number | null;
   isActive: boolean | null;
-  isApproved: boolean | null;
   createdAt: string | null;
   sellerId: string | null;
 };
@@ -53,8 +51,7 @@ const AdminProducts = () => {
   const [loading, setLoading] = useState(true);
   const [actionLoading, setActionLoading] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [search, setSearch] = useState(""
-);
+  const [search, setSearch] = useState("");
 
   const fetchProducts = useCallback(async () => {
     setLoading(true);
@@ -63,7 +60,7 @@ const AdminProducts = () => {
       // 1) Fetch products first (include sellerId)
       const { data: productsData, error: productsError } = await supabase
         .from("products")
-        .select("id,title,price,stockQuantity,isActive,isApproved,createdAt,sellerId")
+        .select("id,title,price,stockQuantity,isActive,createdAt,sellerId")
         .order("createdAt", { ascending: false })
         .limit(200);
 
@@ -128,7 +125,6 @@ const AdminProducts = () => {
           price: p.price ?? 0,
           stockQuantity: p.stockQuantity ?? 0,
           isActive: p.isActive ?? true,
-          isApproved: p.isApproved ?? false,
           createdAt: p.createdAt
             ? new Date(p.createdAt).toLocaleDateString("en-GB", { day: "numeric", month: "short", year: "numeric" })
             : "—",
@@ -145,35 +141,22 @@ const AdminProducts = () => {
 
   useEffect(() => { fetchProducts(); }, [fetchProducts]);
 
-  const toggleActive = async (id: string, currentActive: boolean) => {
+  // Product moderation is post-publication enforcement. Admin may hide a live
+  // listing, but this screen must not publish an inactive seller draft on the
+  // seller's behalf. A dedicated moderation state would be required to safely
+  // distinguish an admin-hidden listing from a seller-owned draft for restore.
+  const hideListing = async (id: string) => {
     setActionLoading(id);
     setError(null);
     try {
       const { error } = await supabase
         .from("products")
-        .update({ isActive: !currentActive })
+        .update({ isActive: false })
         .eq("id", id);
       if (error) throw error;
-      setProducts((prev) => prev.map((p) => p.id === id ? { ...p, isActive: !currentActive } : p));
+      setProducts((prev) => prev.map((p) => p.id === id ? { ...p, isActive: false } : p));
     } catch (err: unknown) {
-      setError((err as Error).message || "Failed to update product");
-    } finally {
-      setActionLoading(null);
-    }
-  };
-
-  const toggleApprove = async (id: string, currentApproved: boolean) => {
-    setActionLoading(id);
-    setError(null);
-    try {
-      const { error } = await supabase
-        .from("products")
-        .update({ isApproved: !currentApproved })
-        .eq("id", id);
-      if (error) throw error;
-      setProducts((prev) => prev.map((p) => p.id === id ? { ...p, isApproved: !currentApproved } : p));
-    } catch (err: unknown) {
-      setError((err as Error).message || "Failed to update approval status");
+      setError((err as Error).message || "Failed to hide listing");
     } finally {
       setActionLoading(null);
     }
@@ -197,20 +180,19 @@ const AdminProducts = () => {
           <TableHead className="text-xs font-semibold tracking-wide uppercase text-muted-foreground/85">Price</TableHead>
           <TableHead className="hidden md:table-cell text-xs font-semibold tracking-wide uppercase text-muted-foreground/85">Stock</TableHead>
           <TableHead className="text-xs font-semibold tracking-wide uppercase text-muted-foreground/85">Published</TableHead>
-          <TableHead className="hidden lg:table-cell text-xs font-semibold tracking-wide uppercase text-muted-foreground/85">Approved</TableHead>
           <TableHead className="text-right text-xs font-semibold tracking-wide uppercase text-muted-foreground/85">Actions</TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
         {loading ? (
           <TableRow>
-            <TableCell colSpan={7} className="text-center py-8">
+            <TableCell colSpan={6} className="text-center py-8">
               <Loader2 className="h-6 w-6 animate-spin mx-auto text-muted-foreground/65" />
             </TableCell>
           </TableRow>
         ) : data.length === 0 ? (
           <TableRow>
-            <TableCell colSpan={7} className="text-center py-8 text-muted-foreground/65">
+            <TableCell colSpan={6} className="text-center py-8 text-muted-foreground/65">
               <Package className="h-8 w-8 mx-auto mb-2 opacity-40" />No products found.
             </TableCell>
           </TableRow>
@@ -245,18 +227,6 @@ const AdminProducts = () => {
                   {p.isActive ? "Published" : "Unpublished"}
                 </Badge>
               </TableCell>
-              <TableCell className="hidden lg:table-cell">
-                <Badge
-                  variant="outline"
-                  className={
-                    p.isApproved
-                      ? "border-emerald-500/30 text-success bg-success/10"
-                      : "border-primary/40 text-primary bg-primary/10"
-                  }
-                >
-                  {p.isApproved ? "Approved" : "Pending"}
-                </Badge>
-              </TableCell>
               <TableCell className="text-right">
                 <DropdownMenu>
                   <DropdownMenuTrigger asChild>
@@ -272,22 +242,9 @@ const AdminProducts = () => {
                     <DropdownMenuItem onClick={() => navigate(`/product/${p.id}`)}>
                       <Eye className="h-3.5 w-3.5 mr-2" /> View Listing
                     </DropdownMenuItem>
-                    {p.isApproved ? (
-                      <DropdownMenuItem onClick={() => toggleApprove(p.id, p.isApproved)} className="text-primary">
-                        <ShieldX className="h-3.5 w-3.5 mr-2" /> Revoke Approval
-                      </DropdownMenuItem>
-                    ) : (
-                      <DropdownMenuItem onClick={() => toggleApprove(p.id, p.isApproved)} className="text-emerald-500">
-                        <ShieldCheck className="h-3.5 w-3.5 mr-2" /> Approve
-                      </DropdownMenuItem>
-                    )}
-                    {p.isActive ? (
-                      <DropdownMenuItem onClick={() => toggleActive(p.id, p.isActive)} className="text-destructive">
-                        <Ban className="h-3.5 w-3.5 mr-2" /> Deactivate
-                      </DropdownMenuItem>
-                    ) : (
-                      <DropdownMenuItem onClick={() => toggleActive(p.id, p.isActive)}>
-                        <CheckCircle2 className="h-3.5 w-3.5 mr-2" /> Activate
+                    {p.isActive && (
+                      <DropdownMenuItem onClick={() => hideListing(p.id)} className="text-destructive">
+                        <Ban className="h-3.5 w-3.5 mr-2" /> Hide Listing
                       </DropdownMenuItem>
                     )}
                   </DropdownMenuContent>
@@ -305,7 +262,10 @@ const AdminProducts = () => {
       <div className="pb-2" style={{ borderBottom: "1px solid rgba(255,255,255,0.04)" }}>
         <h1 className="text-2xl font-bold text-white tracking-tight">Product Moderation</h1>
         <p className="text-sm mt-1 text-muted-foreground/85">
-          {products.length} total listings · {activeProducts.length} published · {inactiveProducts.length} unpublished · {products.filter(p => !p.isApproved).length} pending approval
+          {products.length} total listings · {activeProducts.length} published · {inactiveProducts.length} unpublished
+        </p>
+        <p className="text-xs mt-1 text-muted-foreground/65">
+          Listings publish without mandatory product approval. Use moderation actions to review and hide live listings that breach marketplace rules.
         </p>
       </div>
 
@@ -322,7 +282,7 @@ const AdminProducts = () => {
             placeholder="Search products or sellers..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
-          className="pl-9 h-10 border border-white/5 text-white"
+            className="pl-9 h-10 border border-white/5 text-white"
           />
         </div>
       </div>

--- a/src/pages/pixel-perfect/admin/AdminSettings.tsx
+++ b/src/pages/pixel-perfect/admin/AdminSettings.tsx
@@ -14,7 +14,7 @@ import { toast } from "@/hooks/use-toast";
 import { supabase } from "@/lib/supabase";
 import { authorizedFetch } from "@/lib/authorizedFetch";
 
-type FeatureKey = "sellerRegistration" | "buyerRegistration" | "rfqSystem" | "reviewSystem" | "maintenanceMode" | "autoApproveProducts";
+type FeatureKey = "sellerRegistration" | "buyerRegistration" | "rfqSystem" | "reviewSystem" | "maintenanceMode";
 type Features = Record<FeatureKey, boolean>;
 
 interface PlatformConfig {
@@ -37,7 +37,6 @@ const DEFAULT_FEATURES: Features = {
   rfqSystem: false,
   reviewSystem: true,
   maintenanceMode: false,
-  autoApproveProducts: false,
 };
 
 const DEFAULT_CONFIG: PlatformConfig = {
@@ -242,7 +241,6 @@ const AdminSettings = () => {
             { key: "buyerRegistration" as const, label: "Buyer Registration", desc: "Allow new buyers to create accounts" },
             { key: "rfqSystem" as const, label: "RFQ / Quote System", desc: "Optional custom quotes flow. Keep disabled for fixed-price marketplace launch." },
             { key: "reviewSystem" as const, label: "Reviews & Ratings", desc: "Allow buyers to leave reviews on sellers" },
-            { key: "autoApproveProducts" as const, label: "Auto-Approve Products", desc: "Skip manual review for new product listings" },
             { key: "maintenanceMode" as const, label: "Maintenance Mode", desc: "Show maintenance page to all users (admins excluded)" },
           ].map((item) => (
             <div key={item.key} className="flex items-center justify-between">


### PR DESCRIPTION
## Purpose
Align product publication with the confirmed Loadify business contract:

- **eligible seller → publish → live immediately**;
- no mandatory per-product admin approval/certification;
- seller/account verification remains separate;
- admin product moderation/enforcement remains post-publication.

## Changes
- remove `autoApproveProducts` from the server feature-flag contract and Admin Settings UI;
- make new listings/drafts start free of manual product-review gating while preserving seller eligibility, Stripe, pause, shipping and listing-limit guards;
- keep legacy `isApproved` only as an existing compatibility/moderation-hold marker, not as a pre-publication approval queue;
- block sellers from republishing a listing while that existing marker is on moderation hold;
- Admin Products now exposes **Place Moderation Hold** and **Release Moderation Hold** instead of Approve/Revoke Approval;
- releasing a moderation hold does **not** publish a seller draft on the admin's behalf;
- server-side Admin Settings sanitization strips the retired `autoApproveProducts` key from future saves;
- Product Form publish copy no longer says submit/wait for admin approval;
- Product Form section numbers are derived from visible sections, so conditional Product/Service/Bulk sections no longer produce skipped numbering;
- README and ROADMAP document seller responsibility, direct publication and post-publication moderation separately.

## Existing DB enforcement verified
Production already has `trg_protect_product_platform_managed_fields` / `private.protect_product_platform_managed_fields()`, which restores `isApproved` to its old value for authenticated non-admin updates. A seller therefore cannot bypass the Netlify function and clear a moderation hold directly through Supabase.

No RLS, permission, RPC, schema or migration changes are introduced by this PR.

## Production data alignment already performed
Before this PR, production `feature_flags.autoApproveProducts` was `false`. It was changed to `true` so the currently deployed legacy backend no longer queues new eligible products while this code is awaiting deployment. `reviewSystem` remained `true`.

Two existing active products were found with `isApproved=false`; both belonged to an active, Stripe-active, non-paused seller and were clearly legacy approval-gate rows. They were narrowly migrated to `isApproved=true`. Verification after migration: 5 total products, 5 active+approved, 0 active+not-approved.

**Do not remove the live legacy `autoApproveProducts` JSON key until this PR's backend is deployed**, because the currently deployed old `create-product` still reads it. After deployment, `save-admin-settings` strips the key on future saves and the legacy DB key can be removed deliberately.

## Tests added/updated
- eligible seller create → live immediately;
- client cannot override server-owned moderation marker;
- paused seller cannot force public publication;
- draft stays inactive but is not placed on moderation hold;
- eligible existing draft can publish without admin approval;
- moderation-held listing cannot be republished by seller;
- legacy `autoApproveProducts` is stripped by Admin Settings server boundary;
- conditional Product Form section numbering remains dynamic and consecutive.

## Branch Guard
- base: `main` at `22e13a6933c7c7a3bc423bffbd0364eb34f35a04`;
- no payment/checkout/auth changes;
- no RLS/permission/schema/RPC changes;
- no PR #484 seller-media changes;
- seller verification remains intact;
- seller eligibility/Stripe/pause/shipping/listing-limit guards remain intact.

## Validation gate
This PR is intentionally **draft/unmerged** until the exact final head passes the authoritative local Windows PowerShell gate:

1. `npm ci`
2. `npm run lint`
3. `npx tsc -b --pretty false`
4. focused tests for create/update/settings/numbering
5. full `npm test`
6. `npm run build`
7. `git diff --check origin/main...HEAD`
8. clean worktree + exact SHA verification
9. functional UI verification of consecutive Add Product numbering and direct publish/moderation-hold behavior.

GitHub Actions remains supplementary/non-authoritative due the known account/billing condition.