### PR TITLE
Stabilize native login viewport and OAuth probe handling

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,11 +6,19 @@ import App from "./App.tsx";
 import ErrorBoundary from "./components/ErrorBoundary.tsx";
 import { initErrorTracking } from "./lib/errorTracking.ts";
 import { patchCapacitorFetch } from "./lib/capacitorFetchPatch.ts";
+import { isCapacitorContext } from "./lib/capacitorUtils.ts";
 import "./index.css";
+import "./native.css";
 
 // Initialise global error tracking (unhandled errors + unhandled rejections).
 // Must be called before the React tree mounts so no early errors are missed.
 initErrorTracking();
+
+// Mark the native WebView once at bootstrap so native-only layout fixes can be
+// scoped without changing the regular website or mobile browser experience.
+if (isCapacitorContext()) {
+  document.documentElement.classList.add('capacitor-native');
+}
 
 // On Capacitor APK, relative /.netlify/functions/ URLs resolve to
 // https://localhost (the local WebView file server) instead of the Netlify

--- a/src/native.css
+++ b/src/native.css
@@ -1,19 +1,10 @@
-/* Native Capacitor-only layout corrections.
- * Keep the regular website and mobile browser untouched.
+/* Native Capacitor-only login corrections.
+ * The selector intentionally matches the existing Login.tsx root exactly so
+ * no marketplace, dashboard, checkout, admin, or other mobile surface inherits
+ * these layout rules.
  */
 
-html.capacitor-native,
-html.capacitor-native body,
-html.capacitor-native #root {
-  min-height: 100%;
-  background: var(--background);
-}
-
-/* The login page currently reserves the global web header with inline styles.
- * In the APK that header is not part of the native login surface, so remove the
- * web offset and size the screen against the dynamic viewport instead.
- */
-html.capacitor-native #main-content {
+html.capacitor-native #main-content.flex.bg-background {
   margin-top: 0 !important;
   min-height: 100dvh !important;
   padding-top: env(safe-area-inset-top, 0px);
@@ -22,28 +13,27 @@ html.capacitor-native #main-content {
   overscroll-behavior-y: none;
 }
 
-html.capacitor-native #main-content > div:last-child {
+html.capacitor-native #main-content.flex.bg-background > div:last-child {
   min-height: calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) !important;
 }
 
-/* Do not vertically recenter the whole form when an error/notice changes its
- * height. Keep a stable top anchor and let the page scroll only when required.
+/* Login.tsx vertically centres this wrapper on the website. In the native app,
+ * an OAuth notice changes the card height and therefore shifts the whole form.
+ * Anchor only the native login form to the top instead.
  */
-html.capacitor-native #main-content > div:last-child > div {
+html.capacitor-native #main-content.flex.bg-background > div:last-child > div {
   align-items: flex-start !important;
   padding-top: 1rem !important;
   padding-bottom: 1.5rem !important;
 }
 
-html.capacitor-native #main-content > div:last-child > div > div {
+html.capacitor-native #main-content.flex.bg-background > div:last-child > div > div {
   margin-left: auto;
   margin-right: auto;
   max-width: 32rem;
 }
 
-/* Leave a small protected zone above Android gesture / three-button navigation
- * so the final account CTA never sits underneath system chrome.
- */
-html.capacitor-native #main-content > div:last-child > div > div > p:last-child {
+/* Protect the final account CTA from Android gesture / three-button navigation. */
+html.capacitor-native #main-content.flex.bg-background > div:last-child > div > div > p:last-child {
   margin-bottom: max(0.75rem, env(safe-area-inset-bottom, 0px));
 }

--- a/src/native.css
+++ b/src/native.css
@@ -1,0 +1,49 @@
+/* Native Capacitor-only layout corrections.
+ * Keep the regular website and mobile browser untouched.
+ */
+
+html.capacitor-native,
+html.capacitor-native body,
+html.capacitor-native #root {
+  min-height: 100%;
+  background: var(--background);
+}
+
+/* The login page currently reserves the global web header with inline styles.
+ * In the APK that header is not part of the native login surface, so remove the
+ * web offset and size the screen against the dynamic viewport instead.
+ */
+html.capacitor-native #main-content {
+  margin-top: 0 !important;
+  min-height: 100dvh !important;
+  padding-top: env(safe-area-inset-top, 0px);
+  padding-bottom: env(safe-area-inset-bottom, 0px);
+  overflow-y: auto;
+  overscroll-behavior-y: none;
+}
+
+html.capacitor-native #main-content > div:last-child {
+  min-height: calc(100dvh - env(safe-area-inset-top, 0px) - env(safe-area-inset-bottom, 0px)) !important;
+}
+
+/* Do not vertically recenter the whole form when an error/notice changes its
+ * height. Keep a stable top anchor and let the page scroll only when required.
+ */
+html.capacitor-native #main-content > div:last-child > div {
+  align-items: flex-start !important;
+  padding-top: 1rem !important;
+  padding-bottom: 1.5rem !important;
+}
+
+html.capacitor-native #main-content > div:last-child > div > div {
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 32rem;
+}
+
+/* Leave a small protected zone above Android gesture / three-button navigation
+ * so the final account CTA never sits underneath system chrome.
+ */
+html.capacitor-native #main-content > div:last-child > div > div > p:last-child {
+  margin-bottom: max(0.75rem, env(safe-area-inset-bottom, 0px));
+}

--- a/src/pages/AuthCallbackPage.tsx
+++ b/src/pages/AuthCallbackPage.tsx
@@ -22,9 +22,18 @@ export default function AuthCallbackPage() {
       try {
         const currentUrl = new URL(window.location.href);
         const authCode = currentUrl.searchParams.get('code');
+        const isSyntheticDeepLinkProbe = currentUrl.searchParams.get('test') === '1';
         const hashParams = new URLSearchParams(currentUrl.hash.replace(/^#/, ''));
         const accessToken = hashParams.get('access_token');
         const refreshToken = hashParams.get('refresh_token');
+
+        // Device-level deep-link verification intentionally contains no OAuth
+        // credentials. It proves routing only and must not poison the real login
+        // screen with a persistent social-auth failure banner.
+        if (isSyntheticDeepLinkProbe && !authCode && !accessToken && !refreshToken) {
+          if (!cancelled) navigate('/login', { replace: true });
+          return;
+        }
 
         if (authCode) {
           const { error } = await supabase.auth.exchangeCodeForSession(authCode);


### PR DESCRIPTION
## Scope
Fix the native Android login defects reproduced on-device without changing the regular website contract.

## Root causes addressed
- Capacitor login inherited the web-header offset even though the native login surface has no web header.
- The login form was vertically re-centered whenever an OAuth notice changed content height, causing visible up/down jumps.
- Bottom content could approach Android system navigation without a protected safe-area.
- The synthetic `?test=1` deep-link verification probe was being treated as a real OAuth failure and permanently polluted the login UI with `oauth_failed`.

## Changes
- mark Capacitor context at bootstrap with a native-only root class;
- add a scoped `native.css` layer that removes the web-header offset, anchors the native form to a stable top position, uses `100dvh`, respects safe-area insets, and protects the final CTA from system chrome;
- make `AuthCallbackPage` recognize the explicit synthetic deep-link probe and return cleanly to `/login` without creating a false OAuth failure state.

## Branch Guard
- no DB/schema/RLS changes;
- no Stripe/payment changes;
- no role/permission changes;
- no marketplace lifecycle changes;
- no web/mobile-browser layout changes because all layout rules are scoped to `.capacitor-native`;
- real OAuth failures still preserve the existing `oauth_failed` path; only the explicit `test=1` probe is excluded.

Draft until CI/build and on-device validation are complete.