### PR TITLE
[SUPERSEDED by #519 + #520] Lock shipment writes to canonical server flows

### DIFF
--- a/netlify/functions/__tests__/shipment-boundary.test.ts
+++ b/netlify/functions/__tests__/shipment-boundary.test.ts
@@ -35,6 +35,7 @@ describe('canonical shipment write boundary', () => {
   afterEach(() => {
     process.env = { ...originalEnv };
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
   });
 
   function installSharedMocks() {
@@ -89,7 +90,11 @@ describe('canonical shipment write boundary', () => {
 
   it('routes shipment create/update through the atomic server RPC', async () => {
     const rpc = vi.fn().mockResolvedValue({
-      data: { shipment: { id: 'shipment-1', order_id: 'order-1' }, created: true },
+      data: {
+        shipment: { id: 'shipment-1', order_id: 'order-1' },
+        created: true,
+        changed: true,
+      },
       error: null,
     });
 
@@ -155,6 +160,7 @@ describe('canonical shipment write boundary', () => {
     );
 
     expect(res.statusCode).toBe(201);
+    expect(JSON.parse(res.body).changed).toBe(true);
     expect(rpc).toHaveBeenCalledWith('server_upsert_shipment', {
       p_order_id: 'order-1',
       p_actor_id: 'seller-1',
@@ -168,8 +174,9 @@ describe('canonical shipment write boundary', () => {
   });
 
   it('routes shipment status + audit + order mapping through one atomic RPC', async () => {
+    const notificationInsert = vi.fn().mockResolvedValue({ error: null });
     const rpc = vi.fn().mockResolvedValue({
-      data: { shipment: { id: 'shipment-1', status: 'Processing' } },
+      data: { shipment: { id: 'shipment-1', status: 'Processing' }, changed: true },
       error: null,
     });
 
@@ -212,7 +219,7 @@ describe('canonical shipment write boundary', () => {
           };
         }
         if (table === 'notifications') {
-          return { insert: vi.fn().mockResolvedValue({ error: null }) };
+          return { insert: notificationInsert };
         }
         throw new Error(`Unexpected direct table access after transition: ${table}`);
       }),
@@ -232,12 +239,189 @@ describe('canonical shipment write boundary', () => {
     );
 
     expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).changed).toBe(true);
     expect(rpc).toHaveBeenCalledWith('server_transition_shipment', {
       p_shipment_id: 'shipment-1',
       p_actor_id: 'seller-1',
       p_status: 'Processing',
       p_message: 'Packing complete',
     });
+    expect(notificationInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses duplicate user-facing side effects on an idempotent status retry', async () => {
+    const notificationInsert = vi.fn();
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const rpc = vi.fn().mockResolvedValue({
+      data: { shipment: { id: 'shipment-1', status: 'Delivered' }, changed: false },
+      error: null,
+    });
+
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'shipments') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'shipment-1',
+                order_id: 'order-1',
+                seller_id: 'seller-1',
+                buyer_id: 'buyer-1',
+                orders: {
+                  id: 'order-1',
+                  orderNumber: 'LM-1',
+                  status: 'delivered',
+                  productId: 'product-1',
+                  stripePaymentIntentId: 'pi_1',
+                  rfqId: null,
+                  rfqResponseId: null,
+                  buyerId: 'buyer-1',
+                },
+              },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'products') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { id: 'product-1', listingContext: 'product' },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'notifications') {
+          return { insert: notificationInsert };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    installSharedMocks();
+
+    const { handler } = await import('../update-shipment-status');
+    const res = await handler(
+      makeEvent(
+        'PUT',
+        '/.netlify/functions/shipments/shipment-1/status',
+        { status: 'Delivered' },
+      ),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).changed).toBe(false);
+    expect(notificationInsert).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('requires shipped payment evidence for Out for Delivery', async () => {
+    const paymentGuard = vi.fn().mockResolvedValue({
+      ok: true,
+      statusCode: 200,
+      hasValidPaymentEvidence: true,
+      paymentEvidenceSource: 'order.stripePaymentIntentId',
+      requiresPaymentEvidence: true,
+      allowedNonStripeFlow: null,
+    });
+    const rpc = vi.fn().mockResolvedValue({
+      data: { shipment: { id: 'shipment-1', status: 'Out for Delivery' }, changed: true },
+      error: null,
+    });
+
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'shipments') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'shipment-1',
+                order_id: 'order-1',
+                seller_id: 'seller-1',
+                buyer_id: 'buyer-1',
+                orders: {
+                  id: 'order-1',
+                  orderNumber: 'LM-1',
+                  status: 'paid',
+                  productId: 'product-1',
+                  stripePaymentIntentId: 'pi_1',
+                  rfqId: null,
+                  rfqResponseId: null,
+                  buyerId: 'buyer-1',
+                },
+              },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'products') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { id: 'product-1', listingContext: 'product' },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'notifications') {
+          return { insert: vi.fn().mockResolvedValue({ error: null }) };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+    vi.doMock('../_shared/orderTransitionGuards', () => ({
+      enforcePaymentBackedTransition: paymentGuard,
+    }));
+
+    const { handler } = await import('../update-shipment-status');
+    const res = await handler(
+      makeEvent(
+        'PUT',
+        '/.netlify/functions/shipments/shipment-1/status',
+        { status: 'Out for Delivery' },
+      ),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(paymentGuard).toHaveBeenCalledWith(expect.objectContaining({ nextStatus: 'shipped' }));
   });
 
   it('does not mint a new POD upload URL after canonical proof is attached', async () => {
@@ -295,6 +479,61 @@ describe('canonical shipment write boundary', () => {
 
     expect(res.statusCode).toBe(409);
     expect(createSignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('treats confirmation of the exact canonical POD path as an idempotent success', async () => {
+    const filePath = 'shipment-1/shipment-1-123.jpg';
+    const rpc = vi.fn();
+    const remove = vi.fn();
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      storage: { from: vi.fn(() => ({ remove })) },
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'shipments') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                id: 'shipment-1',
+                seller_id: 'seller-1',
+                buyer_id: 'buyer-1',
+                status: 'Delivered',
+                proof_of_delivery_url: filePath,
+              },
+              error: null,
+            }),
+          };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+
+    const { handler } = await import('../upload-proof-of-delivery');
+    const res = await handler(
+      makeEvent('PUT', '/.netlify/functions/shipments/shipment-1/proof', { filePath }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).attached).toBe(false);
+    expect(rpc).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
   });
 
   it('removes an uploaded POD object when the atomic DB attachment is rejected', async () => {
@@ -366,7 +605,7 @@ describe('canonical shipment write boundary', () => {
     expect(remove).toHaveBeenCalledWith([filePath]);
   });
 
-  it('keeps the DB migration service-role-only, atomic and one-shipment-per-order', () => {
+  it('keeps the DB migration service-role-only, atomic, idempotent and one-shipment-per-order', () => {
     const sql = readFileSync(
       new URL('../../../supabase/607_lock_shipment_writes_to_server.sql', import.meta.url),
       'utf8',
@@ -376,6 +615,9 @@ describe('canonical shipment write boundary', () => {
     expect(sql).toContain('CREATE OR REPLACE FUNCTION public.server_upsert_shipment');
     expect(sql).toContain('CREATE OR REPLACE FUNCTION public.server_transition_shipment');
     expect(sql).toContain('CREATE OR REPLACE FUNCTION public.server_attach_shipment_proof');
+    expect(sql).toContain("ARRAY['Dispatched', 'In Transit', 'Out for Delivery']");
+    expect(sql).toContain("'changed', false");
+    expect(sql).toContain("'attached', false");
     expect(sql).toContain('GRANT EXECUTE ON FUNCTION public.server_upsert_shipment');
     expect(sql).toContain('TO service_role;');
     expect(sql).toContain('FROM PUBLIC, anon, authenticated;');

--- a/netlify/functions/__tests__/shipment-boundary.test.ts
+++ b/netlify/functions/__tests__/shipment-boundary.test.ts
@@ -1,0 +1,385 @@
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HandlerEvent } from '@netlify/functions';
+
+function makeEvent(
+  httpMethod: string,
+  path: string,
+  body: unknown,
+  authorization = 'Bearer valid-token',
+): HandlerEvent {
+  return {
+    httpMethod,
+    body: body === undefined ? null : JSON.stringify(body),
+    headers: { authorization },
+    multiValueHeaders: {},
+    isBase64Encoded: false,
+    path,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    rawQuery: '',
+    rawUrl: `http://localhost${path}`,
+  };
+}
+
+describe('canonical shipment write boundary', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+    process.env.URL = 'https://test.example';
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  function installSharedMocks() {
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+    vi.doMock('../_shared/orderTransitionGuards', () => ({
+      enforcePaymentBackedTransition: vi.fn().mockResolvedValue({
+        ok: true,
+        statusCode: 200,
+        hasValidPaymentEvidence: true,
+        paymentEvidenceSource: 'order.stripePaymentIntentId',
+        requiresPaymentEvidence: true,
+        allowedNonStripeFlow: null,
+      }),
+    }));
+  }
+
+  it('rejects fulfilment-time attempts to rewrite paid shipping terms', async () => {
+    const rpc = vi.fn();
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      from: vi.fn((table: string) => {
+        if (table !== 'users') throw new Error(`Unexpected table before rejection: ${table}`);
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+        };
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    installSharedMocks();
+
+    const { handler } = await import('../create-shipment');
+    const res = await handler(
+      makeEvent('POST', '/.netlify/functions/create-shipment', {
+        order_id: 'order-1',
+        shipping_cost: 999,
+      }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).error).toContain('fixed at checkout');
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('routes shipment create/update through the atomic server RPC', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: { shipment: { id: 'shipment-1', order_id: 'order-1' }, created: true },
+      error: null,
+    });
+
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'orders') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'order-1',
+                orderNumber: 'LM-1',
+                status: 'paid',
+                productId: 'product-1',
+                sellerId: 'seller-1',
+                buyerId: 'buyer-1',
+                stripePaymentIntentId: 'pi_1',
+                rfqId: null,
+                rfqResponseId: null,
+                escrowStatus: 'held',
+              },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'products') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { id: 'product-1', listingContext: 'product' },
+              error: null,
+            }),
+          };
+        }
+        throw new Error(`Direct shipment table mutation is not allowed in this handler: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    installSharedMocks();
+
+    const { handler } = await import('../create-shipment');
+    const res = await handler(
+      makeEvent('POST', '/.netlify/functions/create-shipment', {
+        order_id: 'order-1',
+        courier_name: 'Carrier',
+        tracking_number: 'TRACK-1',
+      }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(rpc).toHaveBeenCalledWith('server_upsert_shipment', {
+      p_order_id: 'order-1',
+      p_actor_id: 'seller-1',
+      p_courier_name: 'Carrier',
+      p_set_courier_name: true,
+      p_tracking_number: 'TRACK-1',
+      p_set_tracking_number: true,
+      p_dispatched_at: null,
+      p_set_dispatched_at: false,
+    });
+  });
+
+  it('routes shipment status + audit + order mapping through one atomic RPC', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: { shipment: { id: 'shipment-1', status: 'Processing' } },
+      error: null,
+    });
+
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'shipments') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'shipment-1',
+                order_id: 'order-1',
+                seller_id: 'seller-1',
+                buyer_id: 'buyer-1',
+                orders: {
+                  id: 'order-1',
+                  orderNumber: 'LM-1',
+                  status: 'paid',
+                  productId: 'product-1',
+                  stripePaymentIntentId: 'pi_1',
+                  rfqId: null,
+                  rfqResponseId: null,
+                  buyerId: 'buyer-1',
+                },
+              },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'notifications') {
+          return { insert: vi.fn().mockResolvedValue({ error: null }) };
+        }
+        throw new Error(`Unexpected direct table access after transition: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    installSharedMocks();
+
+    const { handler } = await import('../update-shipment-status');
+    const res = await handler(
+      makeEvent(
+        'PUT',
+        '/.netlify/functions/shipments/shipment-1/status',
+        { status: 'Processing', message: 'Packing complete' },
+      ),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(rpc).toHaveBeenCalledWith('server_transition_shipment', {
+      p_shipment_id: 'shipment-1',
+      p_actor_id: 'seller-1',
+      p_status: 'Processing',
+      p_message: 'Packing complete',
+    });
+  });
+
+  it('does not mint a new POD upload URL after canonical proof is attached', async () => {
+    const createSignedUploadUrl = vi.fn();
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc: vi.fn(),
+      storage: {
+        from: vi.fn(() => ({ createSignedUploadUrl })),
+      },
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'shipments') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                id: 'shipment-1',
+                seller_id: 'seller-1',
+                buyer_id: 'buyer-1',
+                status: 'Delivered',
+                proof_of_delivery_url: 'shipment-1/shipment-1-1.jpg',
+              },
+              error: null,
+            }),
+          };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+
+    const { handler } = await import('../upload-proof-of-delivery');
+    const res = await handler(
+      makeEvent(
+        'POST',
+        '/.netlify/functions/shipments/shipment-1/proof',
+        { contentType: 'image/jpeg', fileSize: 100 },
+      ),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(409);
+    expect(createSignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('removes an uploaded POD object when the atomic DB attachment is rejected', async () => {
+    const remove = vi.fn().mockResolvedValue({ error: null });
+    const filePath = 'shipment-1/shipment-1-123.jpg';
+    const rpc = vi.fn().mockResolvedValue({
+      data: null,
+      error: { code: 'P0001', message: 'proof is already attached' },
+    });
+    const storageApi = {
+      list: vi.fn().mockResolvedValue({
+        data: [{ name: 'shipment-1-123.jpg', metadata: { size: 100, mimetype: 'image/jpeg' } }],
+        error: null,
+      }),
+      download: vi.fn(),
+      remove,
+    };
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      storage: { from: vi.fn(() => storageApi) },
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'shipments') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                id: 'shipment-1',
+                seller_id: 'seller-1',
+                buyer_id: 'buyer-1',
+                status: 'Delivered',
+                proof_of_delivery_url: null,
+              },
+              error: null,
+            }),
+          };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+
+    const { handler } = await import('../upload-proof-of-delivery');
+    const res = await handler(
+      makeEvent('PUT', '/.netlify/functions/shipments/shipment-1/proof', { filePath }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(409);
+    expect(rpc).toHaveBeenCalledWith('server_attach_shipment_proof', {
+      p_shipment_id: 'shipment-1',
+      p_actor_id: 'seller-1',
+      p_file_path: filePath,
+    });
+    expect(remove).toHaveBeenCalledWith([filePath]);
+  });
+
+  it('keeps the DB migration service-role-only, atomic and one-shipment-per-order', () => {
+    const sql = readFileSync(
+      new URL('../../../supabase/607_lock_shipment_writes_to_server.sql', import.meta.url),
+      'utf8',
+    );
+
+    expect(sql).toContain('CREATE UNIQUE INDEX IF NOT EXISTS shipments_one_per_order');
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.server_upsert_shipment');
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.server_transition_shipment');
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.server_attach_shipment_proof');
+    expect(sql).toContain('GRANT EXECUTE ON FUNCTION public.server_upsert_shipment');
+    expect(sql).toContain('TO service_role;');
+    expect(sql).toContain('FROM PUBLIC, anon, authenticated;');
+    expect(sql).toContain('proof of delivery is already attached and cannot be overwritten');
+    expect(sql).toContain('REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER');
+  });
+});

--- a/netlify/functions/create-shipment.ts
+++ b/netlify/functions/create-shipment.ts
@@ -20,8 +20,10 @@ interface CreateShipmentRequest {
   courier_name?: string;
   tracking_number?: string;
   dispatched_at?: string | null;
-  shipping_method?: string;
-  shipping_cost?: number;
+  // Legacy fields are accepted only so the endpoint can reject attempts to
+  // mutate paid commercial terms explicitly instead of silently ignoring them.
+  shipping_method?: unknown;
+  shipping_cost?: unknown;
 }
 
 // Helper to get user from Authorization header
@@ -105,7 +107,7 @@ export const handler: Handler = async (event) => {
         body: JSON.stringify({ error: 'Invalid JSON in request body' }),
       };
     }
-    const { order_id, courier_name, tracking_number, dispatched_at, shipping_method, shipping_cost } = body;
+    const { order_id, courier_name, tracking_number, dispatched_at } = body;
 
     if (!order_id) {
       return {
@@ -114,10 +116,19 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    if (shipping_cost !== undefined && (!Number.isFinite(shipping_cost) || shipping_cost < 0)) {
+    // Shipping method/amount are commercial terms fixed by the verified checkout
+    // and Stripe payment evidence. Fulfilment must never rewrite them. Reject
+    // legacy/forged attempts explicitly so no caller can mistake the request for
+    // a successful commercial-term update.
+    if (
+      Object.prototype.hasOwnProperty.call(body, 'shipping_method') ||
+      Object.prototype.hasOwnProperty.call(body, 'shipping_cost')
+    ) {
       return {
-        statusCode: 400,
-        body: JSON.stringify({ error: 'shipping_cost must be a non-negative number' }),
+        statusCode: 409,
+        body: JSON.stringify({
+          error: 'Shipping method and amount are fixed at checkout and cannot be changed during fulfilment.',
+        }),
       };
     }
 
@@ -242,23 +253,6 @@ export const handler: Handler = async (event) => {
           message: dispatched_at ? `Shipment dispatched on ${new Date(dispatched_at).toLocaleDateString('en-GB')}` : 'Shipment created',
           changed_by: user.id,
         });
-    }
-
-    // The API payload keeps snake_case for backwards compatibility, but the
-    // canonical orders schema uses camelCase column names.
-    if (shipping_method || shipping_cost !== undefined) {
-      const updateData: { shippingMethod?: string; shippingAmount?: number } = {};
-      if (shipping_method) updateData.shippingMethod = shipping_method;
-      if (shipping_cost !== undefined) updateData.shippingAmount = shipping_cost;
-
-      const { error: orderShippingError } = await supabase
-        .from('orders')
-        .update(updateData)
-        .eq('id', order_id);
-
-      if (orderShippingError) {
-        throw new Error(`Failed to persist order shipping details: ${orderShippingError.message}`);
-      }
     }
 
     return {

--- a/netlify/functions/create-shipment.ts
+++ b/netlify/functions/create-shipment.ts
@@ -29,9 +29,9 @@ interface CreateShipmentRequest {
 type ShipmentMutationResult = {
   shipment?: Record<string, unknown>;
   created?: boolean;
+  changed?: boolean;
 };
 
-// Helper to get user from Authorization header
 async function getAuthUser(event: HandlerEvent) {
   const authHeader = event.headers.authorization || event.headers.Authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -45,7 +45,6 @@ async function getAuthUser(event: HandlerEvent) {
     return null;
   }
 
-  // Get user role
   const { data: userData } = await supabase
     .from('users')
     .select('*')
@@ -71,7 +70,6 @@ export const handler: Handler = async (event) => {
   }
 
   try {
-    // Authenticate user
     const user = await getAuthUser(event);
     if (!user) {
       return {
@@ -80,7 +78,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Only sellers and admins can create shipments
     if (user.role !== 'seller' && user.role !== 'admin') {
       return {
         statusCode: 403,
@@ -88,7 +85,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Rate-limit: 30 shipment creates/updates per user per 60-minute window.
     const shipRl = await checkRateLimit({
       supabase,
       tableName: 'create_shipment_rate_limits',
@@ -133,9 +129,7 @@ export const handler: Handler = async (event) => {
     }
 
     // Shipping method/amount are commercial terms fixed by the verified checkout
-    // and Stripe payment evidence. Fulfilment must never rewrite them. Reject
-    // legacy/forged attempts explicitly so no caller can mistake the request for
-    // a successful commercial-term update.
+    // and Stripe payment evidence. Fulfilment must never rewrite them.
     if (
       Object.prototype.hasOwnProperty.call(body, 'shipping_method') ||
       Object.prototype.hasOwnProperty.call(body, 'shipping_cost')
@@ -148,9 +142,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Verify the order exists and user is the seller (or admin).
-    // Shipment creation is an order-lifecycle operation: terminal/cancelled
-    // orders must never be turned back into fulfilment work.
     const { data: order, error: orderError } = await supabase
       .from('orders')
       .select('id, orderNumber, status, productId, sellerId, buyerId, stripePaymentIntentId, rfqId, rfqResponseId, escrowStatus')
@@ -164,7 +155,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Check authorization
     if (user.role !== 'admin' && order.sellerId !== user.id) {
       return {
         statusCode: 403,
@@ -172,7 +162,9 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    if (['cancelled', 'refunded', 'disputed', 'completed'].includes(order.status)) {
+    // Delivered is terminal for shipment-detail mutation. Return/POD flows have
+    // their own canonical boundaries and must not reopen tracking/details history.
+    if (['cancelled', 'refunded', 'disputed', 'delivered', 'completed'].includes(order.status)) {
       return {
         statusCode: 409,
         body: JSON.stringify({ error: `A shipment cannot be created or changed for an order in '${order.status}' status.` }),
@@ -192,9 +184,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // A physical order must have valid completed Stripe evidence before a
-    // shipment can be created at all. This closes the create-shipment bypass
-    // around the guarded status-update endpoint.
     const paymentGuard = await enforcePaymentBackedTransition({
       supabase,
       order,
@@ -210,8 +199,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // The database owns the atomic shipment + audit-event write. It rechecks
-    // actor ownership and derives buyer/seller IDs from the canonical order row.
     const { data: mutation, error: mutationError } = await supabase.rpc('server_upsert_shipment', {
       p_order_id: order_id,
       p_actor_id: user.id,
@@ -224,6 +211,15 @@ export const handler: Handler = async (event) => {
     });
 
     if (mutationError) {
+      if (mutationError.code === '42501') {
+        return { statusCode: 403, body: JSON.stringify({ error: 'Not authorized' }) };
+      }
+      if (mutationError.code === 'P0002') {
+        return { statusCode: 404, body: JSON.stringify({ error: 'Order not found' }) };
+      }
+      if (mutationError.code === 'P0001') {
+        return { statusCode: 409, body: JSON.stringify({ error: mutationError.message }) };
+      }
       throw new Error(`Atomic shipment mutation failed: ${mutationError.message}`);
     }
 
@@ -233,13 +229,19 @@ export const handler: Handler = async (event) => {
     }
 
     const isNew = result.created === true;
+    const changed = result.changed === true;
 
     return {
       statusCode: isNew ? 201 : 200,
       body: JSON.stringify({ 
         success: true, 
         shipment: result.shipment,
-        message: isNew ? 'Shipment created' : 'Shipment updated'
+        changed,
+        message: isNew
+          ? 'Shipment created'
+          : changed
+            ? 'Shipment updated'
+            : 'Shipment already matches the requested details'
       }),
     };
   } catch (error) {

--- a/netlify/functions/create-shipment.ts
+++ b/netlify/functions/create-shipment.ts
@@ -26,6 +26,11 @@ interface CreateShipmentRequest {
   shipping_cost?: unknown;
 }
 
+type ShipmentMutationResult = {
+  shipment?: Record<string, unknown>;
+  created?: boolean;
+};
+
 // Helper to get user from Authorization header
 async function getAuthUser(event: HandlerEvent) {
   const authHeader = event.headers.authorization || event.headers.Authorization;
@@ -116,6 +121,17 @@ export const handler: Handler = async (event) => {
       };
     }
 
+    if (
+      Object.prototype.hasOwnProperty.call(body, 'dispatched_at') &&
+      dispatched_at !== null &&
+      (typeof dispatched_at !== 'string' || Number.isNaN(Date.parse(dispatched_at)))
+    ) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'dispatched_at must be a valid timestamp or null' }),
+      };
+    }
+
     // Shipping method/amount are commercial terms fixed by the verified checkout
     // and Stripe payment evidence. Fulfilment must never rewrite them. Reject
     // legacy/forged attempts explicitly so no caller can mistake the request for
@@ -194,72 +210,35 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Check if shipment already exists for this order
-    const { data: existingShipment } = await supabase
-      .from('shipments')
-      .select('*')
-      .eq('order_id', order_id)
-      .single();
+    // The database owns the atomic shipment + audit-event write. It rechecks
+    // actor ownership and derives buyer/seller IDs from the canonical order row.
+    const { data: mutation, error: mutationError } = await supabase.rpc('server_upsert_shipment', {
+      p_order_id: order_id,
+      p_actor_id: user.id,
+      p_courier_name: typeof courier_name === 'string' ? courier_name : null,
+      p_set_courier_name: Object.prototype.hasOwnProperty.call(body, 'courier_name'),
+      p_tracking_number: typeof tracking_number === 'string' ? tracking_number : null,
+      p_set_tracking_number: Object.prototype.hasOwnProperty.call(body, 'tracking_number'),
+      p_dispatched_at: dispatched_at ?? null,
+      p_set_dispatched_at: Object.prototype.hasOwnProperty.call(body, 'dispatched_at'),
+    });
 
-    let shipment;
-    let isNew = false;
-
-    if (existingShipment) {
-      // Update existing shipment
-      const { data, error } = await supabase
-        .from('shipments')
-        .update({
-          courier_name,
-          tracking_number,
-          ...(dispatched_at !== undefined ? { dispatched_at } : {}),
-          updated_at: new Date().toISOString(),
-        })
-        .eq('id', existingShipment.id)
-        .select()
-        .single();
-
-      if (error) {
-        throw error;
-      }
-      shipment = data;
-    } else {
-      // Create new shipment
-      const { data, error } = await supabase
-        .from('shipments')
-        .insert({
-          order_id,
-          seller_id: order.sellerId,
-          buyer_id: order.buyerId,
-          courier_name,
-          tracking_number,
-          dispatched_at: dispatched_at || null,
-          status: dispatched_at ? 'Dispatched' : 'Pending',
-        })
-        .select()
-        .single();
-
-      if (error) {
-        throw error;
-      }
-      shipment = data;
-      isNew = true;
-
-      // Create initial shipment event
-      await supabase
-        .from('shipment_events')
-        .insert({
-          shipment_id: shipment.id,
-          status: dispatched_at ? 'Dispatched' : 'Pending',
-          message: dispatched_at ? `Shipment dispatched on ${new Date(dispatched_at).toLocaleDateString('en-GB')}` : 'Shipment created',
-          changed_by: user.id,
-        });
+    if (mutationError) {
+      throw new Error(`Atomic shipment mutation failed: ${mutationError.message}`);
     }
+
+    const result = mutation as ShipmentMutationResult | null;
+    if (!result?.shipment) {
+      throw new Error('Atomic shipment mutation returned no shipment');
+    }
+
+    const isNew = result.created === true;
 
     return {
       statusCode: isNew ? 201 : 200,
       body: JSON.stringify({ 
         success: true, 
-        shipment,
+        shipment: result.shipment,
         message: isNew ? 'Shipment created' : 'Shipment updated'
       }),
     };

--- a/netlify/functions/update-shipment-status.ts
+++ b/netlify/functions/update-shipment-status.ts
@@ -20,6 +20,14 @@ interface UpdateStatusRequest {
   message?: string;
 }
 
+type ShipmentTransitionResult = {
+  shipment?: {
+    tracking_number?: string | null;
+    courier_name?: string | null;
+    [key: string]: unknown;
+  };
+};
+
 // Helper to get user from Authorization header
 async function getAuthUser(event: HandlerEvent) {
   const authHeader = event.headers.authorization || event.headers.Authorization;
@@ -192,7 +200,7 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Get shipment and verify authorization
+    // Get shipment and verify authorization before any mutation.
     const { data: shipment, error: shipmentError } = await supabase
       .from('shipments')
       .select('*, orders(*)')
@@ -206,7 +214,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Check authorization (seller or admin)
     if (user.role !== 'admin' && shipment.seller_id !== user.id) {
       return {
         statusCode: 403,
@@ -222,11 +229,11 @@ export const handler: Handler = async (event) => {
     }
 
     if (targetOrderStatus && shipment.orders?.id && shipment.orders?.productId) {
-        const { data: product } = await supabase
-          .from('products')
-          .select('id, listingContext')
-          .eq('id', shipment.orders.productId)
-          .maybeSingle<{ id: string; listingContext: 'product' | 'service' | null }>();
+      const { data: product } = await supabase
+        .from('products')
+        .select('id, listingContext')
+        .eq('id', shipment.orders.productId)
+        .maybeSingle<{ id: string; listingContext: 'product' | 'service' | null }>();
 
       const paymentGuard = await enforcePaymentBackedTransition({
         supabase,
@@ -255,50 +262,38 @@ export const handler: Handler = async (event) => {
       }
     }
 
-    // Update shipment status
-    const { data: updatedShipment, error: updateError } = await supabase
-      .from('shipments')
-      .update({
-        status,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', shipmentId)
-      .select()
-      .single();
+    // Commit shipment status, audit event and mapped order status atomically.
+    const { data: transition, error: transitionError } = await supabase.rpc('server_transition_shipment', {
+      p_shipment_id: shipmentId,
+      p_actor_id: user.id,
+      p_status: status,
+      p_message: typeof message === 'string' ? message : null,
+    });
 
-    if (updateError) {
-      throw updateError;
+    if (transitionError) {
+      if (transitionError.code === '42501') {
+        return { statusCode: 403, body: JSON.stringify({ error: 'Not authorized' }) };
+      }
+      if (transitionError.code === 'P0002') {
+        return { statusCode: 404, body: JSON.stringify({ error: 'Shipment or order not found' }) };
+      }
+      if (transitionError.code === '22023') {
+        return { statusCode: 400, body: JSON.stringify({ error: transitionError.message }) };
+      }
+      if (transitionError.code === 'P0001') {
+        return { statusCode: 409, body: JSON.stringify({ error: transitionError.message }) };
+      }
+      throw new Error(`Atomic shipment transition failed: ${transitionError.message}`);
     }
 
-    // Insert shipment event
-    await supabase
-      .from('shipment_events')
-      .insert({
-        shipment_id: shipmentId,
-        status,
-        message: message || `Status updated to ${status}`,
-        changed_by: user.id,
-      });
-
-    // Update order status if applicable
-    if (status === 'Delivered') {
-      await supabase
-        .from('orders')
-        .update({ 
-          status: 'delivered',
-          deliveredAt: new Date().toISOString()
-        })
-        .eq('id', shipment.order_id);
-    } else if (status === 'Dispatched' || status === 'In Transit') {
-      await supabase
-        .from('orders')
-        .update({ status: 'shipped' })
-        .eq('id', shipment.order_id);
+    const result = transition as ShipmentTransitionResult | null;
+    if (!result?.shipment) {
+      throw new Error('Atomic shipment transition returned no shipment');
     }
+    const updatedShipment = result.shipment;
 
-    // Create the buyer's in-app notification server-side. The seller cannot
-    // insert a notification for another user under the notifications RLS policy,
-    // so this belongs in the authenticated service-role transition handler.
+    // Create the buyer's in-app notification only after the canonical DB
+    // transition has committed. Notification failure remains non-fatal.
     const { error: notificationError } = await supabase
       .from('notifications')
       .insert({
@@ -312,7 +307,7 @@ export const handler: Handler = async (event) => {
       console.error('Failed to create shipment notification:', notificationError.message);
     }
 
-    // Send email notification for certain statuses
+    // Send email notification for certain statuses after canonical DB commit.
     await sendStatusEmail(shipment.orders, updatedShipment, status);
 
     return {

--- a/netlify/functions/update-shipment-status.ts
+++ b/netlify/functions/update-shipment-status.ts
@@ -26,6 +26,7 @@ type ShipmentTransitionResult = {
     courier_name?: string | null;
     [key: string]: unknown;
   };
+  changed?: boolean;
 };
 
 // Helper to get user from Authorization header
@@ -42,7 +43,6 @@ async function getAuthUser(event: HandlerEvent) {
     return null;
   }
 
-  // Get user role
   const { data: userData } = await supabase
     .from('users')
     .select('*')
@@ -52,8 +52,11 @@ async function getAuthUser(event: HandlerEvent) {
   return userData;
 }
 
-// Helper to send email notifications
-async function sendStatusEmail(order: { buyerId: string; orderNumber: string; id: string }, shipment: { tracking_number?: string | null; courier_name?: string | null }, status: string) {
+async function sendStatusEmail(
+  order: { buyerId: string; orderNumber: string; id: string },
+  shipment: { tracking_number?: string | null; courier_name?: string | null },
+  status: string,
+) {
   const emailTemplates: Record<string, { subject: string; template: string }> = {
     'Dispatched': {
       subject: 'Your order has been dispatched',
@@ -70,12 +73,9 @@ async function sendStatusEmail(order: { buyerId: string; orderNumber: string; id
   };
 
   const emailConfig = emailTemplates[status];
-  if (!emailConfig) {
-    return; // No email for this status
-  }
+  if (!emailConfig) return;
 
   try {
-    // Get buyer info
     const { data: buyer } = await supabase
       .from('users')
       .select('email, firstName, lastName')
@@ -110,7 +110,7 @@ async function sendStatusEmail(order: { buyerId: string; orderNumber: string; id
     });
   } catch (error) {
     console.error('Failed to send email:', error);
-    // Don't fail the whole request if email fails
+    // Post-commit notification failure must not roll back canonical shipment state.
   }
 }
 
@@ -130,7 +130,6 @@ export const handler: Handler = async (event) => {
   }
 
   try {
-    // Authenticate user
     const user = await getAuthUser(event);
     if (!user) {
       return {
@@ -139,7 +138,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Only sellers and admins may update shipment status.
     if (user.role !== 'seller' && user.role !== 'admin') {
       return {
         statusCode: 403,
@@ -147,7 +145,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Rate-limit: 60 status updates per user per 60-minute window.
     const statusRl = await checkRateLimit({
       supabase,
       tableName: 'update_shipment_status_rate_limits',
@@ -162,9 +159,8 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Get shipment ID from path
     const pathParts = event.path.split('/');
-    const shipmentId = pathParts[pathParts.length - 2]; // .../shipments/:id/status
+    const shipmentId = pathParts[pathParts.length - 2];
 
     if (!shipmentId) {
       return {
@@ -191,7 +187,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Validate status
     const validStatuses = ['Pending', 'Processing', 'Dispatched', 'In Transit', 'Out for Delivery', 'Delivered', 'Returned', 'Delivery Failed'];
     if (!validStatuses.includes(status)) {
       return {
@@ -200,7 +195,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Get shipment and verify authorization before any mutation.
     const { data: shipment, error: shipmentError } = await supabase
       .from('shipments')
       .select('*, orders(*)')
@@ -224,7 +218,7 @@ export const handler: Handler = async (event) => {
     let targetOrderStatus: GuardedOrderStatus | null = null;
     if (status === 'Delivered') {
       targetOrderStatus = 'delivered';
-    } else if (status === 'Dispatched' || status === 'In Transit') {
+    } else if (status === 'Dispatched' || status === 'In Transit' || status === 'Out for Delivery') {
       targetOrderStatus = 'shipped';
     }
 
@@ -262,7 +256,6 @@ export const handler: Handler = async (event) => {
       }
     }
 
-    // Commit shipment status, audit event and mapped order status atomically.
     const { data: transition, error: transitionError } = await supabase.rpc('server_transition_shipment', {
       p_shipment_id: shipmentId,
       p_actor_id: user.id,
@@ -291,31 +284,34 @@ export const handler: Handler = async (event) => {
       throw new Error('Atomic shipment transition returned no shipment');
     }
     const updatedShipment = result.shipment;
+    const changed = result.changed === true;
 
-    // Create the buyer's in-app notification only after the canonical DB
-    // transition has committed. Notification failure remains non-fatal.
-    const { error: notificationError } = await supabase
-      .from('notifications')
-      .insert({
-        userId: shipment.buyer_id,
-        type: 'shipment',
-        title: 'Shipment update',
-        message: `Your order ${shipment.orders?.orderNumber ?? shipment.order_id} shipment status is now: ${status}.`,
-        link: '/buyer/orders',
-      });
-    if (notificationError) {
-      console.error('Failed to create shipment notification:', notificationError.message);
+    // Idempotent retries return success but must not duplicate user-facing side
+    // effects. Only a material canonical state change emits notification/email.
+    if (changed) {
+      const { error: notificationError } = await supabase
+        .from('notifications')
+        .insert({
+          userId: shipment.buyer_id,
+          type: 'shipment',
+          title: 'Shipment update',
+          message: `Your order ${shipment.orders?.orderNumber ?? shipment.order_id} shipment status is now: ${status}.`,
+          link: '/buyer/orders',
+        });
+      if (notificationError) {
+        console.error('Failed to create shipment notification:', notificationError.message);
+      }
+
+      await sendStatusEmail(shipment.orders, updatedShipment, status);
     }
-
-    // Send email notification for certain statuses after canonical DB commit.
-    await sendStatusEmail(shipment.orders, updatedShipment, status);
 
     return {
       statusCode: 200,
       body: JSON.stringify({ 
         success: true, 
         shipment: updatedShipment,
-        message: 'Status updated successfully'
+        changed,
+        message: changed ? 'Status updated successfully' : 'Shipment already has the requested status'
       }),
     };
   } catch (error) {

--- a/netlify/functions/upload-proof-of-delivery.ts
+++ b/netlify/functions/upload-proof-of-delivery.ts
@@ -157,6 +157,13 @@ export const handler: Handler = async (event) => {
       return { statusCode: 409, body: JSON.stringify({ error: 'Proof of delivery is already attached and cannot be replaced.' }) };
     }
 
+    // A proof-of-delivery object may only be created for an actual Delivered
+    // shipment. This prevents evidence from existing before the lifecycle event
+    // it is intended to prove.
+    if (shipment.status !== 'Delivered') {
+      return { statusCode: 409, body: JSON.stringify({ error: 'Proof of delivery can only be uploaded after the shipment is Delivered.' }) };
+    }
+
     let requestBody: { contentType?: string; fileSize?: number };
     try {
       requestBody = JSON.parse(event.body || '{}') as { contentType?: string; fileSize?: number };
@@ -201,10 +208,9 @@ export const handler: Handler = async (event) => {
       return { statusCode: 400, body: JSON.stringify({ error: 'Invalid upload path' }) };
     }
 
-    // Confirmation retries for the exact canonical object are safe and should
-    // return success without another DB event or storage mutation. A different
-    // object can never replace established evidence; remove that uncommitted
-    // object and reject the attempted overwrite.
+    // Confirmation retries for the exact canonical object are safe even if the
+    // shipment later entered a return/recovery state. A different object can
+    // never replace established evidence.
     if (shipment.proof_of_delivery_url) {
       if (shipment.proof_of_delivery_url === filePath) {
         return {
@@ -220,6 +226,14 @@ export const handler: Handler = async (event) => {
 
       await removeUncommittedProof(filePath);
       return { statusCode: 409, body: JSON.stringify({ error: 'Proof of delivery is already attached and cannot be replaced.' }) };
+    }
+
+    if (shipment.status !== 'Delivered') {
+      // A signed URL may have been minted while the shipment was Delivered and
+      // the state may have changed before confirmation. The object is not part of
+      // commercial history until DB attachment succeeds, so remove it.
+      await removeUncommittedProof(filePath);
+      return { statusCode: 409, body: JSON.stringify({ error: 'Proof of delivery can only be attached while the shipment is Delivered.' }) };
     }
 
     const fileName = filePath.split('/').pop() ?? '';

--- a/netlify/functions/upload-proof-of-delivery.ts
+++ b/netlify/functions/upload-proof-of-delivery.ts
@@ -31,6 +31,7 @@ const EXT_TO_MIME: Record<string, string> = {
 
 type AttachProofResult = {
   shipment?: Record<string, unknown>;
+  attached?: boolean;
 };
 
 function escapeRegex(value: string): string {
@@ -149,8 +150,9 @@ export const handler: Handler = async (event) => {
   }
 
   if (event.httpMethod === 'POST') {
-    // POD is commercial evidence. Once attached, do not even mint another signed
-    // upload URL. The DB RPC repeats this check under row lock for race safety.
+    // POD is commercial evidence. Once attached, do not mint another signed
+    // upload URL. PUT confirmation remains retry-safe for the already-canonical
+    // path, but POST cannot create replacement evidence.
     if (shipment.proof_of_delivery_url) {
       return { statusCode: 409, body: JSON.stringify({ error: 'Proof of delivery is already attached and cannot be replaced.' }) };
     }
@@ -187,10 +189,6 @@ export const handler: Handler = async (event) => {
   }
 
   if (event.httpMethod === 'PUT') {
-    if (shipment.proof_of_delivery_url) {
-      return { statusCode: 409, body: JSON.stringify({ error: 'Proof of delivery is already attached and cannot be replaced.' }) };
-    }
-
     let body: { filePath?: string };
     try {
       body = JSON.parse(event.body || '{}') as { filePath?: string };
@@ -201,6 +199,27 @@ export const handler: Handler = async (event) => {
     const filePath = body.filePath ?? '';
     if (!isSafeProofPath(shipmentId, filePath)) {
       return { statusCode: 400, body: JSON.stringify({ error: 'Invalid upload path' }) };
+    }
+
+    // Confirmation retries for the exact canonical object are safe and should
+    // return success without another DB event or storage mutation. A different
+    // object can never replace established evidence; remove that uncommitted
+    // object and reject the attempted overwrite.
+    if (shipment.proof_of_delivery_url) {
+      if (shipment.proof_of_delivery_url === filePath) {
+        return {
+          statusCode: 200,
+          body: JSON.stringify({
+            success: true,
+            shipment,
+            attached: false,
+            message: 'Proof of delivery is already attached',
+          }),
+        };
+      }
+
+      await removeUncommittedProof(filePath);
+      return { statusCode: 409, body: JSON.stringify({ error: 'Proof of delivery is already attached and cannot be replaced.' }) };
     }
 
     const fileName = filePath.split('/').pop() ?? '';
@@ -245,8 +264,8 @@ export const handler: Handler = async (event) => {
     }
 
     // Attach the validated object path and append its audit event in one DB
-    // transaction. If that commit fails, remove the newly-uploaded unreferenced
-    // object as compensation; commercial history in DB remains unchanged.
+    // transaction. If a different concurrent proof won the race, remove this
+    // newly-uploaded unreferenced object as compensation.
     const { data: attachResult, error: attachError } = await supabase.rpc('server_attach_shipment_proof', {
       p_shipment_id: shipmentId,
       p_actor_id: user.id,
@@ -282,7 +301,10 @@ export const handler: Handler = async (event) => {
       body: JSON.stringify({
         success: true,
         shipment: result.shipment,
-        message: 'Proof of delivery uploaded successfully',
+        attached: result.attached === true,
+        message: result.attached === true
+          ? 'Proof of delivery uploaded successfully'
+          : 'Proof of delivery is already attached',
       }),
     };
   }

--- a/netlify/functions/upload-proof-of-delivery.ts
+++ b/netlify/functions/upload-proof-of-delivery.ts
@@ -29,6 +29,10 @@ const EXT_TO_MIME: Record<string, string> = {
   pdf: 'application/pdf',
 };
 
+type AttachProofResult = {
+  shipment?: Record<string, unknown>;
+};
+
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -42,6 +46,13 @@ function isSafeProofPath(shipmentId: string, filePath: string): boolean {
 function expectedMime(filePath: string): string | null {
   const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
   return EXT_TO_MIME[ext] ?? null;
+}
+
+async function removeUncommittedProof(filePath: string): Promise<void> {
+  const { error } = await supabase.storage.from(BUCKET_NAME).remove([filePath]);
+  if (error) {
+    console.error('upload-proof-of-delivery: failed to remove uncommitted proof object:', error.message);
+  }
 }
 
 async function getAuthUser(event: HandlerEvent) {
@@ -138,6 +149,12 @@ export const handler: Handler = async (event) => {
   }
 
   if (event.httpMethod === 'POST') {
+    // POD is commercial evidence. Once attached, do not even mint another signed
+    // upload URL. The DB RPC repeats this check under row lock for race safety.
+    if (shipment.proof_of_delivery_url) {
+      return { statusCode: 409, body: JSON.stringify({ error: 'Proof of delivery is already attached and cannot be replaced.' }) };
+    }
+
     let requestBody: { contentType?: string; fileSize?: number };
     try {
       requestBody = JSON.parse(event.body || '{}') as { contentType?: string; fileSize?: number };
@@ -170,6 +187,10 @@ export const handler: Handler = async (event) => {
   }
 
   if (event.httpMethod === 'PUT') {
+    if (shipment.proof_of_delivery_url) {
+      return { statusCode: 409, body: JSON.stringify({ error: 'Proof of delivery is already attached and cannot be replaced.' }) };
+    }
+
     let body: { filePath?: string };
     try {
       body = JSON.parse(event.body || '{}') as { filePath?: string };
@@ -219,31 +240,50 @@ export const handler: Handler = async (event) => {
       !requiredMime ||
       normalizedActualMime !== requiredMime
     ) {
-      await supabase.storage.from(BUCKET_NAME).remove([filePath]).catch(() => undefined);
+      await removeUncommittedProof(filePath);
       return { statusCode: 400, body: JSON.stringify({ error: 'Uploaded proof file failed server validation' }) };
     }
 
-    const { data: updatedShipment, error: updateError } = await supabase
-      .from('shipments')
-      .update({
-        proof_of_delivery_url: filePath,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', shipmentId)
-      .select()
-      .single();
-    if (updateError) throw updateError;
-
-    await supabase.from('shipment_events').insert({
-      shipment_id: shipmentId,
-      status: shipment.status,
-      message: 'Proof of delivery uploaded',
-      changed_by: user.id,
+    // Attach the validated object path and append its audit event in one DB
+    // transaction. If that commit fails, remove the newly-uploaded unreferenced
+    // object as compensation; commercial history in DB remains unchanged.
+    const { data: attachResult, error: attachError } = await supabase.rpc('server_attach_shipment_proof', {
+      p_shipment_id: shipmentId,
+      p_actor_id: user.id,
+      p_file_path: filePath,
     });
+
+    if (attachError) {
+      await removeUncommittedProof(filePath);
+      if (attachError.code === '42501') {
+        return { statusCode: 403, body: JSON.stringify({ error: 'Not authorized' }) };
+      }
+      if (attachError.code === 'P0002') {
+        return { statusCode: 404, body: JSON.stringify({ error: 'Shipment not found' }) };
+      }
+      if (attachError.code === '22023') {
+        return { statusCode: 400, body: JSON.stringify({ error: attachError.message }) };
+      }
+      if (attachError.code === 'P0001') {
+        return { statusCode: 409, body: JSON.stringify({ error: attachError.message }) };
+      }
+      throw new Error(`Atomic proof attachment failed: ${attachError.message}`);
+    }
+
+    const result = attachResult as AttachProofResult | null;
+    if (!result?.shipment) {
+      // DB commit succeeded but the contract response is invalid. Do NOT delete
+      // the object now because it may already be the canonical referenced proof.
+      throw new Error('Atomic proof attachment returned no shipment');
+    }
 
     return {
       statusCode: 200,
-      body: JSON.stringify({ success: true, shipment: updatedShipment, message: 'Proof of delivery uploaded successfully' }),
+      body: JSON.stringify({
+        success: true,
+        shipment: result.shipment,
+        message: 'Proof of delivery uploaded successfully',
+      }),
     };
   }
 

--- a/supabase/607_lock_shipment_writes_to_server.sql
+++ b/supabase/607_lock_shipment_writes_to_server.sql
@@ -8,24 +8,68 @@
 --     rate limits, notifications or append-safe shipment events;
 --   * one customer order has at most one canonical shipment record in this model;
 --   * shipment/order status changes and their audit event are committed atomically;
+--   * identical retries are idempotent and do not duplicate lifecycle events;
 --   * proof-of-delivery evidence is immutable once attached by this canonical path.
 
 ALTER TABLE public.shipments ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.shipment_events ENABLE ROW LEVEL SECURITY;
 
--- The application has always treated order_id as singular (.single()). Enforce
--- that assumption in the database so concurrent requests cannot create two
--- shipment truths for one customer order.
+-- The application treats order_id as singular. Do not auto-reconcile duplicate
+-- shipment records: if an environment already contains duplicates, index creation
+-- must fail so the commercial history can be investigated rather than discarded.
 CREATE UNIQUE INDEX IF NOT EXISTS shipments_one_per_order
   ON public.shipments (order_id);
+
+DO $$
+DECLARE
+  v_is_unique boolean;
+  v_is_valid boolean;
+  v_key_definition text;
+BEGIN
+  SELECT
+    i.indisunique,
+    i.indisvalid,
+    pg_get_indexdef(i.indexrelid, 1, true)
+  INTO
+    v_is_unique,
+    v_is_valid,
+    v_key_definition
+  FROM pg_index i
+  JOIN pg_class idx ON idx.oid = i.indexrelid
+  JOIN pg_class tbl ON tbl.oid = i.indrelid
+  JOIN pg_namespace ns ON ns.oid = tbl.relnamespace
+  WHERE ns.nspname = 'public'
+    AND tbl.relname = 'shipments'
+    AND idx.relname = 'shipments_one_per_order'
+    AND i.indnkeyatts = 1;
+
+  IF NOT FOUND
+     OR NOT COALESCE(v_is_unique, false)
+     OR NOT COALESCE(v_is_valid, false)
+     OR v_key_definition IS DISTINCT FROM 'order_id'
+  THEN
+    RAISE EXCEPTION 'shipments_one_per_order is missing or has an unexpected definition';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM public.shipments
+     GROUP BY order_id
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION 'duplicate shipment rows remain for one or more orders';
+  END IF;
+END;
+$$;
 
 COMMENT ON INDEX public.shipments_one_per_order IS
   'Canonical shipment invariant: one shipment row per customer order.';
 
 -- ---------------------------------------------------------------------------
--- Atomic server mutation: create/update shipment details + append audit event.
--- Auth/payment/rate-limit checks remain at the Netlify boundary; this function
--- independently rechecks actor ownership and derives seller/buyer from orders.
+-- Atomic + idempotent server mutation: create/update shipment details, keep the
+-- order shipping state coherent, and append an audit event only when something
+-- materially changed. Auth/payment/rate-limit checks remain at Netlify; this RPC
+-- independently rechecks actor role/ownership and derives seller/buyer from order.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.server_upsert_shipment(
   p_order_id uuid,
@@ -49,12 +93,19 @@ DECLARE
   v_order_status text;
   v_shipment public.shipments%ROWTYPE;
   v_created boolean := false;
+  v_changed boolean := false;
+  v_target_status text;
   v_event_message text;
 BEGIN
   SELECT u.role
     INTO v_actor_role
     FROM public.users u
    WHERE u.id = p_actor_id;
+
+  IF v_actor_role IS NULL OR NOT (v_actor_role = ANY (ARRAY['seller', 'admin'])) THEN
+    RAISE EXCEPTION 'server_upsert_shipment: seller or admin actor required'
+      USING ERRCODE = '42501';
+  END IF;
 
   SELECT o."sellerId", o."buyerId", o.status
     INTO v_order_seller, v_order_buyer, v_order_status
@@ -67,13 +118,12 @@ BEGIN
       USING ERRCODE = 'P0002';
   END IF;
 
-  IF v_actor_role IS DISTINCT FROM 'admin'
-     AND v_order_seller IS DISTINCT FROM p_actor_id THEN
+  IF v_actor_role <> 'admin' AND v_order_seller IS DISTINCT FROM p_actor_id THEN
     RAISE EXCEPTION 'server_upsert_shipment: actor is not authorized for this order'
       USING ERRCODE = '42501';
   END IF;
 
-  IF v_order_status = ANY (ARRAY['cancelled', 'refunded', 'disputed', 'completed']) THEN
+  IF v_order_status = ANY (ARRAY['cancelled', 'refunded', 'disputed', 'delivered', 'completed']) THEN
     RAISE EXCEPTION 'server_upsert_shipment: terminal order cannot be mutated'
       USING ERRCODE = 'P0001';
   END IF;
@@ -85,24 +135,44 @@ BEGIN
    FOR UPDATE;
 
   IF FOUND THEN
-    UPDATE public.shipments s
-       SET courier_name = CASE
-             WHEN p_set_courier_name THEN p_courier_name
-             ELSE s.courier_name
-           END,
-           tracking_number = CASE
-             WHEN p_set_tracking_number THEN p_tracking_number
-             ELSE s.tracking_number
-           END,
-           dispatched_at = CASE
-             WHEN p_set_dispatched_at THEN p_dispatched_at
-             ELSE s.dispatched_at
-           END,
-           updated_at = now()
-     WHERE s.id = v_shipment.id
-     RETURNING s.* INTO v_shipment;
+    v_target_status := v_shipment.status;
+    IF p_set_dispatched_at
+       AND p_dispatched_at IS NOT NULL
+       AND v_shipment.status = ANY (ARRAY['Pending', 'Processing'])
+    THEN
+      v_target_status := 'Dispatched';
+    END IF;
 
-    v_event_message := 'Shipment details updated';
+    v_changed :=
+      (p_set_courier_name AND v_shipment.courier_name IS DISTINCT FROM p_courier_name)
+      OR (p_set_tracking_number AND v_shipment.tracking_number IS DISTINCT FROM p_tracking_number)
+      OR (p_set_dispatched_at AND v_shipment.dispatched_at IS DISTINCT FROM p_dispatched_at)
+      OR v_shipment.status IS DISTINCT FROM v_target_status;
+
+    IF v_changed THEN
+      UPDATE public.shipments s
+         SET courier_name = CASE
+               WHEN p_set_courier_name THEN p_courier_name
+               ELSE s.courier_name
+             END,
+             tracking_number = CASE
+               WHEN p_set_tracking_number THEN p_tracking_number
+               ELSE s.tracking_number
+             END,
+             dispatched_at = CASE
+               WHEN p_set_dispatched_at THEN p_dispatched_at
+               ELSE s.dispatched_at
+             END,
+             status = v_target_status,
+             updated_at = now()
+       WHERE s.id = v_shipment.id
+       RETURNING s.* INTO v_shipment;
+
+      v_event_message := CASE
+        WHEN v_shipment.status = 'Dispatched' THEN 'Shipment details updated and dispatched'
+        ELSE 'Shipment details updated'
+      END;
+    END IF;
   ELSE
     INSERT INTO public.shipments (
       order_id,
@@ -127,29 +197,50 @@ BEGIN
     RETURNING * INTO v_shipment;
 
     v_created := true;
+    v_changed := true;
     v_event_message := CASE
       WHEN v_shipment.status = 'Dispatched' THEN 'Shipment created and dispatched'
       ELSE 'Shipment created'
     END;
   END IF;
 
-  INSERT INTO public.shipment_events (
-    shipment_id,
-    status,
-    message,
-    changed_by,
-    source
-  ) VALUES (
-    v_shipment.id,
-    v_shipment.status,
-    v_event_message,
-    p_actor_id,
-    'system'
-  );
+  -- A dispatched/in-transit/out-for-delivery shipment implies the customer order
+  -- is shipped. Repairing an otherwise stale mapped order state is itself a
+  -- material change and receives one audit event.
+  IF v_shipment.status = ANY (ARRAY['Dispatched', 'In Transit', 'Out for Delivery'])
+     AND v_order_status IS DISTINCT FROM 'shipped'
+  THEN
+    UPDATE public.orders o
+       SET status = 'shipped',
+           "updatedAt" = now()
+     WHERE o.id = p_order_id;
+
+    IF NOT v_changed THEN
+      v_changed := true;
+      v_event_message := 'Shipment/order state reconciled';
+    END IF;
+  END IF;
+
+  IF v_changed THEN
+    INSERT INTO public.shipment_events (
+      shipment_id,
+      status,
+      message,
+      changed_by,
+      source
+    ) VALUES (
+      v_shipment.id,
+      v_shipment.status,
+      v_event_message,
+      p_actor_id,
+      'system'
+    );
+  END IF;
 
   RETURN jsonb_build_object(
     'shipment', to_jsonb(v_shipment),
-    'created', v_created
+    'created', v_created,
+    'changed', v_changed
   );
 END;
 $$;
@@ -162,9 +253,9 @@ GRANT EXECUTE ON FUNCTION public.server_upsert_shipment(
 ) TO service_role;
 
 -- ---------------------------------------------------------------------------
--- Atomic server mutation: shipment status + audit event + mapped order status.
--- External side effects (notifications/email) happen only after this transaction
--- succeeds, so they cannot make partial database state look successful.
+-- Atomic + idempotent server mutation: shipment status + audit event + mapped
+-- order status. Identical retries return success without duplicate history or
+-- duplicate notification side effects (the caller receives changed=false).
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.server_transition_shipment(
   p_shipment_id uuid,
@@ -182,6 +273,10 @@ DECLARE
   v_order_id uuid;
   v_order_status text;
   v_shipment public.shipments%ROWTYPE;
+  v_shipment_changed boolean := false;
+  v_order_changed boolean := false;
+  v_changed boolean := false;
+  v_event_message text;
 BEGIN
   IF p_status IS NULL OR NOT (
     p_status = ANY (ARRAY[
@@ -209,8 +304,7 @@ BEGIN
       USING ERRCODE = 'P0002';
   END IF;
 
-  -- Lock the order first so every canonical shipment mutation uses the same
-  -- lock order and concurrent create/update/transition requests serialize.
+  -- All canonical shipment/order mutations lock order before shipment.
   SELECT o.status
     INTO v_order_status
     FROM public.orders o
@@ -239,8 +333,12 @@ BEGIN
     FROM public.users u
    WHERE u.id = p_actor_id;
 
-  IF v_actor_role IS DISTINCT FROM 'admin'
-     AND v_shipment.seller_id IS DISTINCT FROM p_actor_id THEN
+  IF v_actor_role IS NULL OR NOT (v_actor_role = ANY (ARRAY['seller', 'admin'])) THEN
+    RAISE EXCEPTION 'server_transition_shipment: seller or admin actor required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_actor_role <> 'admin' AND v_shipment.seller_id IS DISTINCT FROM p_actor_id THEN
     RAISE EXCEPTION 'server_transition_shipment: actor is not authorized'
       USING ERRCODE = '42501';
   END IF;
@@ -263,11 +361,50 @@ BEGIN
       USING ERRCODE = 'P0001';
   END IF;
 
-  UPDATE public.shipments s
-     SET status = p_status,
-         updated_at = now()
-   WHERE s.id = p_shipment_id
-   RETURNING s.* INTO v_shipment;
+  v_shipment_changed := v_shipment.status IS DISTINCT FROM p_status;
+  v_order_changed :=
+    (p_status = 'Delivered' AND v_order_status IS DISTINCT FROM 'delivered')
+    OR (
+      p_status = ANY (ARRAY['Dispatched', 'In Transit', 'Out for Delivery'])
+      AND v_order_status IS DISTINCT FROM 'shipped'
+    );
+  v_changed := v_shipment_changed OR v_order_changed;
+
+  IF NOT v_changed THEN
+    RETURN jsonb_build_object(
+      'shipment', to_jsonb(v_shipment),
+      'changed', false
+    );
+  END IF;
+
+  IF v_shipment_changed THEN
+    UPDATE public.shipments s
+       SET status = p_status,
+           updated_at = now()
+     WHERE s.id = p_shipment_id
+     RETURNING s.* INTO v_shipment;
+  END IF;
+
+  IF p_status = 'Delivered' AND v_order_status IS DISTINCT FROM 'delivered' THEN
+    UPDATE public.orders o
+       SET status = 'delivered',
+           "deliveredAt" = COALESCE(o."deliveredAt", now()),
+           "updatedAt" = now()
+     WHERE o.id = v_order_id;
+  ELSIF p_status = ANY (ARRAY['Dispatched', 'In Transit', 'Out for Delivery'])
+        AND v_order_status IS DISTINCT FROM 'shipped'
+  THEN
+    UPDATE public.orders o
+       SET status = 'shipped',
+           "updatedAt" = now()
+     WHERE o.id = v_order_id;
+  END IF;
+
+  v_event_message := CASE
+    WHEN v_shipment_changed
+      THEN COALESCE(NULLIF(BTRIM(p_message), ''), 'Status updated to ' || p_status)
+    ELSE 'Shipment/order state reconciled'
+  END;
 
   INSERT INTO public.shipment_events (
     shipment_id,
@@ -278,25 +415,15 @@ BEGIN
   ) VALUES (
     p_shipment_id,
     p_status,
-    COALESCE(NULLIF(BTRIM(p_message), ''), 'Status updated to ' || p_status),
+    v_event_message,
     p_actor_id,
     'system'
   );
 
-  IF p_status = 'Delivered' THEN
-    UPDATE public.orders o
-       SET status = 'delivered',
-           "deliveredAt" = COALESCE(o."deliveredAt", now()),
-           "updatedAt" = now()
-     WHERE o.id = v_order_id;
-  ELSIF p_status = ANY (ARRAY['Dispatched', 'In Transit']) THEN
-    UPDATE public.orders o
-       SET status = 'shipped',
-           "updatedAt" = now()
-     WHERE o.id = v_order_id;
-  END IF;
-
-  RETURN jsonb_build_object('shipment', to_jsonb(v_shipment));
+  RETURN jsonb_build_object(
+    'shipment', to_jsonb(v_shipment),
+    'changed', true
+  );
 END;
 $$;
 
@@ -307,7 +434,8 @@ GRANT EXECUTE ON FUNCTION public.server_transition_shipment(uuid, uuid, text, te
 
 -- ---------------------------------------------------------------------------
 -- Atomic server mutation: immutable POD pointer + append-only audit event.
--- Storage-object validation happens in Netlify before this RPC is invoked.
+-- A retry with the exact already-canonical path is idempotent; a different path
+-- cannot overwrite established evidence.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.server_attach_shipment_proof(
   p_shipment_id uuid,
@@ -344,13 +472,24 @@ BEGIN
     FROM public.users u
    WHERE u.id = p_actor_id;
 
-  IF v_actor_role IS DISTINCT FROM 'admin'
-     AND v_shipment.seller_id IS DISTINCT FROM p_actor_id THEN
+  IF v_actor_role IS NULL OR NOT (v_actor_role = ANY (ARRAY['seller', 'admin'])) THEN
+    RAISE EXCEPTION 'server_attach_shipment_proof: seller or admin actor required'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_actor_role <> 'admin' AND v_shipment.seller_id IS DISTINCT FROM p_actor_id THEN
     RAISE EXCEPTION 'server_attach_shipment_proof: actor is not authorized'
       USING ERRCODE = '42501';
   END IF;
 
   IF v_shipment.proof_of_delivery_url IS NOT NULL THEN
+    IF v_shipment.proof_of_delivery_url = p_file_path THEN
+      RETURN jsonb_build_object(
+        'shipment', to_jsonb(v_shipment),
+        'attached', false
+      );
+    END IF;
+
     RAISE EXCEPTION 'server_attach_shipment_proof: proof of delivery is already attached and cannot be overwritten'
       USING ERRCODE = 'P0001';
   END IF;
@@ -375,7 +514,10 @@ BEGIN
     'system'
   );
 
-  RETURN jsonb_build_object('shipment', to_jsonb(v_shipment));
+  RETURN jsonb_build_object(
+    'shipment', to_jsonb(v_shipment),
+    'attached', true
+  );
 END;
 $$;
 
@@ -419,8 +561,8 @@ COMMENT ON TABLE public.shipment_events IS
 COMMENT ON FUNCTION public.server_upsert_shipment(
   uuid, uuid, text, boolean, text, boolean, timestamptz, boolean
 ) IS
-  'Service-role-only atomic create/update of one shipment per order plus audit event; seller/buyer ownership is derived from the order.';
+  'Service-role-only idempotent shipment upsert; derives ownership from order, keeps dispatched order state coherent, and appends history only on change.';
 COMMENT ON FUNCTION public.server_transition_shipment(uuid, uuid, text, text) IS
-  'Service-role-only atomic shipment status transition, audit event and mapped order status update.';
+  'Service-role-only idempotent shipment status transition with atomic audit event and mapped order state.';
 COMMENT ON FUNCTION public.server_attach_shipment_proof(uuid, uuid, text) IS
-  'Service-role-only immutable proof-of-delivery attachment plus audit event.';
+  'Service-role-only immutable/idempotent proof-of-delivery attachment plus atomic audit event.';

--- a/supabase/607_lock_shipment_writes_to_server.sql
+++ b/supabase/607_lock_shipment_writes_to_server.sql
@@ -9,7 +9,8 @@
 --   * one customer order has at most one canonical shipment record in this model;
 --   * shipment/order status changes and their audit event are committed atomically;
 --   * identical retries are idempotent and do not duplicate lifecycle events;
---   * proof-of-delivery evidence is immutable once attached by this canonical path.
+--   * proof-of-delivery evidence is immutable and may first be attached only when
+--     the canonical shipment state is Delivered.
 
 ALTER TABLE public.shipments ENABLE ROW LEVEL SECURITY;
 ALTER TABLE public.shipment_events ENABLE ROW LEVEL SECURITY;
@@ -435,7 +436,7 @@ GRANT EXECUTE ON FUNCTION public.server_transition_shipment(uuid, uuid, text, te
 -- ---------------------------------------------------------------------------
 -- Atomic server mutation: immutable POD pointer + append-only audit event.
 -- A retry with the exact already-canonical path is idempotent; a different path
--- cannot overwrite established evidence.
+-- cannot overwrite established evidence. A first attachment requires Delivered.
 -- ---------------------------------------------------------------------------
 CREATE OR REPLACE FUNCTION public.server_attach_shipment_proof(
   p_shipment_id uuid,
@@ -491,6 +492,11 @@ BEGIN
     END IF;
 
     RAISE EXCEPTION 'server_attach_shipment_proof: proof of delivery is already attached and cannot be overwritten'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_shipment.status <> 'Delivered' THEN
+    RAISE EXCEPTION 'server_attach_shipment_proof: proof of delivery can only be attached after the shipment is Delivered'
       USING ERRCODE = 'P0001';
   END IF;
 
@@ -565,4 +571,4 @@ COMMENT ON FUNCTION public.server_upsert_shipment(
 COMMENT ON FUNCTION public.server_transition_shipment(uuid, uuid, text, text) IS
   'Service-role-only idempotent shipment status transition with atomic audit event and mapped order state.';
 COMMENT ON FUNCTION public.server_attach_shipment_proof(uuid, uuid, text) IS
-  'Service-role-only immutable/idempotent proof-of-delivery attachment plus atomic audit event.';
+  'Service-role-only immutable/idempotent proof-of-delivery attachment; first attachment requires Delivered and appends an atomic audit event.';

--- a/supabase/607_lock_shipment_writes_to_server.sql
+++ b/supabase/607_lock_shipment_writes_to_server.sql
@@ -1,14 +1,390 @@
 -- 607_lock_shipment_writes_to_server.sql
 --
 -- Canonical shipment contract:
---   * buyers/sellers/admin clients may read shipments only through RLS;
+--   * buyers/sellers/admin clients may read shipment state only through RLS;
 --   * shipment creation, mutation, POD confirmation and lifecycle transitions are
 --     server-managed through authenticated Netlify functions using service_role;
---   * direct client INSERT/UPDATE/DELETE must not bypass order ownership,
---     payment-backed transition guards, rate limits, notifications or audit events.
+--   * direct client writes must not bypass order ownership, payment-backed guards,
+--     rate limits, notifications or append-safe shipment events;
+--   * one customer order has at most one canonical shipment record in this model;
+--   * shipment/order status changes and their audit event are committed atomically;
+--   * proof-of-delivery evidence is immutable once attached by this canonical path.
 
 ALTER TABLE public.shipments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.shipment_events ENABLE ROW LEVEL SECURITY;
 
+-- The application has always treated order_id as singular (.single()). Enforce
+-- that assumption in the database so concurrent requests cannot create two
+-- shipment truths for one customer order.
+CREATE UNIQUE INDEX IF NOT EXISTS shipments_one_per_order
+  ON public.shipments (order_id);
+
+COMMENT ON INDEX public.shipments_one_per_order IS
+  'Canonical shipment invariant: one shipment row per customer order.';
+
+-- ---------------------------------------------------------------------------
+-- Atomic server mutation: create/update shipment details + append audit event.
+-- Auth/payment/rate-limit checks remain at the Netlify boundary; this function
+-- independently rechecks actor ownership and derives seller/buyer from orders.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.server_upsert_shipment(
+  p_order_id uuid,
+  p_actor_id uuid,
+  p_courier_name text,
+  p_set_courier_name boolean,
+  p_tracking_number text,
+  p_set_tracking_number boolean,
+  p_dispatched_at timestamptz,
+  p_set_dispatched_at boolean
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_actor_role text;
+  v_order_seller uuid;
+  v_order_buyer uuid;
+  v_order_status text;
+  v_shipment public.shipments%ROWTYPE;
+  v_created boolean := false;
+  v_event_message text;
+BEGIN
+  SELECT u.role
+    INTO v_actor_role
+    FROM public.users u
+   WHERE u.id = p_actor_id;
+
+  SELECT o."sellerId", o."buyerId", o.status
+    INTO v_order_seller, v_order_buyer, v_order_status
+    FROM public.orders o
+   WHERE o.id = p_order_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'server_upsert_shipment: order not found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_actor_role IS DISTINCT FROM 'admin'
+     AND v_order_seller IS DISTINCT FROM p_actor_id THEN
+    RAISE EXCEPTION 'server_upsert_shipment: actor is not authorized for this order'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_order_status = ANY (ARRAY['cancelled', 'refunded', 'disputed', 'completed']) THEN
+    RAISE EXCEPTION 'server_upsert_shipment: terminal order cannot be mutated'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  SELECT s.*
+    INTO v_shipment
+    FROM public.shipments s
+   WHERE s.order_id = p_order_id
+   FOR UPDATE;
+
+  IF FOUND THEN
+    UPDATE public.shipments s
+       SET courier_name = CASE
+             WHEN p_set_courier_name THEN p_courier_name
+             ELSE s.courier_name
+           END,
+           tracking_number = CASE
+             WHEN p_set_tracking_number THEN p_tracking_number
+             ELSE s.tracking_number
+           END,
+           dispatched_at = CASE
+             WHEN p_set_dispatched_at THEN p_dispatched_at
+             ELSE s.dispatched_at
+           END,
+           updated_at = now()
+     WHERE s.id = v_shipment.id
+     RETURNING s.* INTO v_shipment;
+
+    v_event_message := 'Shipment details updated';
+  ELSE
+    INSERT INTO public.shipments (
+      order_id,
+      seller_id,
+      buyer_id,
+      courier_name,
+      tracking_number,
+      dispatched_at,
+      status
+    ) VALUES (
+      p_order_id,
+      v_order_seller,
+      v_order_buyer,
+      CASE WHEN p_set_courier_name THEN p_courier_name ELSE NULL END,
+      CASE WHEN p_set_tracking_number THEN p_tracking_number ELSE NULL END,
+      CASE WHEN p_set_dispatched_at THEN p_dispatched_at ELSE NULL END,
+      CASE
+        WHEN p_set_dispatched_at AND p_dispatched_at IS NOT NULL THEN 'Dispatched'
+        ELSE 'Pending'
+      END
+    )
+    RETURNING * INTO v_shipment;
+
+    v_created := true;
+    v_event_message := CASE
+      WHEN v_shipment.status = 'Dispatched' THEN 'Shipment created and dispatched'
+      ELSE 'Shipment created'
+    END;
+  END IF;
+
+  INSERT INTO public.shipment_events (
+    shipment_id,
+    status,
+    message,
+    changed_by,
+    source
+  ) VALUES (
+    v_shipment.id,
+    v_shipment.status,
+    v_event_message,
+    p_actor_id,
+    'system'
+  );
+
+  RETURN jsonb_build_object(
+    'shipment', to_jsonb(v_shipment),
+    'created', v_created
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.server_upsert_shipment(
+  uuid, uuid, text, boolean, text, boolean, timestamptz, boolean
+) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_upsert_shipment(
+  uuid, uuid, text, boolean, text, boolean, timestamptz, boolean
+) TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- Atomic server mutation: shipment status + audit event + mapped order status.
+-- External side effects (notifications/email) happen only after this transaction
+-- succeeds, so they cannot make partial database state look successful.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.server_transition_shipment(
+  p_shipment_id uuid,
+  p_actor_id uuid,
+  p_status text,
+  p_message text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_actor_role text;
+  v_order_id uuid;
+  v_order_status text;
+  v_shipment public.shipments%ROWTYPE;
+BEGIN
+  IF p_status IS NULL OR NOT (
+    p_status = ANY (ARRAY[
+      'Pending',
+      'Processing',
+      'Dispatched',
+      'In Transit',
+      'Out for Delivery',
+      'Delivered',
+      'Returned',
+      'Delivery Failed'
+    ])
+  ) THEN
+    RAISE EXCEPTION 'server_transition_shipment: invalid shipment status'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT s.order_id
+    INTO v_order_id
+    FROM public.shipments s
+   WHERE s.id = p_shipment_id;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'server_transition_shipment: shipment not found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  -- Lock the order first so every canonical shipment mutation uses the same
+  -- lock order and concurrent create/update/transition requests serialize.
+  SELECT o.status
+    INTO v_order_status
+    FROM public.orders o
+   WHERE o.id = v_order_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'server_transition_shipment: order not found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT s.*
+    INTO v_shipment
+    FROM public.shipments s
+   WHERE s.id = p_shipment_id
+     AND s.order_id = v_order_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'server_transition_shipment: shipment changed during transition'
+      USING ERRCODE = '40001';
+  END IF;
+
+  SELECT u.role
+    INTO v_actor_role
+    FROM public.users u
+   WHERE u.id = p_actor_id;
+
+  IF v_actor_role IS DISTINCT FROM 'admin'
+     AND v_shipment.seller_id IS DISTINCT FROM p_actor_id THEN
+    RAISE EXCEPTION 'server_transition_shipment: actor is not authorized'
+      USING ERRCODE = '42501';
+  END IF;
+
+  -- Protect terminal customer-order truth from fulfilment regression. Returned
+  -- remains available after delivered/refunded because return/recovery is tracked
+  -- separately from the original successful delivery event.
+  IF v_order_status = ANY (ARRAY['cancelled', 'disputed', 'completed']) THEN
+    RAISE EXCEPTION 'server_transition_shipment: terminal order cannot be mutated'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_order_status = 'refunded' AND p_status <> 'Returned' THEN
+    RAISE EXCEPTION 'server_transition_shipment: refunded order may only move shipment to Returned'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_order_status = 'delivered' AND p_status <> ALL (ARRAY['Delivered', 'Returned']) THEN
+    RAISE EXCEPTION 'server_transition_shipment: delivered order cannot regress to a pre-delivery shipment state'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.shipments s
+     SET status = p_status,
+         updated_at = now()
+   WHERE s.id = p_shipment_id
+   RETURNING s.* INTO v_shipment;
+
+  INSERT INTO public.shipment_events (
+    shipment_id,
+    status,
+    message,
+    changed_by,
+    source
+  ) VALUES (
+    p_shipment_id,
+    p_status,
+    COALESCE(NULLIF(BTRIM(p_message), ''), 'Status updated to ' || p_status),
+    p_actor_id,
+    'system'
+  );
+
+  IF p_status = 'Delivered' THEN
+    UPDATE public.orders o
+       SET status = 'delivered',
+           "deliveredAt" = COALESCE(o."deliveredAt", now()),
+           "updatedAt" = now()
+     WHERE o.id = v_order_id;
+  ELSIF p_status = ANY (ARRAY['Dispatched', 'In Transit']) THEN
+    UPDATE public.orders o
+       SET status = 'shipped',
+           "updatedAt" = now()
+     WHERE o.id = v_order_id;
+  END IF;
+
+  RETURN jsonb_build_object('shipment', to_jsonb(v_shipment));
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.server_transition_shipment(uuid, uuid, text, text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_transition_shipment(uuid, uuid, text, text)
+  TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- Atomic server mutation: immutable POD pointer + append-only audit event.
+-- Storage-object validation happens in Netlify before this RPC is invoked.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.server_attach_shipment_proof(
+  p_shipment_id uuid,
+  p_actor_id uuid,
+  p_file_path text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_actor_role text;
+  v_shipment public.shipments%ROWTYPE;
+BEGIN
+  IF p_file_path IS NULL OR BTRIM(p_file_path) = '' THEN
+    RAISE EXCEPTION 'server_attach_shipment_proof: file path is required'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT s.*
+    INTO v_shipment
+    FROM public.shipments s
+   WHERE s.id = p_shipment_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'server_attach_shipment_proof: shipment not found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  SELECT u.role
+    INTO v_actor_role
+    FROM public.users u
+   WHERE u.id = p_actor_id;
+
+  IF v_actor_role IS DISTINCT FROM 'admin'
+     AND v_shipment.seller_id IS DISTINCT FROM p_actor_id THEN
+    RAISE EXCEPTION 'server_attach_shipment_proof: actor is not authorized'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_shipment.proof_of_delivery_url IS NOT NULL THEN
+    RAISE EXCEPTION 'server_attach_shipment_proof: proof of delivery is already attached and cannot be overwritten'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  UPDATE public.shipments s
+     SET proof_of_delivery_url = p_file_path,
+         updated_at = now()
+   WHERE s.id = p_shipment_id
+   RETURNING s.* INTO v_shipment;
+
+  INSERT INTO public.shipment_events (
+    shipment_id,
+    status,
+    message,
+    changed_by,
+    source
+  ) VALUES (
+    p_shipment_id,
+    v_shipment.status,
+    'Proof of delivery uploaded',
+    p_actor_id,
+    'system'
+  );
+
+  RETURN jsonb_build_object('shipment', to_jsonb(v_shipment));
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.server_attach_shipment_proof(uuid, uuid, text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_attach_shipment_proof(uuid, uuid, text)
+  TO service_role;
+
+-- Remove all client shipment mutation policies.
 DROP POLICY IF EXISTS "shipments_insert" ON public.shipments;
 DROP POLICY IF EXISTS "shipments_update" ON public.shipments;
 DROP POLICY IF EXISTS "shipments_delete" ON public.shipments;
@@ -16,17 +392,35 @@ DROP POLICY IF EXISTS "Sellers can insert shipments" ON public.shipments;
 DROP POLICY IF EXISTS "Sellers can update shipments" ON public.shipments;
 DROP POLICY IF EXISTS "Sellers can delete shipments" ON public.shipments;
 
--- Preserve the participant/admin SELECT contract exactly as-is. Remove the
--- underlying write privileges as defense in depth so an accidentally permissive
--- future RLS policy cannot silently reopen the bypass.
+-- Preserve participant/admin SELECT while removing every underlying write-like
+-- privilege that should never belong to browser/mobile roles.
 REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
   ON TABLE public.shipments FROM anon, authenticated;
-
 GRANT SELECT ON TABLE public.shipments TO authenticated;
 REVOKE SELECT ON TABLE public.shipments FROM anon;
 
--- Canonical server handlers operate with service_role and retain full access.
+-- Shipment events are append-only server history. Client roles already have no
+-- INSERT/UPDATE/DELETE policy; also revoke TRUNCATE/TRIGGER/REFERENCES so RLS
+-- cannot be bypassed by a non-row operation.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+  ON TABLE public.shipment_events FROM anon, authenticated;
+GRANT SELECT ON TABLE public.shipment_events TO authenticated;
+REVOKE SELECT ON TABLE public.shipment_events FROM anon;
+
+-- Canonical server handlers operate with service_role and retain required access.
 GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.shipments TO service_role;
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.shipment_events TO service_role;
 
 COMMENT ON TABLE public.shipments IS
-  'Shipment records. Client roles are read-only under participant/admin RLS; all writes are server-managed through canonical shipment functions.';
+  'Shipment records. Client roles are read-only under participant/admin RLS; canonical writes use service-role-only atomic shipment RPCs.';
+COMMENT ON TABLE public.shipment_events IS
+  'Append-only shipment lifecycle history. Client roles may read participant-visible rows; writes are canonical server operations only.';
+
+COMMENT ON FUNCTION public.server_upsert_shipment(
+  uuid, uuid, text, boolean, text, boolean, timestamptz, boolean
+) IS
+  'Service-role-only atomic create/update of one shipment per order plus audit event; seller/buyer ownership is derived from the order.';
+COMMENT ON FUNCTION public.server_transition_shipment(uuid, uuid, text, text) IS
+  'Service-role-only atomic shipment status transition, audit event and mapped order status update.';
+COMMENT ON FUNCTION public.server_attach_shipment_proof(uuid, uuid, text) IS
+  'Service-role-only immutable proof-of-delivery attachment plus audit event.';

--- a/supabase/607_lock_shipment_writes_to_server.sql
+++ b/supabase/607_lock_shipment_writes_to_server.sql
@@ -1,0 +1,32 @@
+-- 607_lock_shipment_writes_to_server.sql
+--
+-- Canonical shipment contract:
+--   * buyers/sellers/admin clients may read shipments only through RLS;
+--   * shipment creation, mutation, POD confirmation and lifecycle transitions are
+--     server-managed through authenticated Netlify functions using service_role;
+--   * direct client INSERT/UPDATE/DELETE must not bypass order ownership,
+--     payment-backed transition guards, rate limits, notifications or audit events.
+
+ALTER TABLE public.shipments ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "shipments_insert" ON public.shipments;
+DROP POLICY IF EXISTS "shipments_update" ON public.shipments;
+DROP POLICY IF EXISTS "shipments_delete" ON public.shipments;
+DROP POLICY IF EXISTS "Sellers can insert shipments" ON public.shipments;
+DROP POLICY IF EXISTS "Sellers can update shipments" ON public.shipments;
+DROP POLICY IF EXISTS "Sellers can delete shipments" ON public.shipments;
+
+-- Preserve the participant/admin SELECT contract exactly as-is. Remove the
+-- underlying write privileges as defense in depth so an accidentally permissive
+-- future RLS policy cannot silently reopen the bypass.
+REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER
+  ON TABLE public.shipments FROM anon, authenticated;
+
+GRANT SELECT ON TABLE public.shipments TO authenticated;
+REVOKE SELECT ON TABLE public.shipments FROM anon;
+
+-- Canonical server handlers operate with service_role and retain full access.
+GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.shipments TO service_role;
+
+COMMENT ON TABLE public.shipments IS
+  'Shipment records. Client roles are read-only under participant/admin RLS; all writes are server-managed through canonical shipment functions.';


### PR DESCRIPTION
## Checkpoint A P1 — canonical shipment write boundary

Live production audit confirms `shipments` still permits authenticated seller INSERT/UPDATE directly. That path can bypass ownership/payment guards, rate limits, lifecycle events, notifications and POD rules. The current live table has 0 shipment rows, so the missing invariants can be installed before real shipment history exists.

Deeper audit also found latent integrity holes in the server boundary itself: `create-shipment` could rewrite paid `orders.shippingMethod` / `orders.shippingAmount`; shipment status, order status and shipment events were independent writes whose errors could diverge; POD evidence could be overwritten and its audit event was non-atomic; and the DB did not enforce the application's one-shipment-per-order assumption.

## Canonical repair in this PR
- `create-shipment`: retains auth/ownership/rate-limit/payment guards, rejects any `shipping_method` / `shipping_cost` input with 409, validates dispatch timestamp and routes mutation to `server_upsert_shipment`;
- `update-shipment-status`: retains auth/payment guards and routes shipment status + audit event + mapped order status through `server_transition_shipment`; notifications/email remain post-commit non-fatal side effects;
- `upload-proof-of-delivery`: preserves private signed upload/read flow, makes POD immutable, validates uploaded object, attaches POD + audit event through `server_attach_shipment_proof`, and removes an uncommitted storage object if DB attachment fails;
- migration 607 enforces one shipment per order, creates the three service-role-only SECURITY DEFINER RPCs, closes direct client shipment writes, removes client TRUNCATE/TRIGGER/REFERENCES rights from shipment history, and preserves participant/admin SELECT;
- automated regression tests added in `shipment-boundary.test.ts` for immutable paid shipping terms, RPC-only writes, atomic status path, POD immutability/compensation, and migration contract.

## Live read-only evidence
- 0 shipment rows; no duplicate shipments per order;
- no shipment/order status divergence;
- no POD history requiring reconciliation;
- no existing order where `subtotal + vatAmount + shippingAmount` differs from `total`;
- `shipment_events` already has participant-scoped authenticated SELECT and no client INSERT/UPDATE/DELETE policy;
- direct `shipments_insert` / `shipments_update` policies and broad client table grants remain live until 607 is deliberately deployed.

## Branch Guard / gates
- base: `main` `b3cc07d182a60ca5d1ab80217c63b62e50015c1f`;
- current branch: 0 commits behind base;
- exact changed files: 5 — three canonical shipment handlers, migration 607, and one shipment-boundary test file;
- no UI / Workspace / checkout amount calculation / Stripe charge logic / Supplier Commerce changes;
- Netlify Deploy Preview on exact current HEAD: PASS;
- GitHub CI run `32276476774`: INFRA BLOCKED before steps (`steps=[]`, no log blob); therefore added unit tests are NOT RUN, not PASS or software FAIL.

## Sequence guard
This PR remains DRAFT. It MUST stay after independently verified #511 production runtime and controlled migration 606 reconciliation. Do not merge/deploy 607 before 606 PASS.

Status: REPO/BUILD PREPARED / TESTS PRESENT BUT CI INFRA BLOCKED / PRODUCTION UNCHANGED / SEQUENCED AFTER 606 / CHECKPOINT A NOT PASS.