### PR TITLE
Lock shipment writes to canonical server flows

### DIFF
--- a/supabase/607_lock_shipment_writes_to_server.sql
+++ b/supabase/607_lock_shipment_writes_to_server.sql
@@ -1,0 +1,32 @@
+-- 607_lock_shipment_writes_to_server.sql
+--
+-- Canonical shipment contract:
+--   * buyers/sellers/admin clients may read shipments only through RLS;
+--   * shipment creation, mutation, POD confirmation and lifecycle transitions are
+--     server-managed through authenticated Netlify functions using service_role;
+--   * direct client INSERT/UPDATE/DELETE must not bypass order ownership,
+--     payment-backed transition guards, rate limits, notifications or audit events.
+
+ALTER TABLE public.shipments ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "shipments_insert" ON public.shipments;
+DROP POLICY IF EXISTS "shipments_update" ON public.shipments;
+DROP POLICY IF EXISTS "shipments_delete" ON public.shipments;
+DROP POLICY IF EXISTS "Sellers can insert shipments" ON public.shipments;
+DROP POLICY IF EXISTS "Sellers can update shipments" ON public.shipments;
+DROP POLICY IF EXISTS "Sellers can delete shipments" ON public.shipments;
+
+-- Preserve the participant/admin SELECT contract exactly as-is. Remove the
+-- underlying write privileges as defense in depth so an accidentally permissive
+-- future RLS policy cannot silently reopen the bypass.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+  ON TABLE public.shipments FROM anon, authenticated;
+
+GRANT SELECT ON TABLE public.shipments TO authenticated;
+REVOKE SELECT ON TABLE public.shipments FROM anon;
+
+-- Canonical server handlers operate with service_role and retain full access.
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.shipments TO service_role;
+
+COMMENT ON TABLE public.shipments IS
+  'Shipment records. Client roles are read-only under participant/admin RLS; all writes are server-managed through canonical shipment functions.';


### PR DESCRIPTION
## Checkpoint A blocker
Live RLS audit confirmed that `shipments` still allows authenticated sellers to INSERT/UPDATE directly even though the active seller UI already uses the canonical `create-shipment`, `update-shipment-status`, and POD server functions. That direct DB path can bypass order ownership verification, payment-backed transition guards, rate limits, shipment events, buyer notifications, and server lifecycle rules.

## Canonical repair
- remove client INSERT/UPDATE/DELETE shipment policies;
- revoke client write privileges as defense in depth;
- preserve authenticated participant/admin SELECT behavior;
- revoke unnecessary direct anon SELECT; public tracking uses the protected `track-shipment` endpoint;
- keep service-role writes for canonical server functions;
- no order/payment/Stripe status or business-rule changes.

## Branch Guard evidence
- branch was created directly from current main `a59ce66c9a507022a866101390d891fef50674db`;
- exact PR patch contains one file only: `supabase/607_lock_shipment_writes_to_server.sql`;
- seller shipment UI reads shipments under RLS but sends create/status/POD writes through authenticated Netlify functions;
- repository search found no legitimate direct frontend shipment INSERT/UPDATE caller;
- public TrackOrderPage uses `track-shipment` rather than direct shipment reads;
- financial/lifecycle policy audit found no equivalent ordinary-user write bypass in seller_balance, payouts, payout_requests, orders, platform_settings or stripe_events;
- Netlify Deploy Preview: PASS.

## Sequence
Migration 607 remains ordered after the pending push privacy 606 work. Do not merge/deploy 607 before the Checkpoint A 603→605→606 reconciliation gates are complete.

Status: REPO PASS / SEQUENCED AFTER 606 / PRODUCTION UNCHANGED.