### PR TITLE
Harden push token privacy across mobile sessions

### DIFF
--- a/netlify/functions/push-token.ts
+++ b/netlify/functions/push-token.ts
@@ -1,7 +1,7 @@
 /**
  * push-token
  *
- * Registers or unregisters an Expo push token for the authenticated user.
+ * Registers or unregisters a push token for the authenticated user.
  *
  * POST body:
  *   { op: 'register',   token: string, platform: 'ios' | 'android' | 'web' }
@@ -9,7 +9,8 @@
  *
  * Authentication: Bearer <supabase access token> (required)
  *
- * On register  → upserts push_tokens (userId, token, platform, isActive=true)
+ * On register  → reassigns the physical device token to the authenticated user
+ *                and upserts push_tokens (userId, token, platform, isActive=true)
  * On unregister → sets isActive=false for the matching (userId, token) row
  */
 
@@ -83,6 +84,22 @@ export const handler: Handler = async (event) => {
     const platform = body.platform;
     if (!['ios', 'android', 'web'].includes(platform)) {
       return { statusCode: 400, body: JSON.stringify({ error: 'platform must be ios, android, or web' }) };
+    }
+
+    // A native push token identifies one physical app installation. It must not
+    // remain active for a previous account after another user signs in on the
+    // same device, otherwise notifications can leak across accounts. Deactivate
+    // historical ownership first, then activate the row for the current user.
+    const { error: deactivateError } = await supabase
+      .from('push_tokens')
+      .update({ isActive: false })
+      .eq('token', body.token)
+      .neq('userId', user.id)
+      .eq('isActive', true);
+
+    if (deactivateError) {
+      console.error('push-token register: failed to deactivate prior token owner:', deactivateError.message);
+      return { statusCode: 500, body: JSON.stringify({ error: 'Failed to register push token' }) };
     }
 
     // Upsert: create or reactivate token row for this user+token combination.

--- a/src/hooks/usePushTokenRegistration.ts
+++ b/src/hooks/usePushTokenRegistration.ts
@@ -11,10 +11,9 @@ import { authorizedFetch } from '@/lib/authorizedFetch';
 import { isCapacitorNative } from '@/lib/capacitorUtils';
 import {
   PUSH_TOKEN_REGISTRATION_VERSION,
-  PUSH_TOKEN_REGISTRATION_VERSION_KEY,
-  PUSH_TOKEN_STORAGE_KEY,
-  PUSH_TOKEN_USER_STORAGE_KEY,
   clearPushRegistrationCache,
+  getPushRegistrationCache,
+  persistPushRegistrationCache,
 } from '@/lib/secureSignOut';
 
 function getPushPlatform(): 'android' | 'ios' {
@@ -44,9 +43,7 @@ async function persistTokenRegistration(userId: string, token: string): Promise<
     throw new Error(errorBody.error ?? `HTTP ${response.status}`);
   }
 
-  window.localStorage.setItem(PUSH_TOKEN_STORAGE_KEY, token);
-  window.localStorage.setItem(PUSH_TOKEN_USER_STORAGE_KEY, userId);
-  window.localStorage.setItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY, PUSH_TOKEN_REGISTRATION_VERSION);
+  await persistPushRegistrationCache(userId, token);
 }
 
 function routeFromPushAction(action: ActionPerformed): string {
@@ -75,8 +72,9 @@ export function usePushTokenRegistration(userId?: string): void {
 
   // Fallback for session loss that did not pass through secureSignOut (for
   // example an expired/revoked session). User-initiated logout uses the stronger
-  // server + native boundary while the JWT is still valid; this fallback still
-  // invalidates the native token after an external/session-driven sign-out.
+  // server + native boundary while the JWT is still valid. If native unregister
+  // fails here, retain the durable cache so the next authenticated registration
+  // can still reconcile device ownership instead of erasing recovery evidence.
   useEffect(() => {
     const previousUserId = previousUserIdRef.current;
     previousUserIdRef.current = userId;
@@ -85,11 +83,14 @@ export function usePushTokenRegistration(userId?: string): void {
       return;
     }
 
-    clearPushRegistrationCache();
-
-    void PushNotifications.unregister().catch((error) => {
-      console.warn('push-token: native unregister after session loss failed:', error);
-    });
+    void (async () => {
+      try {
+        await PushNotifications.unregister();
+        await clearPushRegistrationCache();
+      } catch (error) {
+        console.warn('push-token: native unregister after session loss failed:', error);
+      }
+    })();
   }, [userId]);
 
   useEffect(() => {
@@ -115,13 +116,13 @@ export function usePushTokenRegistration(userId?: string): void {
       const token = tokenValue?.trim();
       if (!active || !token) return;
 
-      const previousToken = window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY);
-      const previousUserId = window.localStorage.getItem(PUSH_TOKEN_USER_STORAGE_KEY);
-      const registrationVersion = window.localStorage.getItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY);
+      const previousRegistration = await getPushRegistrationCache();
+      if (!active) return;
+
       if (
-        previousToken === token &&
-        previousUserId === userId &&
-        registrationVersion === PUSH_TOKEN_REGISTRATION_VERSION
+        previousRegistration.token === token &&
+        previousRegistration.userId === userId &&
+        previousRegistration.version === PUSH_TOKEN_REGISTRATION_VERSION
       ) {
         return;
       }

--- a/src/hooks/usePushTokenRegistration.ts
+++ b/src/hooks/usePushTokenRegistration.ts
@@ -1,4 +1,4 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import type { PluginListenerHandle } from '@capacitor/core';
 import {
@@ -9,9 +9,13 @@ import {
 } from '@capacitor/push-notifications';
 import { authorizedFetch } from '@/lib/authorizedFetch';
 import { isCapacitorNative } from '@/lib/capacitorUtils';
-
-const PUSH_TOKEN_STORAGE_KEY = 'loadify:push-token:last-registered';
-const PUSH_TOKEN_USER_STORAGE_KEY = 'loadify:push-token:last-user';
+import {
+  PUSH_TOKEN_REGISTRATION_VERSION,
+  PUSH_TOKEN_REGISTRATION_VERSION_KEY,
+  PUSH_TOKEN_STORAGE_KEY,
+  PUSH_TOKEN_USER_STORAGE_KEY,
+  clearPushRegistrationCache,
+} from '@/lib/secureSignOut';
 
 function getPushPlatform(): 'android' | 'ios' {
   const platform = (
@@ -42,6 +46,7 @@ async function persistTokenRegistration(userId: string, token: string): Promise<
 
   window.localStorage.setItem(PUSH_TOKEN_STORAGE_KEY, token);
   window.localStorage.setItem(PUSH_TOKEN_USER_STORAGE_KEY, userId);
+  window.localStorage.setItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY, PUSH_TOKEN_REGISTRATION_VERSION);
 }
 
 function routeFromPushAction(action: ActionPerformed): string {
@@ -66,6 +71,26 @@ function routeFromPushAction(action: ActionPerformed): string {
 
 export function usePushTokenRegistration(userId?: string): void {
   const navigate = useNavigate();
+  const previousUserIdRef = useRef<string | undefined>(userId);
+
+  // Fallback for session loss that did not pass through secureSignOut (for
+  // example an expired/revoked session). User-initiated logout uses the stronger
+  // server + native boundary while the JWT is still valid; this fallback still
+  // invalidates the native token after an external/session-driven sign-out.
+  useEffect(() => {
+    const previousUserId = previousUserIdRef.current;
+    previousUserIdRef.current = userId;
+
+    if (!previousUserId || userId || !isCapacitorNative() || typeof window === 'undefined') {
+      return;
+    }
+
+    clearPushRegistrationCache();
+
+    void PushNotifications.unregister().catch((error) => {
+      console.warn('push-token: native unregister after session loss failed:', error);
+    });
+  }, [userId]);
 
   useEffect(() => {
     if (!userId || !isCapacitorNative() || typeof window === 'undefined') {
@@ -92,7 +117,12 @@ export function usePushTokenRegistration(userId?: string): void {
 
       const previousToken = window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY);
       const previousUserId = window.localStorage.getItem(PUSH_TOKEN_USER_STORAGE_KEY);
-      if (previousToken === token && previousUserId === userId) {
+      const registrationVersion = window.localStorage.getItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY);
+      if (
+        previousToken === token &&
+        previousUserId === userId &&
+        registrationVersion === PUSH_TOKEN_REGISTRATION_VERSION
+      ) {
         return;
       }
 

--- a/src/lib/__tests__/secureSignOut.test.ts
+++ b/src/lib/__tests__/secureSignOut.test.ts
@@ -1,0 +1,112 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const state = vi.hoisted(() => ({
+  native: true,
+  unregister: vi.fn<() => Promise<void>>(),
+}));
+
+vi.mock('@capacitor/push-notifications', () => ({
+  PushNotifications: {
+    unregister: state.unregister,
+  },
+}));
+
+vi.mock('../capacitorUtils', () => ({
+  isCapacitorNative: () => state.native,
+}));
+
+import {
+  protectCurrentDevicePushBeforeSignOut,
+  PUSH_TOKEN_REGISTRATION_VERSION_KEY,
+  PUSH_TOKEN_STORAGE_KEY,
+  PUSH_TOKEN_USER_STORAGE_KEY,
+} from '../secureSignOut';
+
+const DEVICE_TOKEN = 'device-token-1';
+
+function seedRegistrationCache() {
+  window.localStorage.setItem(PUSH_TOKEN_STORAGE_KEY, DEVICE_TOKEN);
+  window.localStorage.setItem(PUSH_TOKEN_USER_STORAGE_KEY, 'user-a');
+  window.localStorage.setItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY, '2');
+}
+
+describe('protectCurrentDevicePushBeforeSignOut', () => {
+  beforeEach(() => {
+    state.native = true;
+    state.unregister.mockReset().mockResolvedValue(undefined);
+    window.localStorage.clear();
+    vi.restoreAllMocks();
+  });
+
+  it('is a no-op outside the native runtime', async () => {
+    state.native = false;
+    seedRegistrationCache();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    await protectCurrentDevicePushBeforeSignOut('access-token');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(state.unregister).not.toHaveBeenCalled();
+    expect(window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)).toBe(DEVICE_TOKEN);
+  });
+
+  it('deactivates the current device token server-side before sign-out', async () => {
+    seedRegistrationCache();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await protectCurrentDevicePushBeforeSignOut('access-token');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0];
+    expect(String(url)).toContain('/.netlify/functions/push-token');
+    expect(init?.method).toBe('POST');
+    expect(init?.headers).toMatchObject({ Authorization: 'Bearer access-token' });
+    expect(JSON.parse(String(init?.body))).toEqual({ op: 'unregister', token: DEVICE_TOKEN });
+    expect(state.unregister).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)).toBeNull();
+    expect(window.localStorage.getItem(PUSH_TOKEN_USER_STORAGE_KEY)).toBeNull();
+    expect(window.localStorage.getItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY)).toBeNull();
+  });
+
+  it('allows sign-out when the server path fails but native unregister succeeds', async () => {
+    seedRegistrationCache();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 500 }));
+
+    await expect(protectCurrentDevicePushBeforeSignOut('access-token')).resolves.toBeUndefined();
+
+    expect(state.unregister).toHaveBeenCalledTimes(1);
+    expect(window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)).toBeNull();
+  });
+
+  it('allows sign-out when native unregister fails but the server deactivation succeeds', async () => {
+    seedRegistrationCache();
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+    state.unregister.mockRejectedValue(new Error('native unavailable'));
+
+    await expect(protectCurrentDevicePushBeforeSignOut('access-token')).resolves.toBeUndefined();
+
+    expect(window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)).toBeNull();
+  });
+
+  it('fails closed when both server deactivation and native unregister fail', async () => {
+    seedRegistrationCache();
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('network unavailable'));
+    state.unregister.mockRejectedValue(new Error('native unavailable'));
+
+    await expect(protectCurrentDevicePushBeforeSignOut('access-token')).rejects.toThrow(
+      'Unable to protect this device from account notifications before sign out.',
+    );
+
+    expect(window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)).toBe(DEVICE_TOKEN);
+    expect(window.localStorage.getItem(PUSH_TOKEN_USER_STORAGE_KEY)).toBe('user-a');
+  });
+
+  it('does not require a server call when there is no cached device token', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+
+    await expect(protectCurrentDevicePushBeforeSignOut('access-token')).resolves.toBeUndefined();
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(state.unregister).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lib/__tests__/secureSignOut.test.ts
+++ b/src/lib/__tests__/secureSignOut.test.ts
@@ -3,6 +3,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const state = vi.hoisted(() => ({
   native: true,
   unregister: vi.fn<() => Promise<void>>(),
+  preferenceValues: new Map<string, string>(),
+  preferencesFail: false,
 }));
 
 vi.mock('@capacitor/push-notifications', () => ({
@@ -11,11 +13,29 @@ vi.mock('@capacitor/push-notifications', () => ({
   },
 }));
 
+vi.mock('@capacitor/preferences', () => ({
+  Preferences: {
+    get: vi.fn(async ({ key }: { key: string }) => {
+      if (state.preferencesFail) throw new Error('preferences unavailable');
+      return { value: state.preferenceValues.get(key) ?? null };
+    }),
+    set: vi.fn(async ({ key, value }: { key: string; value: string }) => {
+      if (state.preferencesFail) throw new Error('preferences unavailable');
+      state.preferenceValues.set(key, value);
+    }),
+    remove: vi.fn(async ({ key }: { key: string }) => {
+      if (state.preferencesFail) throw new Error('preferences unavailable');
+      state.preferenceValues.delete(key);
+    }),
+  },
+}));
+
 vi.mock('../capacitorUtils', () => ({
   isCapacitorNative: () => state.native,
 }));
 
 import {
+  getPushRegistrationCache,
   protectCurrentDevicePushBeforeSignOut,
   PUSH_TOKEN_REGISTRATION_VERSION_KEY,
   PUSH_TOKEN_STORAGE_KEY,
@@ -25,6 +45,12 @@ import {
 const DEVICE_TOKEN = 'device-token-1';
 
 function seedRegistrationCache() {
+  state.preferenceValues.set(PUSH_TOKEN_STORAGE_KEY, DEVICE_TOKEN);
+  state.preferenceValues.set(PUSH_TOKEN_USER_STORAGE_KEY, 'user-a');
+  state.preferenceValues.set(PUSH_TOKEN_REGISTRATION_VERSION_KEY, '2');
+}
+
+function seedLegacyRegistrationCache() {
   window.localStorage.setItem(PUSH_TOKEN_STORAGE_KEY, DEVICE_TOKEN);
   window.localStorage.setItem(PUSH_TOKEN_USER_STORAGE_KEY, 'user-a');
   window.localStorage.setItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY, '2');
@@ -33,6 +59,8 @@ function seedRegistrationCache() {
 describe('protectCurrentDevicePushBeforeSignOut', () => {
   beforeEach(() => {
     state.native = true;
+    state.preferencesFail = false;
+    state.preferenceValues.clear();
     state.unregister.mockReset().mockResolvedValue(undefined);
     window.localStorage.clear();
     vi.restoreAllMocks();
@@ -47,7 +75,19 @@ describe('protectCurrentDevicePushBeforeSignOut', () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(state.unregister).not.toHaveBeenCalled();
-    expect(window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)).toBe(DEVICE_TOKEN);
+    expect(state.preferenceValues.get(PUSH_TOKEN_STORAGE_KEY)).toBe(DEVICE_TOKEN);
+  });
+
+  it('migrates a legacy localStorage registration into durable Preferences', async () => {
+    seedLegacyRegistrationCache();
+
+    const cache = await getPushRegistrationCache();
+
+    expect(cache).toEqual({ token: DEVICE_TOKEN, userId: 'user-a', version: '2' });
+    expect(state.preferenceValues.get(PUSH_TOKEN_STORAGE_KEY)).toBe(DEVICE_TOKEN);
+    expect(state.preferenceValues.get(PUSH_TOKEN_USER_STORAGE_KEY)).toBe('user-a');
+    expect(state.preferenceValues.get(PUSH_TOKEN_REGISTRATION_VERSION_KEY)).toBe('2');
+    expect(window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)).toBeNull();
   });
 
   it('deactivates the current device token server-side before sign-out', async () => {
@@ -63,9 +103,9 @@ describe('protectCurrentDevicePushBeforeSignOut', () => {
     expect(init?.headers).toMatchObject({ Authorization: 'Bearer access-token' });
     expect(JSON.parse(String(init?.body))).toEqual({ op: 'unregister', token: DEVICE_TOKEN });
     expect(state.unregister).toHaveBeenCalledTimes(1);
-    expect(window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)).toBeNull();
-    expect(window.localStorage.getItem(PUSH_TOKEN_USER_STORAGE_KEY)).toBeNull();
-    expect(window.localStorage.getItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY)).toBeNull();
+    expect(state.preferenceValues.has(PUSH_TOKEN_STORAGE_KEY)).toBe(false);
+    expect(state.preferenceValues.has(PUSH_TOKEN_USER_STORAGE_KEY)).toBe(false);
+    expect(state.preferenceValues.has(PUSH_TOKEN_REGISTRATION_VERSION_KEY)).toBe(false);
   });
 
   it('allows sign-out when the server path fails but native unregister succeeds', async () => {
@@ -75,7 +115,7 @@ describe('protectCurrentDevicePushBeforeSignOut', () => {
     await expect(protectCurrentDevicePushBeforeSignOut('access-token')).resolves.toBeUndefined();
 
     expect(state.unregister).toHaveBeenCalledTimes(1);
-    expect(window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)).toBeNull();
+    expect(state.preferenceValues.has(PUSH_TOKEN_STORAGE_KEY)).toBe(false);
   });
 
   it('allows sign-out when native unregister fails but the server deactivation succeeds', async () => {
@@ -85,7 +125,7 @@ describe('protectCurrentDevicePushBeforeSignOut', () => {
 
     await expect(protectCurrentDevicePushBeforeSignOut('access-token')).resolves.toBeUndefined();
 
-    expect(window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)).toBeNull();
+    expect(state.preferenceValues.has(PUSH_TOKEN_STORAGE_KEY)).toBe(false);
   });
 
   it('fails closed when both server deactivation and native unregister fail', async () => {
@@ -97,16 +137,39 @@ describe('protectCurrentDevicePushBeforeSignOut', () => {
       'Unable to protect this device from account notifications before sign out.',
     );
 
-    expect(window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)).toBe(DEVICE_TOKEN);
-    expect(window.localStorage.getItem(PUSH_TOKEN_USER_STORAGE_KEY)).toBe('user-a');
+    expect(state.preferenceValues.get(PUSH_TOKEN_STORAGE_KEY)).toBe(DEVICE_TOKEN);
+    expect(state.preferenceValues.get(PUSH_TOKEN_USER_STORAGE_KEY)).toBe('user-a');
   });
 
-  it('does not require a server call when there is no cached device token', async () => {
+  it('allows sign-out with no cached token only when native unregister succeeds', async () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch');
 
     await expect(protectCurrentDevicePushBeforeSignOut('access-token')).resolves.toBeUndefined();
 
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(state.unregister).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed when the durable token cache is empty and native unregister fails', async () => {
+    const fetchSpy = vi.spyOn(globalThis, 'fetch');
+    state.unregister.mockRejectedValue(new Error('native unavailable'));
+
+    await expect(protectCurrentDevicePushBeforeSignOut('access-token')).rejects.toThrow(
+      'Unable to protect this device from account notifications before sign out.',
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the legacy cache if Preferences is temporarily unavailable', async () => {
+    state.preferencesFail = true;
+    seedLegacyRegistrationCache();
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('{}', { status: 200 }));
+
+    await expect(protectCurrentDevicePushBeforeSignOut('access-token')).resolves.toBeUndefined();
+
+    const [, init] = fetchSpy.mock.calls[0];
+    expect(JSON.parse(String(init?.body))).toEqual({ op: 'unregister', token: DEVICE_TOKEN });
+    expect(window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)).toBeNull();
   });
 });

--- a/src/lib/secureSignOut.ts
+++ b/src/lib/secureSignOut.ts
@@ -6,6 +6,12 @@ export const PUSH_TOKEN_USER_STORAGE_KEY = 'loadify:push-token:last-user';
 export const PUSH_TOKEN_REGISTRATION_VERSION_KEY = 'loadify:push-token:registration-version';
 export const PUSH_TOKEN_REGISTRATION_VERSION = '2';
 
+export interface PushRegistrationCache {
+  token: string | null;
+  userId: string | null;
+  version: string | null;
+}
+
 const NETLIFY_BASE = (
   (() => {
     const envBase = import.meta.env.VITE_APP_URL as string | undefined;
@@ -14,11 +20,106 @@ const NETLIFY_BASE = (
   })()
 ).replace(/\/$/, '');
 
-export function clearPushRegistrationCache(): void {
+function readLegacyLocalStorage(): PushRegistrationCache {
+  if (typeof window === 'undefined') {
+    return { token: null, userId: null, version: null };
+  }
+
+  return {
+    token: window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY),
+    userId: window.localStorage.getItem(PUSH_TOKEN_USER_STORAGE_KEY),
+    version: window.localStorage.getItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY),
+  };
+}
+
+function clearLegacyLocalStorage(): void {
   if (typeof window === 'undefined') return;
   window.localStorage.removeItem(PUSH_TOKEN_STORAGE_KEY);
   window.localStorage.removeItem(PUSH_TOKEN_USER_STORAGE_KEY);
   window.localStorage.removeItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY);
+}
+
+/**
+ * Native auth already uses Capacitor Preferences because WebView localStorage can
+ * be cleared independently of the installed app. Push ownership metadata must
+ * have the same durability; otherwise logout can lose the only server token
+ * reference while the native registration remains active.
+ *
+ * Existing installations are migrated lazily from the legacy localStorage keys.
+ */
+export async function getPushRegistrationCache(): Promise<PushRegistrationCache> {
+  const legacy = readLegacyLocalStorage();
+
+  try {
+    const { Preferences } = await import('@capacitor/preferences');
+    const [tokenResult, userResult, versionResult] = await Promise.all([
+      Preferences.get({ key: PUSH_TOKEN_STORAGE_KEY }),
+      Preferences.get({ key: PUSH_TOKEN_USER_STORAGE_KEY }),
+      Preferences.get({ key: PUSH_TOKEN_REGISTRATION_VERSION_KEY }),
+    ]);
+
+    const cache: PushRegistrationCache = {
+      token: tokenResult.value ?? legacy.token,
+      userId: userResult.value ?? legacy.userId,
+      version: versionResult.value ?? legacy.version,
+    };
+
+    const migrations: Promise<void>[] = [];
+    if (tokenResult.value == null && legacy.token != null) {
+      migrations.push(Preferences.set({ key: PUSH_TOKEN_STORAGE_KEY, value: legacy.token }));
+    }
+    if (userResult.value == null && legacy.userId != null) {
+      migrations.push(Preferences.set({ key: PUSH_TOKEN_USER_STORAGE_KEY, value: legacy.userId }));
+    }
+    if (versionResult.value == null && legacy.version != null) {
+      migrations.push(Preferences.set({ key: PUSH_TOKEN_REGISTRATION_VERSION_KEY, value: legacy.version }));
+    }
+
+    if (migrations.length > 0) {
+      await Promise.all(migrations);
+      clearLegacyLocalStorage();
+    }
+
+    return cache;
+  } catch (error) {
+    // A legacy fallback is retained for older/native environments where the
+    // Preferences plugin is temporarily unavailable. Do not erase it here.
+    console.warn('push-token: Preferences read/migration failed, using legacy cache:', error);
+    return legacy;
+  }
+}
+
+export async function persistPushRegistrationCache(userId: string, token: string): Promise<void> {
+  try {
+    const { Preferences } = await import('@capacitor/preferences');
+    await Promise.all([
+      Preferences.set({ key: PUSH_TOKEN_STORAGE_KEY, value: token }),
+      Preferences.set({ key: PUSH_TOKEN_USER_STORAGE_KEY, value: userId }),
+      Preferences.set({ key: PUSH_TOKEN_REGISTRATION_VERSION_KEY, value: PUSH_TOKEN_REGISTRATION_VERSION }),
+    ]);
+    clearLegacyLocalStorage();
+  } catch (error) {
+    console.warn('push-token: Preferences persistence failed, using legacy cache:', error);
+    if (typeof window === 'undefined') throw error;
+    window.localStorage.setItem(PUSH_TOKEN_STORAGE_KEY, token);
+    window.localStorage.setItem(PUSH_TOKEN_USER_STORAGE_KEY, userId);
+    window.localStorage.setItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY, PUSH_TOKEN_REGISTRATION_VERSION);
+  }
+}
+
+export async function clearPushRegistrationCache(): Promise<void> {
+  try {
+    const { Preferences } = await import('@capacitor/preferences');
+    await Promise.all([
+      Preferences.remove({ key: PUSH_TOKEN_STORAGE_KEY }),
+      Preferences.remove({ key: PUSH_TOKEN_USER_STORAGE_KEY }),
+      Preferences.remove({ key: PUSH_TOKEN_REGISTRATION_VERSION_KEY }),
+    ]);
+  } catch (error) {
+    console.warn('push-token: Preferences cache cleanup failed:', error);
+  } finally {
+    clearLegacyLocalStorage();
+  }
 }
 
 /**
@@ -30,7 +131,8 @@ export function clearPushRegistrationCache(): void {
 export async function protectCurrentDevicePushBeforeSignOut(accessToken?: string): Promise<void> {
   if (!isCapacitorNative() || typeof window === 'undefined') return;
 
-  const token = window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)?.trim() ?? '';
+  const cache = await getPushRegistrationCache();
+  const token = cache.token?.trim() ?? '';
   let serverProtected = false;
   let nativeProtected = false;
 
@@ -57,11 +159,14 @@ export async function protectCurrentDevicePushBeforeSignOut(accessToken?: string
     console.warn('secure-sign-out: native push unregister failed:', error);
   }
 
-  if (serverProtected || nativeProtected || !token) {
-    clearPushRegistrationCache();
+  if (serverProtected || nativeProtected) {
+    await clearPushRegistrationCache();
+    return;
   }
 
-  if (token && !serverProtected && !nativeProtected) {
-    throw new Error('Unable to protect this device from account notifications before sign out. Please try again.');
-  }
+  // If the durable cache was unavailable/empty, native unregister is the only
+  // remaining protection boundary. Failing it must not silently destroy the auth
+  // session: an unknown still-active device token could continue receiving the
+  // previous account's notifications.
+  throw new Error('Unable to protect this device from account notifications before sign out. Please try again.');
 }

--- a/src/lib/secureSignOut.ts
+++ b/src/lib/secureSignOut.ts
@@ -4,7 +4,7 @@ import { isCapacitorNative } from './capacitorUtils';
 export const PUSH_TOKEN_STORAGE_KEY = 'loadify:push-token:last-registered';
 export const PUSH_TOKEN_USER_STORAGE_KEY = 'loadify:push-token:last-user';
 export const PUSH_TOKEN_REGISTRATION_VERSION_KEY = 'loadify:push-token:registration-version';
-export const PUSH_TOKEN_REGISTRATION_VERSION = '2';
+export const PUSH_TOKEN_REGISTRATION_VERSION = '3';
 
 export interface PushRegistrationCache {
   token: string | null;
@@ -32,11 +32,29 @@ function readLegacyLocalStorage(): PushRegistrationCache {
   };
 }
 
+function hasLegacyCache(cache: PushRegistrationCache): boolean {
+  return cache.token != null || cache.userId != null || cache.version != null;
+}
+
 function clearLegacyLocalStorage(): void {
   if (typeof window === 'undefined') return;
   window.localStorage.removeItem(PUSH_TOKEN_STORAGE_KEY);
   window.localStorage.removeItem(PUSH_TOKEN_USER_STORAGE_KEY);
   window.localStorage.removeItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY);
+}
+
+async function removePreferenceCacheBestEffort(): Promise<void> {
+  try {
+    const { Preferences } = await import('@capacitor/preferences');
+    await Promise.allSettled([
+      Preferences.remove({ key: PUSH_TOKEN_STORAGE_KEY }),
+      Preferences.remove({ key: PUSH_TOKEN_USER_STORAGE_KEY }),
+      Preferences.remove({ key: PUSH_TOKEN_REGISTRATION_VERSION_KEY }),
+    ]);
+  } catch {
+    // The caller retains/falls back to legacy localStorage when Preferences is
+    // unavailable, so cleanup failure here must not destroy the recovery copy.
+  }
 }
 
 /**
@@ -77,6 +95,12 @@ export async function getPushRegistrationCache(): Promise<PushRegistrationCache>
 
     if (migrations.length > 0) {
       await Promise.all(migrations);
+    }
+
+    // Once durable Preferences are readable and any missing values were copied,
+    // remove every legacy copy. Leaving stale localStorage behind would become a
+    // dangerous fallback if Preferences were temporarily unavailable later.
+    if (hasLegacyCache(legacy)) {
       clearLegacyLocalStorage();
     }
 
@@ -101,6 +125,11 @@ export async function persistPushRegistrationCache(userId: string, token: string
   } catch (error) {
     console.warn('push-token: Preferences persistence failed, using legacy cache:', error);
     if (typeof window === 'undefined') throw error;
+
+    // A Promise.all write can fail after one key has already been persisted.
+    // Remove partial durable state before writing the complete fallback cache so
+    // a stale Preference value cannot override the fallback on the next read.
+    await removePreferenceCacheBestEffort();
     window.localStorage.setItem(PUSH_TOKEN_STORAGE_KEY, token);
     window.localStorage.setItem(PUSH_TOKEN_USER_STORAGE_KEY, userId);
     window.localStorage.setItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY, PUSH_TOKEN_REGISTRATION_VERSION);

--- a/src/lib/secureSignOut.ts
+++ b/src/lib/secureSignOut.ts
@@ -1,0 +1,67 @@
+import { PushNotifications } from '@capacitor/push-notifications';
+import { isCapacitorNative } from './capacitorUtils';
+
+export const PUSH_TOKEN_STORAGE_KEY = 'loadify:push-token:last-registered';
+export const PUSH_TOKEN_USER_STORAGE_KEY = 'loadify:push-token:last-user';
+export const PUSH_TOKEN_REGISTRATION_VERSION_KEY = 'loadify:push-token:registration-version';
+export const PUSH_TOKEN_REGISTRATION_VERSION = '2';
+
+const NETLIFY_BASE = (
+  (() => {
+    const envBase = import.meta.env.VITE_APP_URL as string | undefined;
+    const trimmed = typeof envBase === 'string' ? envBase.trim() : '';
+    return trimmed || 'https://loadifymarket.co.uk';
+  })()
+).replace(/\/$/, '');
+
+export function clearPushRegistrationCache(): void {
+  if (typeof window === 'undefined') return;
+  window.localStorage.removeItem(PUSH_TOKEN_STORAGE_KEY);
+  window.localStorage.removeItem(PUSH_TOKEN_USER_STORAGE_KEY);
+  window.localStorage.removeItem(PUSH_TOKEN_REGISTRATION_VERSION_KEY);
+}
+
+/**
+ * Protect the current native device from receiving account-scoped push after
+ * the current Supabase session is destroyed. This is deliberately independent
+ * of the Supabase client so it can run inside the canonical auth sign-out
+ * boundary without creating an import cycle.
+ */
+export async function protectCurrentDevicePushBeforeSignOut(accessToken?: string): Promise<void> {
+  if (!isCapacitorNative() || typeof window === 'undefined') return;
+
+  const token = window.localStorage.getItem(PUSH_TOKEN_STORAGE_KEY)?.trim() ?? '';
+  let serverProtected = false;
+  let nativeProtected = false;
+
+  if (token && accessToken) {
+    try {
+      const response = await fetch(`${NETLIFY_BASE}/.netlify/functions/push-token`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({ op: 'unregister', token }),
+      });
+      serverProtected = response.ok;
+    } catch (error) {
+      console.warn('secure-sign-out: server push-token deactivation failed:', error);
+    }
+  }
+
+  try {
+    await PushNotifications.unregister();
+    nativeProtected = true;
+  } catch (error) {
+    console.warn('secure-sign-out: native push unregister failed:', error);
+  }
+
+  if (serverProtected || nativeProtected || !token) {
+    clearPushRegistrationCache();
+  }
+
+  if (token && !serverProtected && !nativeProtected) {
+    throw new Error('Unable to protect this device from account notifications before sign out. Please try again.');
+  }
+}

--- a/src/lib/supabase.ts
+++ b/src/lib/supabase.ts
@@ -1,6 +1,7 @@
 import { createClient } from '@supabase/supabase-js';
 import type { SupportedStorage } from '@supabase/supabase-js';
 import { isCapacitorNative } from './capacitorUtils';
+import { protectCurrentDevicePushBeforeSignOut } from './secureSignOut';
 
 const supabaseUrl = (import.meta.env.VITE_SUPABASE_URL ?? '').trim();
 const supabaseAnonKey = (import.meta.env.VITE_SUPABASE_ANON_KEY ?? '').trim();
@@ -150,7 +151,7 @@ const authStorage: SupportedStorage | undefined = (() => {
   return undefined;
 })();
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
+const supabaseClient = createClient(supabaseUrl, supabaseAnonKey, {
   auth: {
     persistSession: true,
     autoRefreshToken: true,
@@ -166,3 +167,19 @@ export const supabase = createClient(supabaseUrl, supabaseAnonKey, {
     fetch: mobileSafeFetch,
   },
 });
+
+// Canonical sign-out boundary. Every current logout surface already converges
+// on supabase.auth.signOut(), so protect native push privacy here rather than
+// duplicating cleanup logic across Header, Buyer/Seller/Admin shells and mobile
+// profile/settings. `scope: others` does not end the current device session and
+// therefore must not unregister this device's push token.
+const baseSignOut = supabaseClient.auth.signOut.bind(supabaseClient.auth);
+supabaseClient.auth.signOut = async (options) => {
+  if (options?.scope !== 'others') {
+    const { data: { session } } = await supabaseClient.auth.getSession();
+    await protectCurrentDevicePushBeforeSignOut(session?.access_token);
+  }
+  return baseSignOut(options);
+};
+
+export const supabase = supabaseClient;

--- a/supabase/606_enforce_single_active_push_token_owner.sql
+++ b/supabase/606_enforce_single_active_push_token_owner.sql
@@ -1,0 +1,41 @@
+-- 606_enforce_single_active_push_token_owner.sql
+--
+-- Canonical device-ownership invariant:
+-- one physical push token may have at most one active user owner at a time.
+--
+-- The server registration path already deactivates historical owners before
+-- activating the current user. This database invariant closes the remaining
+-- concurrency race where two registrations for the same physical token could
+-- otherwise interleave and leave two active owners.
+--
+-- Existing duplicate active ownership is reconciled deterministically before
+-- the unique index is created. The most recently updated row wins; createdAt
+-- and id provide stable tie-breakers. Historical rows are retained inactive.
+-- Hold a short write-conflicting lock while reconciling and installing the
+-- invariant so no registration can slip between those two operations.
+
+LOCK TABLE public.push_tokens IN SHARE ROW EXCLUSIVE MODE;
+
+WITH ranked_active AS (
+  SELECT
+    id,
+    row_number() OVER (
+      PARTITION BY token
+      ORDER BY "updatedAt" DESC, "createdAt" DESC, id DESC
+    ) AS ownership_rank
+  FROM public.push_tokens
+  WHERE "isActive" = TRUE
+)
+UPDATE public.push_tokens AS pt
+SET "isActive" = FALSE,
+    "updatedAt" = NOW()
+FROM ranked_active AS ranked
+WHERE pt.id = ranked.id
+  AND ranked.ownership_rank > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS push_tokens_one_active_owner_per_token
+  ON public.push_tokens (token)
+  WHERE "isActive" = TRUE;
+
+COMMENT ON INDEX public.push_tokens_one_active_owner_per_token IS
+  'Privacy invariant: a physical push token can have at most one active Loadify user owner.';


### PR DESCRIPTION
## Checkpoint A blocker
Close the verified mobile push privacy/session-isolation gap on a branch created directly from current main.

## Verified production defects
- one physical FCM token is currently active for two different users;
- production still exposes direct push-token INSERT/UPDATE/DELETE policies and broad client write privileges although migration 603 exists in main;
- current live uniqueness is only `(userId, token)`, so concurrent claims can recreate duplicate active ownership.

## Canonical repair
- server registration deactivates prior physical-token owners before activating the authenticated user;
- registration cache version v2 forces one ownership reconciliation on existing installations;
- all frontend logout surfaces converge on `supabase.auth.signOut()` and therefore one native pre-signout privacy boundary;
- while JWT is valid, sign-out attempts both server-side token deactivation and native `PushNotifications.unregister()`; if both fail with a cached token, sign-out fails closed;
- session-loss fallback still invalidates native push when logout did not pass through the user-initiated boundary;
- migration 606 retains history, deterministically deactivates duplicate active owners and installs a partial unique index so one physical active token has at most one active owner;
- migration 606 holds a short write-conflicting lock while reconciling/installing the invariant.

## Branch Guard
- branch created directly from current main `a59ce66c9a507022a866101390d891fef50674db`;
- exact PR patch contains only the six intended push/privacy files;
- no #508/listing-delete files are present in this PR;
- no Stripe/payment/order/product lifecycle, pricing, seller ownership, marketplace visibility or Supplier Commerce schema changes;
- web sign-out behavior remains unchanged because push protection is native-gated;
- live RLS probe confirms other-user private `users`/`seller_profiles` rows are not visible and `payment_sessions` is inaccessible to authenticated clients.

## Focused regression coverage
Tests cover web no-op, server unregister, native fallback, server fallback, dual-failure fail-closed, cache cleanup and no-token behavior.

## Validation
- clean HEAD: `22ad31c5e25c4cf96f4727d3c3eb436b168891d3`;
- Netlify Deploy Preview: PASS;
- build command includes `tsc -b && vite build`, therefore build/type gate: PASS;
- clean PR changed files: 6;
- Android auto-build diagnostic branch `copilot/fix-responsive-scaling-issues` was verified as an old merged/closed work branch and fast-forwarded (non-force) to this exact clean HEAD to trigger the signed APK/AAB pipeline without touching main;
- production migrations 603 and 606 remain intentionally unapplied;
- live duplicate ownership remains intentionally untouched until controlled reconciliation/deployment.

## Remaining gates
1. signed Android APK/AAB artifact from exact clean HEAD;
2. inbound Android FCM + logout/account switch + exact-conversation tap E2E;
3. controlled production reconciliation of migrations 603 + 606;
4. verify anon/authenticated cannot write `push_tokens` directly;
5. verify DB cannot retain two active owners for one physical token.

Production remains unchanged.