### PR TITLE
Enforce server-only push token writes at RLS boundary

### DIFF
--- a/supabase/603_lock_push_token_writes_to_server.sql
+++ b/supabase/603_lock_push_token_writes_to_server.sql
@@ -1,0 +1,44 @@
+-- 603_lock_push_token_writes_to_server.sql
+--
+-- Canonical push-token contract:
+--   * authenticated users may read only their own registered devices;
+--   * all token registration / reassignment / deactivation is performed through
+--     the authenticated push-token Netlify function using service_role;
+--   * clients must not be able to bypass ownership reconciliation by writing
+--     public.push_tokens directly.
+--
+-- This migration is deliberately non-destructive to existing token rows.
+
+ALTER TABLE public.push_tokens ENABLE ROW LEVEL SECURITY;
+
+-- Remove drifted client-write policies. Historical environments may contain
+-- one or more of these names; DROP IF EXISTS keeps the repair idempotent.
+DROP POLICY IF EXISTS "push_tokens_insert" ON public.push_tokens;
+DROP POLICY IF EXISTS "push_tokens_update" ON public.push_tokens;
+DROP POLICY IF EXISTS "push_tokens_delete" ON public.push_tokens;
+DROP POLICY IF EXISTS "push_tokens_owner_insert" ON public.push_tokens;
+DROP POLICY IF EXISTS "push_tokens_owner_update" ON public.push_tokens;
+DROP POLICY IF EXISTS "push_tokens_owner_delete" ON public.push_tokens;
+
+-- Reapply the read-only owner policy as the single client-facing contract.
+DROP POLICY IF EXISTS "push_tokens_owner_select" ON public.push_tokens;
+DROP POLICY IF EXISTS "push_tokens_select" ON public.push_tokens;
+CREATE POLICY "push_tokens_owner_select"
+  ON public.push_tokens
+  FOR SELECT
+  TO authenticated
+  USING (auth.uid() = "userId");
+
+-- Supabase projects commonly grant broad table privileges to anon/authenticated
+-- by default and rely on RLS for row filtering. For this server-only write
+-- boundary, remove the underlying write privileges as defense in depth.
+REVOKE ALL ON TABLE public.push_tokens FROM anon;
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+  ON TABLE public.push_tokens FROM authenticated;
+GRANT SELECT ON TABLE public.push_tokens TO authenticated;
+
+-- service_role retains its existing privileges and bypasses RLS, which is what
+-- the canonical /.netlify/functions/push-token endpoint uses.
+
+COMMENT ON TABLE public.push_tokens IS
+  'Push notification device registrations. Authenticated users may read their own rows; all writes are server-managed through the push-token endpoint using service_role.';


### PR DESCRIPTION
## Verified live defect
Production `public.push_tokens` currently has owner-scoped client INSERT/UPDATE/DELETE policies and broad anon/authenticated table grants, while the canonical application path registers tokens through `/.netlify/functions/push-token` using `service_role`. This creates a duplicate write contract and lets authenticated clients bypass server-side token ownership reconciliation.

## Root-cause repair
Adds idempotent migration `supabase/603_lock_push_token_writes_to_server.sql`:
- removes all known client write policies for `push_tokens`;
- preserves authenticated owner-only SELECT;
- revokes anon table access;
- revokes authenticated INSERT/UPDATE/DELETE/TRUNCATE/REFERENCES/TRIGGER privileges;
- leaves service_role privileges and RLS bypass unchanged;
- does not delete or mutate existing token rows.

## Branch Guard
- current main baseline only;
- exactly one migration file added;
- no production migration applied automatically;
- no auth/session, Stripe, orders, marketplace lifecycle, messaging payload, or mobile routing changes;
- aligns DB boundary with the existing server endpoint rather than creating a new API.

## Deployment safety
CODE ONLY. Production policy reconciliation remains a separate controlled deployment step after migration review and the push runtime branch is finalized.