### PR TITLE
Fix Stripe constructor mock under Vitest 4

### DIFF
--- a/netlify/functions/__tests__/payment-session-cleanup.test.ts
+++ b/netlify/functions/__tests__/payment-session-cleanup.test.ts
@@ -20,10 +20,12 @@ vi.mock('@netlify/functions', () => ({
 }));
 
 vi.mock('stripe', () => ({
-  default: vi.fn().mockImplementation(() => ({
-    checkout: { sessions: { retrieve: vi.fn(), expire: vi.fn() } },
-    paymentIntents: { retrieve: vi.fn(), cancel: vi.fn() },
-  })),
+  default: vi.fn(function MockStripe() {
+    return {
+      checkout: { sessions: { retrieve: vi.fn(), expire: vi.fn() } },
+      paymentIntents: { retrieve: vi.fn(), cancel: vi.fn() },
+    };
+  }),
 }));
 
 vi.mock('@supabase/supabase-js', () => ({


### PR DESCRIPTION
## Checkpoint A baseline test-infrastructure repair

The full local suite on exact PR #511 source exposed a pre-existing baseline failure in `payment-session-cleanup.test.ts`: production constructs Stripe with `new Stripe(...)`, while the test mocked the default Stripe export with an arrow-function `mockImplementation`. Vitest 4 requires constructor mocks used with `new` to be implemented with `function` or `class`.

## Fix
- change only the Stripe test double to a constructible named function;
- preserve the exact mocked Stripe surface and test assertions;
- no production/runtime/payment behavior changes.

## Branch Guard
- based directly on main `a59ce66c9a507022a866101390d891fef50674db`;
- exactly one changed file: `netlify/functions/__tests__/payment-session-cleanup.test.ts`;
- no Stripe runtime code, payment semantics, DB schema, migrations, mobile code, or Supplier Commerce changes.

Status: LOCAL FAILURE ROOT CAUSE CONFIRMED / FOCUSED FIX READY FOR LOCAL VERIFICATION / DO NOT MERGE UNTIL TEST PASS.