### PR TITLE
Protect paid orders from stale cleanup and schedule orphan reconciliation

### DIFF
--- a/netlify/functions/__tests__/payment-session-cleanup.test.ts
+++ b/netlify/functions/__tests__/payment-session-cleanup.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const rpc = vi.fn();
+  const limit = vi.fn();
+  const order = vi.fn(() => ({ limit }));
+  const lt = vi.fn(() => ({ order }));
+  const eq = vi.fn(() => ({ lt }));
+  const select = vi.fn(() => ({ eq }));
+  const from = vi.fn((table: string) => {
+    if (table !== 'payment_sessions') throw new Error(`Unexpected table: ${table}`);
+    return { select };
+  });
+
+  return { rpc, limit, order, lt, eq, select, from };
+});
+
+vi.mock('@netlify/functions', () => ({
+  schedule: vi.fn((_cron: string, callback: () => unknown) => callback),
+}));
+
+vi.mock('stripe', () => ({
+  default: vi.fn().mockImplementation(() => ({
+    checkout: { sessions: { retrieve: vi.fn(), expire: vi.fn() } },
+    paymentIntents: { retrieve: vi.fn(), cancel: vi.fn() },
+  })),
+}));
+
+vi.mock('@supabase/supabase-js', () => ({
+  createClient: vi.fn(() => ({
+    rpc: mocks.rpc,
+    from: mocks.from,
+  })),
+}));
+
+describe('payment-session-cleanup scheduled order cleanup', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_cleanup';
+    process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+
+    mocks.rpc.mockReset();
+    mocks.limit.mockReset();
+    mocks.limit.mockResolvedValue({ data: [], error: null });
+    mocks.from.mockClear();
+    mocks.select.mockClear();
+    mocks.eq.mockClear();
+    mocks.lt.mockClear();
+    mocks.order.mockClear();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.clearAllMocks();
+  });
+
+  it('releases stale awaiting-payment orders even when no payment sessions exist', async () => {
+    mocks.rpc.mockResolvedValue({ data: 1, error: null });
+    const { handler } = await import('../payment-session-cleanup');
+
+    const result = await handler({} as never, {} as never);
+
+    expect(mocks.rpc).toHaveBeenCalledWith('release_stale_unpaid_listing_locks');
+    expect(mocks.from).toHaveBeenCalledWith('payment_sessions');
+    expect(result).toEqual({ statusCode: 200 });
+  });
+
+  it('keeps payment-session cleanup running when stale-order cleanup fails', async () => {
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    mocks.rpc.mockResolvedValue({ data: null, error: { message: 'rpc unavailable' } });
+    const { handler } = await import('../payment-session-cleanup');
+
+    const result = await handler({} as never, {} as never);
+
+    expect(consoleError).toHaveBeenCalledWith(
+      'payment-session-cleanup: stale unpaid order cleanup failed:',
+      'rpc unavailable',
+    );
+    expect(mocks.from).toHaveBeenCalledWith('payment_sessions');
+    expect(result).toEqual({ statusCode: 200 });
+    consoleError.mockRestore();
+  });
+});

--- a/netlify/functions/payment-session-cleanup.ts
+++ b/netlify/functions/payment-session-cleanup.ts
@@ -43,6 +43,21 @@ export const handler = schedule('*/5 * * * *', async () => {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 
+  // Accepted-offer flows can create an awaiting_payment order before a Stripe
+  // payment_session exists. Run the canonical stale-order cleanup on the same
+  // five-minute cadence as abandoned Stripe sessions. Migration 604 makes the
+  // RPC fail closed when either the order row or a linked completed payment
+  // session proves that payment exists.
+  const { data: releasedOrderCount, error: staleOrderError } = await supabase
+    .rpc('release_stale_unpaid_listing_locks');
+  if (staleOrderError) {
+    // Non-fatal: a stale-order reconciliation problem must not prevent Stripe
+    // session reconciliation from continuing below.
+    console.error('payment-session-cleanup: stale unpaid order cleanup failed:', staleOrderError.message);
+  } else if (typeof releasedOrderCount === 'number' && releasedOrderCount > 0) {
+    console.log(`payment-session-cleanup: released ${releasedOrderCount} stale unpaid order lock(s)`);
+  }
+
   const cutoff = new Date(Date.now() - PAYMENT_WINDOW_MINUTES * 60 * 1000).toISOString();
   const { data, error } = await supabase
     .from('payment_sessions')

--- a/supabase/604_protect_paid_orders_from_stale_cleanup.sql
+++ b/supabase/604_protect_paid_orders_from_stale_cleanup.sql
@@ -1,0 +1,97 @@
+-- 604_protect_paid_orders_from_stale_cleanup.sql
+--
+-- Payment evidence can live on either orders.stripePaymentIntentId or on a
+-- completed payment_sessions row linked to the order. Legacy/repair flows may
+-- legitimately have only the latter. Stale-unpaid cleanup must therefore fail
+-- closed whenever either source proves payment, otherwise a paid order can be
+-- misclassified as abandoned and cancelled.
+
+CREATE OR REPLACE FUNCTION public.release_stale_unpaid_listing_locks()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  cancelled_count integer := 0;
+BEGIN
+  WITH stale_orders AS (
+    SELECT o.id, o."productId", o."createdAt"
+      FROM public.orders o
+     WHERE o.status = 'awaiting_payment'
+       AND COALESCE(o."stripePaymentIntentId", '') = ''
+       AND o."createdAt" < NOW() - INTERVAL '15 minutes'
+       -- A linked completed payment session with a Stripe PaymentIntent is
+       -- durable payment evidence even if an older order row was never backfilled.
+       AND NOT EXISTS (
+         SELECT 1
+           FROM public.payment_sessions ps
+          WHERE ps."orderId" = o.id
+            AND ps.status = 'completed'
+            AND COALESCE(ps."stripePaymentIntent", '') <> ''
+       )
+  ),
+  cancelled_orders AS (
+    UPDATE public.orders o
+       SET status = 'cancelled'
+      FROM stale_orders s
+     WHERE o.id = s.id
+    RETURNING o.id, o."productId", s."createdAt"
+  ),
+  audit_events AS (
+    INSERT INTO public.order_events ("orderId", "actorId", event, metadata)
+    SELECT c.id,
+           NULL,
+           'stale_unpaid_lock_released',
+           jsonb_build_object(
+             'reason', 'awaiting_payment_expired',
+             'orderCreatedAt', c."createdAt",
+             'releasedAt', NOW(),
+             'paymentEvidenceChecked', true
+           )
+      FROM cancelled_orders c
+  ),
+  released_products AS (
+    UPDATE public.products p
+       SET "listingStatus" = 'active',
+           "reservedUntil" = NULL,
+           "reservationToken" = NULL
+     WHERE p.id IN (SELECT DISTINCT "productId" FROM cancelled_orders)
+       AND p."reservationToken" IS NULL
+       AND NOT EXISTS (
+         SELECT 1
+           FROM public.payment_sessions ps
+          WHERE ps.status = 'pending'
+            AND EXISTS (
+              SELECT 1
+                FROM jsonb_array_elements(
+                  CASE
+                    WHEN jsonb_typeof(ps.metadata -> 'items') = 'array'
+                      THEN ps.metadata -> 'items'
+                    ELSE '[]'::jsonb
+                  END
+                ) AS item
+               WHERE item ->> 'productId' = p.id::text
+            )
+       )
+       AND NOT EXISTS (
+         SELECT 1
+           FROM public.orders o
+          WHERE o."productId" = p.id
+            AND o.status IN ('awaiting_payment', 'paid', 'packed', 'shipped', 'delivered', 'completed')
+       )
+    RETURNING p.id
+  )
+  SELECT COUNT(*) INTO cancelled_count FROM cancelled_orders;
+
+  RETURN cancelled_count;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.release_stale_unpaid_listing_locks()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.release_stale_unpaid_listing_locks()
+  TO service_role;
+
+COMMENT ON FUNCTION public.release_stale_unpaid_listing_locks() IS
+  'Cancels expired awaiting_payment orders only when neither the order nor a linked completed payment session contains Stripe payment evidence, then safely releases unowned listing reservations.';


### PR DESCRIPTION
## Verified production inconsistency
Read-only production audit found a completed `payment_sessions` row with a real Stripe PaymentIntent linked to order `LM-0100001`, while the linked order is currently `cancelled` / escrow `released` and has no `orders.stripePaymentIntentId`. The live `release_stale_unpaid_listing_locks()` only checks the order column and ignores linked completed payment-session evidence, so legacy/repaired paid orders can be misclassified as stale unpaid if they remain `awaiting_payment`.

## Root-cause repair
- add migration `604_protect_paid_orders_from_stale_cleanup.sql` so stale-order cleanup fails closed when either the order row or a linked completed payment session contains Stripe payment evidence;
- keep audited cancellation events for genuinely stale unpaid orders;
- run the canonical stale-order RPC every five minutes from the existing `payment-session-cleanup` schedule, so accepted-offer orders that never create a Stripe session do not remain orphaned indefinitely;
- stale-order RPC failure is non-fatal and does not stop existing Stripe-session reconciliation;
- add focused regression tests for scheduled cleanup with zero payment sessions and RPC-failure isolation.

## Branch Guard
- current main baseline only;
- exactly 3 files changed: one migration, one existing scheduled function, one focused test;
- no Stripe production mutation/config change;
- no existing production order/payment rows changed;
- no checkout payload, pricing, fees, webhook signatures, role/RLS, or UI changes;
- no new lifecycle or duplicate API introduced; this reuses the canonical existing RPC and payment-session scheduler.

## Production safety
CODE ONLY. The production migration and any historical order reconciliation require a separate controlled deployment/reconciliation step after validation. The historical inconsistent order is deliberately not mutated by this PR.