### PR TITLE
Enforce active-account suspension across Auth and RLS

### DIFF
--- a/netlify/functions-modern/admin-user-status.ts
+++ b/netlify/functions-modern/admin-user-status.ts
@@ -1,0 +1,4 @@
+import { handler } from '../functions/admin-user-status';
+import { withLambda } from '../function-runtime/lambdaCompat';
+
+export default withLambda(handler);

--- a/netlify/functions-modern/deactivate-account.ts
+++ b/netlify/functions-modern/deactivate-account.ts
@@ -1,0 +1,4 @@
+import { handler } from '../functions/deactivate-account';
+import { withLambda } from '../function-runtime/lambdaCompat';
+
+export default withLambda(handler);

--- a/netlify/functions/__tests__/active-account-auth.test.ts
+++ b/netlify/functions/__tests__/active-account-auth.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { HandlerEvent } from '@netlify/functions';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from '../_shared/activeAccountAuth';
+
+function event(token?: string): HandlerEvent {
+  return {
+    httpMethod: 'POST',
+    body: '{}',
+    headers: token ? { authorization: `Bearer ${token}` } : {},
+    multiValueHeaders: {},
+    isBase64Encoded: false,
+    path: '/.netlify/functions/test',
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    rawQuery: '',
+    rawUrl: 'http://localhost/.netlify/functions/test',
+  };
+}
+
+function client(options: {
+  authUser?: { id: string; email?: string | null; app_metadata?: Record<string, unknown> } | null;
+  authError?: unknown;
+  account?: { id: string; role: string; isActive: boolean } | null;
+  accountError?: unknown;
+}) {
+  const maybeSingle = vi.fn().mockResolvedValue({
+    data: options.account ?? null,
+    error: options.accountError ?? null,
+  });
+  const from = vi.fn(() => ({
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle,
+  }));
+  const getUser = vi.fn().mockResolvedValue({
+    data: { user: options.authUser ?? null },
+    error: options.authError ?? null,
+  });
+
+  return {
+    api: { auth: { getUser }, from } as unknown as SupabaseClient,
+    getUser,
+    from,
+    maybeSingle,
+  };
+}
+
+describe('authenticateActiveAccount', () => {
+  it('rejects a request without a bearer token before auth or DB access', async () => {
+    const c = client({});
+    const result = await authenticateActiveAccount(event(), c.api);
+
+    expect(result).toEqual({ ok: false, status: 401 });
+    expect(c.getUser).not.toHaveBeenCalled();
+    expect(c.from).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid token before DB access', async () => {
+    const c = client({ authError: new Error('invalid') });
+    const result = await authenticateActiveAccount(event('bad-token'), c.api);
+
+    expect(result).toEqual({ ok: false, status: 401 });
+    expect(c.from).not.toHaveBeenCalled();
+  });
+
+  it('rejects a valid JWT when the live platform account row is missing', async () => {
+    const c = client({ authUser: { id: 'user-1', email: 'user@example.com' }, account: null });
+    const result = await authenticateActiveAccount(event('token'), c.api);
+
+    expect(result).toEqual({ ok: false, status: 403 });
+  });
+
+  it('rejects a valid stale JWT when the live platform account is suspended', async () => {
+    const c = client({
+      authUser: { id: 'user-1', email: 'user@example.com', app_metadata: { role: 'admin' } },
+      account: { id: 'user-1', role: 'admin', isActive: false },
+    });
+    const result = await authenticateActiveAccount(event('still-valid-token'), c.api, ['admin']);
+
+    expect(result).toEqual({ ok: false, status: 403 });
+  });
+
+  it('uses the live DB role rather than a stale JWT admin claim', async () => {
+    const c = client({
+      authUser: { id: 'user-1', email: 'user@example.com', app_metadata: { role: 'admin' } },
+      account: { id: 'user-1', role: 'buyer', isActive: true },
+    });
+    const result = await authenticateActiveAccount(event('token'), c.api, ['admin']);
+
+    expect(result).toEqual({ ok: false, status: 403 });
+  });
+
+  it('returns the live active actor when the role is allowed', async () => {
+    const c = client({
+      authUser: { id: 'seller-1', email: 'SELLER@EXAMPLE.COM', app_metadata: { role: 'seller', marker: 'kept' } },
+      account: { id: 'seller-1', role: 'seller', isActive: true },
+    });
+    const result = await authenticateActiveAccount(event('token'), c.api, ['seller']);
+
+    expect(result).toEqual({
+      ok: true,
+      actor: {
+        id: 'seller-1',
+        role: 'seller',
+        email: 'seller@example.com',
+        appMetadata: { role: 'seller', marker: 'kept' },
+      },
+    });
+  });
+});

--- a/netlify/functions/__tests__/admin-user-status-audit-compensation.test.ts
+++ b/netlify/functions/__tests__/admin-user-status-audit-compensation.test.ts
@@ -1,0 +1,105 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  applyAdminUserStatus,
+  LONG_BAN_DURATION,
+} from '../_shared/adminUserStatus';
+
+const ADMIN_ID = '11111111-1111-4111-8111-111111111111';
+const TARGET_ID = '22222222-2222-4222-8222-222222222222';
+
+describe('applyAdminUserStatus reactivation audit compensation', () => {
+  it('re-bans Auth and restores DB suspension when the privileged reactivation audit cannot persist', async () => {
+    const updateUserById = vi.fn().mockResolvedValue({ data: {}, error: null });
+    const rpc = vi.fn().mockResolvedValue({ data: false, error: null });
+    const userUpdates: Array<Record<string, unknown>> = [];
+    const sellerUpdates: Array<Record<string, unknown>> = [];
+    const auditInsert = vi.fn().mockResolvedValue({ error: { message: 'audit unavailable' } });
+
+    const from = vi.fn((table: string) => {
+      if (table === 'users') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { id: TARGET_ID, role: 'seller', isActive: false },
+                error: null,
+              }),
+            }),
+          }),
+          update: vi.fn((payload: Record<string, unknown>) => {
+            userUpdates.push(payload);
+            return { eq: vi.fn().mockResolvedValue({ error: null }) };
+          }),
+        };
+      }
+
+      if (table === 'seller_profiles') {
+        return {
+          select: vi.fn().mockReturnValue({
+            eq: vi.fn().mockReturnValue({
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: {
+                  userId: TARGET_ID,
+                  sellerStatus: 'suspended',
+                  storeName: 'Seller Store',
+                  businessName: null,
+                  contactPhone: '+441234567890',
+                  businessAddress: { postcode: 'BB1 1AA' },
+                  stripeConnectStatus: 'active',
+                  sellerType: 'individual',
+                  companyRegistrationNumber: null,
+                  vatNumber: null,
+                  isVatRegistered: false,
+                  requiresAdminApproval: false,
+                  isApproved: true,
+                },
+                error: null,
+              }),
+            }),
+          }),
+          update: vi.fn((payload: Record<string, unknown>) => {
+            sellerUpdates.push(payload);
+            return { eq: vi.fn().mockResolvedValue({ error: null }) };
+          }),
+        };
+      }
+
+      if (table === 'admin_actions') {
+        return { insert: auditInsert };
+      }
+
+      throw new Error(`Unexpected table ${table}`);
+    });
+
+    const supabase = {
+      auth: { admin: { updateUserById } },
+      rpc,
+      from,
+    } as unknown as SupabaseClient;
+
+    const result = await applyAdminUserStatus(
+      supabase,
+      ADMIN_ID,
+      'reactivate',
+      TARGET_ID,
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      status: 500,
+      body: {
+        error: 'Account reactivation failed safely and remains blocked because audit persistence failed',
+      },
+    });
+    expect(rpc).toHaveBeenCalledWith('is_active_user');
+    expect(updateUserById).toHaveBeenNthCalledWith(1, TARGET_ID, { ban_duration: 'none' });
+    expect(updateUserById).toHaveBeenNthCalledWith(2, TARGET_ID, { ban_duration: LONG_BAN_DURATION });
+    expect(userUpdates).toEqual([{ isActive: true }, { isActive: false }]);
+    expect(sellerUpdates).toEqual([
+      { sellerStatus: 'active' },
+      { sellerStatus: 'suspended' },
+    ]);
+    expect(auditInsert).toHaveBeenCalledOnce();
+  });
+});

--- a/netlify/functions/__tests__/admin-user-status.test.ts
+++ b/netlify/functions/__tests__/admin-user-status.test.ts
@@ -313,6 +313,24 @@ describe('admin-user-status', () => {
     expect(mocks.usersUpdate).not.toHaveBeenCalled();
   });
 
+  it('restores seller suspension and re-bans Auth when the users reactivation write fails', async () => {
+    const mocks = installSupabaseMock({
+      target: { id: TARGET_ID, role: 'seller', isActive: false },
+      userUpdateError: { message: 'users write failed' },
+    });
+    const { handler } = await import('../admin-user-status');
+
+    const res = await handler(makeEvent({ op: 'reactivate', userId: TARGET_ID }), {} as never);
+
+    expect(res.statusCode).toBe(500);
+    expect(mocks.sellerUpdate).toHaveBeenNthCalledWith(1, { sellerStatus: 'active' });
+    expect(mocks.usersUpdate).toHaveBeenCalledWith({ isActive: true });
+    expect(mocks.sellerUpdate).toHaveBeenNthCalledWith(2, { sellerStatus: 'suspended' });
+    expect(mocks.updateUserById).toHaveBeenNthCalledWith(1, TARGET_ID, { ban_duration: 'none' });
+    expect(mocks.updateUserById).toHaveBeenNthCalledWith(2, TARGET_ID, { ban_duration: '876000h' });
+    expect(mocks.auditInsert).not.toHaveBeenCalled();
+  });
+
   it('refuses to manage admin targets through the standard user-status endpoint', async () => {
     const mocks = installSupabaseMock({
       target: { id: TARGET_ID, role: 'admin', isActive: true },

--- a/netlify/functions/__tests__/admin-user-status.test.ts
+++ b/netlify/functions/__tests__/admin-user-status.test.ts
@@ -1,0 +1,233 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HandlerEvent } from '@netlify/functions';
+
+const ADMIN_ID = '11111111-1111-4111-8111-111111111111';
+const TARGET_ID = '22222222-2222-4222-8222-222222222222';
+
+function makeEvent(
+  body: unknown,
+  method = 'POST',
+  authorization = 'Bearer test-admin-token',
+): HandlerEvent {
+  return {
+    httpMethod: method,
+    body: JSON.stringify(body),
+    headers: authorization ? { authorization } : {},
+    multiValueHeaders: {},
+    isBase64Encoded: false,
+    path: '/.netlify/functions/admin-user-status',
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    rawQuery: '',
+    rawUrl: 'http://localhost/.netlify/functions/admin-user-status',
+  };
+}
+
+interface SetupOptions {
+  caller?: { id: string; role: string; isActive: boolean } | null;
+  target?: { id: string; role: string; isActive: boolean } | null;
+  banError?: { message: string } | null;
+  unbanError?: { message: string } | null;
+  userUpdateError?: { message: string } | null;
+  sellerUpdateError?: { message: string } | null;
+  pushUpdateError?: { message: string } | null;
+  auditError?: { message: string } | null;
+}
+
+function installSupabaseMock(options: SetupOptions = {}) {
+  const caller = options.caller === undefined
+    ? { id: ADMIN_ID, role: 'admin', isActive: true }
+    : options.caller;
+  const target = options.target === undefined
+    ? { id: TARGET_ID, role: 'seller', isActive: true }
+    : options.target;
+
+  const updateUserById = vi.fn(async (_userId: string, attributes: { ban_duration?: string }) => {
+    if (attributes.ban_duration === 'none' && options.unbanError) {
+      return { data: null, error: options.unbanError };
+    }
+    if (attributes.ban_duration !== 'none' && options.banError) {
+      return { data: null, error: options.banError };
+    }
+    return { data: { user: { id: _userId } }, error: null };
+  });
+
+  let lookupIndex = 0;
+  const usersSelectQuery = {
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn(async () => {
+      const value = lookupIndex === 0 ? caller : target;
+      lookupIndex += 1;
+      return { data: value, error: null };
+    }),
+  };
+  const usersSelect = vi.fn(() => usersSelectQuery);
+
+  const userUpdateEq = vi.fn().mockResolvedValue({ error: options.userUpdateError ?? null });
+  const usersUpdate = vi.fn(() => ({ eq: userUpdateEq }));
+
+  const sellerUpdateEq = vi.fn().mockResolvedValue({ error: options.sellerUpdateError ?? null });
+  const sellerUpdate = vi.fn(() => ({ eq: sellerUpdateEq }));
+
+  const pushSecondEq = vi.fn().mockResolvedValue({ error: options.pushUpdateError ?? null });
+  const pushFirstEq = vi.fn(() => ({ eq: pushSecondEq }));
+  const pushUpdate = vi.fn(() => ({ eq: pushFirstEq }));
+
+  const auditInsert = vi.fn().mockResolvedValue({ error: options.auditError ?? null });
+
+  const from = vi.fn((table: string) => {
+    if (table === 'users') {
+      return { select: usersSelect, update: usersUpdate };
+    }
+    if (table === 'seller_profiles') {
+      return { update: sellerUpdate };
+    }
+    if (table === 'push_tokens') {
+      return { update: pushUpdate };
+    }
+    if (table === 'admin_actions') {
+      return { insert: auditInsert };
+    }
+    throw new Error(`Unexpected table in test: ${table}`);
+  });
+
+  vi.doMock('@supabase/supabase-js', () => ({
+    createClient: vi.fn(() => ({
+      auth: {
+        getUser: vi.fn().mockResolvedValue({
+          data: { user: { id: ADMIN_ID, app_metadata: { role: 'admin' } } },
+          error: null,
+        }),
+        admin: { updateUserById },
+      },
+      from,
+    })),
+  }));
+
+  return {
+    updateUserById,
+    usersUpdate,
+    sellerUpdate,
+    pushUpdate,
+    auditInsert,
+  };
+}
+
+describe('admin-user-status', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+    vi.resetModules();
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('rejects an inactive admin even when the JWT still claims admin', async () => {
+    const mocks = installSupabaseMock({
+      caller: { id: ADMIN_ID, role: 'admin', isActive: false },
+    });
+    const { handler } = await import('../admin-user-status');
+
+    const res = await handler(makeEvent({ op: 'suspend', userId: TARGET_ID }), {} as never);
+
+    expect(res.statusCode).toBe(403);
+    expect(mocks.updateUserById).not.toHaveBeenCalled();
+  });
+
+  it('prevents an admin from suspending their own account', async () => {
+    const mocks = installSupabaseMock();
+    const { handler } = await import('../admin-user-status');
+
+    const res = await handler(makeEvent({ op: 'suspend', userId: ADMIN_ID }), {} as never);
+
+    expect(res.statusCode).toBe(400);
+    expect(mocks.updateUserById).not.toHaveBeenCalled();
+  });
+
+  it('suspends Auth before DB state, suspends seller, disables push, and audits', async () => {
+    const mocks = installSupabaseMock();
+    const { handler } = await import('../admin-user-status');
+
+    const res = await handler(makeEvent({ op: 'suspend', userId: TARGET_ID }), {} as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.updateUserById).toHaveBeenCalledWith(TARGET_ID, { ban_duration: '876000h' });
+    expect(mocks.usersUpdate).toHaveBeenCalledWith({ isActive: false });
+    expect(mocks.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'suspended' });
+    expect(mocks.pushUpdate).toHaveBeenCalledWith({ isActive: false });
+    expect(mocks.auditInsert).toHaveBeenCalledWith(expect.objectContaining({
+      adminId: ADMIN_ID,
+      actionType: 'user_suspend',
+      targetType: 'user',
+      targetId: TARGET_ID,
+    }));
+    expect(mocks.updateUserById.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.usersUpdate.mock.invocationCallOrder[0]);
+  });
+
+  it('fails closed when the Auth ban cannot be established', async () => {
+    const mocks = installSupabaseMock({ banError: { message: 'auth unavailable' } });
+    const { handler } = await import('../admin-user-status');
+
+    const res = await handler(makeEvent({ op: 'suspend', userId: TARGET_ID }), {} as never);
+
+    expect(res.statusCode).toBe(502);
+    expect(mocks.usersUpdate).not.toHaveBeenCalled();
+    expect(mocks.sellerUpdate).not.toHaveBeenCalled();
+    expect(mocks.pushUpdate).not.toHaveBeenCalled();
+  });
+
+  it('reactivates Auth and DB without resurrecting historical push tokens', async () => {
+    const mocks = installSupabaseMock({
+      target: { id: TARGET_ID, role: 'seller', isActive: false },
+    });
+    const { handler } = await import('../admin-user-status');
+
+    const res = await handler(makeEvent({ op: 'reactivate', userId: TARGET_ID }), {} as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.updateUserById).toHaveBeenCalledWith(TARGET_ID, { ban_duration: 'none' });
+    expect(mocks.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'submitted' });
+    expect(mocks.usersUpdate).toHaveBeenCalledWith({ isActive: true });
+    expect(mocks.pushUpdate).not.toHaveBeenCalled();
+    expect(mocks.auditInsert).toHaveBeenCalledWith(expect.objectContaining({
+      actionType: 'user_reactivate',
+      targetId: TARGET_ID,
+    }));
+  });
+
+  it('re-bans immediately when seller reactivation cannot synchronize', async () => {
+    const mocks = installSupabaseMock({
+      target: { id: TARGET_ID, role: 'seller', isActive: false },
+      sellerUpdateError: { message: 'seller write failed' },
+    });
+    const { handler } = await import('../admin-user-status');
+
+    const res = await handler(makeEvent({ op: 'reactivate', userId: TARGET_ID }), {} as never);
+
+    expect(res.statusCode).toBe(500);
+    expect(mocks.updateUserById).toHaveBeenNthCalledWith(1, TARGET_ID, { ban_duration: 'none' });
+    expect(mocks.updateUserById).toHaveBeenNthCalledWith(2, TARGET_ID, { ban_duration: '876000h' });
+    expect(mocks.usersUpdate).not.toHaveBeenCalled();
+  });
+
+  it('refuses to manage admin targets through the standard user-status endpoint', async () => {
+    const mocks = installSupabaseMock({
+      target: { id: TARGET_ID, role: 'admin', isActive: true },
+    });
+    const { handler } = await import('../admin-user-status');
+
+    const res = await handler(makeEvent({ op: 'suspend', userId: TARGET_ID }), {} as never);
+
+    expect(res.statusCode).toBe(403);
+    expect(mocks.updateUserById).not.toHaveBeenCalled();
+  });
+});

--- a/netlify/functions/__tests__/admin-user-status.test.ts
+++ b/netlify/functions/__tests__/admin-user-status.test.ts
@@ -50,6 +50,7 @@ interface SetupOptions {
   sellerUpdateError?: { message: string } | null;
   pushUpdateError?: { message: string } | null;
   auditError?: { message: string } | null;
+  activeGateError?: { message: string } | null;
 }
 
 function installSupabaseMock(options: SetupOptions = {}) {
@@ -85,6 +86,11 @@ function installSupabaseMock(options: SetupOptions = {}) {
       return { data: null, error: options.banError };
     }
     return { data: { user: { id: _userId } }, error: null };
+  });
+
+  const activeGateRpc = vi.fn().mockResolvedValue({
+    data: false,
+    error: options.activeGateError ?? null,
   });
 
   let lookupIndex = 0;
@@ -143,12 +149,14 @@ function installSupabaseMock(options: SetupOptions = {}) {
         }),
         admin: { updateUserById },
       },
+      rpc: activeGateRpc,
       from,
     })),
   }));
 
   return {
     updateUserById,
+    activeGateRpc,
     usersUpdate,
     sellerSelect,
     sellerUpdate,
@@ -204,6 +212,7 @@ describe('admin-user-status', () => {
 
     expect(res.statusCode).toBe(200);
     expect(mocks.updateUserById).toHaveBeenCalledWith(TARGET_ID, { ban_duration: '876000h' });
+    expect(mocks.activeGateRpc).not.toHaveBeenCalled();
     expect(mocks.usersUpdate).toHaveBeenCalledWith({ isActive: false });
     expect(mocks.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'suspended' });
     expect(mocks.pushUpdate).toHaveBeenCalledWith({ isActive: false });
@@ -256,6 +265,24 @@ describe('admin-user-status', () => {
     }));
   });
 
+  it('keeps reactivation closed until migration 608 active-account DB gate is installed', async () => {
+    const mocks = installSupabaseMock({
+      target: { id: TARGET_ID, role: 'seller', isActive: false },
+      activeGateError: { message: 'function public.is_active_user() does not exist' },
+    });
+    const { handler } = await import('../admin-user-status');
+
+    const res = await handler(makeEvent({ op: 'reactivate', userId: TARGET_ID }), {} as never);
+
+    expect(res.statusCode).toBe(503);
+    expect(mocks.activeGateRpc).toHaveBeenCalledWith('is_active_user');
+    expect(mocks.updateUserById).not.toHaveBeenCalled();
+    expect(mocks.sellerSelect).not.toHaveBeenCalled();
+    expect(mocks.sellerUpdate).not.toHaveBeenCalled();
+    expect(mocks.usersUpdate).not.toHaveBeenCalled();
+    expect(mocks.auditInsert).not.toHaveBeenCalled();
+  });
+
   it('reactivates a ready seller to its derived active state without resurrecting push tokens', async () => {
     const mocks = installSupabaseMock({
       target: { id: TARGET_ID, role: 'seller', isActive: false },
@@ -265,6 +292,7 @@ describe('admin-user-status', () => {
     const res = await handler(makeEvent({ op: 'reactivate', userId: TARGET_ID }), {} as never);
 
     expect(res.statusCode).toBe(200);
+    expect(mocks.activeGateRpc).toHaveBeenCalledWith('is_active_user');
     expect(JSON.parse(res.body)).toMatchObject({
       ok: true,
       userId: TARGET_ID,

--- a/netlify/functions/__tests__/admin-user-status.test.ts
+++ b/netlify/functions/__tests__/admin-user-status.test.ts
@@ -229,6 +229,33 @@ describe('admin-user-status', () => {
     expect(mocks.pushUpdate).not.toHaveBeenCalled();
   });
 
+  it('continues seller and push cleanup when the users suspension write fails', async () => {
+    const mocks = installSupabaseMock({ userUpdateError: { message: 'users unavailable' } });
+    const { handler } = await import('../admin-user-status');
+
+    const res = await handler(makeEvent({ op: 'suspend', userId: TARGET_ID }), {} as never);
+
+    expect(res.statusCode).toBe(500);
+    expect(mocks.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'suspended' });
+    expect(mocks.pushUpdate).toHaveBeenCalledWith({ isActive: false });
+    expect(mocks.auditInsert).not.toHaveBeenCalled();
+  });
+
+  it('continues push cleanup and audit when seller-state synchronization fails', async () => {
+    const mocks = installSupabaseMock({ sellerUpdateError: { message: 'seller unavailable' } });
+    const { handler } = await import('../admin-user-status');
+
+    const res = await handler(makeEvent({ op: 'suspend', userId: TARGET_ID }), {} as never);
+
+    expect(res.statusCode).toBe(500);
+    expect(mocks.usersUpdate).toHaveBeenCalledWith({ isActive: false });
+    expect(mocks.pushUpdate).toHaveBeenCalledWith({ isActive: false });
+    expect(mocks.auditInsert).toHaveBeenCalledWith(expect.objectContaining({
+      actionType: 'user_suspend',
+      targetId: TARGET_ID,
+    }));
+  });
+
   it('reactivates a ready seller to its derived active state without resurrecting push tokens', async () => {
     const mocks = installSupabaseMock({
       target: { id: TARGET_ID, role: 'seller', isActive: false },

--- a/netlify/functions/__tests__/admin-user-status.test.ts
+++ b/netlify/functions/__tests__/admin-user-status.test.ts
@@ -23,9 +23,27 @@ function makeEvent(
   };
 }
 
+interface SellerProfileMock {
+  userId: string;
+  sellerStatus: string;
+  storeName: string | null;
+  businessName: string | null;
+  contactPhone: string | null;
+  businessAddress: { postcode?: string } | null;
+  stripeConnectStatus: string | null;
+  sellerType: string | null;
+  companyRegistrationNumber: string | null;
+  vatNumber: string | null;
+  isVatRegistered: boolean | null;
+  requiresAdminApproval: boolean | null;
+  isApproved: boolean | null;
+}
+
 interface SetupOptions {
   caller?: { id: string; role: string; isActive: boolean } | null;
   target?: { id: string; role: string; isActive: boolean } | null;
+  sellerProfile?: SellerProfileMock | null;
+  sellerProfileError?: { message: string } | null;
   banError?: { message: string } | null;
   unbanError?: { message: string } | null;
   userUpdateError?: { message: string } | null;
@@ -41,6 +59,23 @@ function installSupabaseMock(options: SetupOptions = {}) {
   const target = options.target === undefined
     ? { id: TARGET_ID, role: 'seller', isActive: true }
     : options.target;
+  const sellerProfile = options.sellerProfile === undefined
+    ? {
+        userId: TARGET_ID,
+        sellerStatus: 'suspended',
+        storeName: 'Acme Supplies',
+        businessName: null,
+        contactPhone: '+441234567890',
+        businessAddress: { postcode: 'BB1 1AA' },
+        stripeConnectStatus: 'active',
+        sellerType: 'individual',
+        companyRegistrationNumber: null,
+        vatNumber: null,
+        isVatRegistered: false,
+        requiresAdminApproval: false,
+        isApproved: true,
+      }
+    : options.sellerProfile;
 
   const updateUserById = vi.fn(async (_userId: string, attributes: { ban_duration?: string }) => {
     if (attributes.ban_duration === 'none' && options.unbanError) {
@@ -66,6 +101,14 @@ function installSupabaseMock(options: SetupOptions = {}) {
   const userUpdateEq = vi.fn().mockResolvedValue({ error: options.userUpdateError ?? null });
   const usersUpdate = vi.fn(() => ({ eq: userUpdateEq }));
 
+  const sellerSelectQuery = {
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({
+      data: sellerProfile,
+      error: options.sellerProfileError ?? null,
+    }),
+  };
+  const sellerSelect = vi.fn(() => sellerSelectQuery);
   const sellerUpdateEq = vi.fn().mockResolvedValue({ error: options.sellerUpdateError ?? null });
   const sellerUpdate = vi.fn(() => ({ eq: sellerUpdateEq }));
 
@@ -80,7 +123,7 @@ function installSupabaseMock(options: SetupOptions = {}) {
       return { select: usersSelect, update: usersUpdate };
     }
     if (table === 'seller_profiles') {
-      return { update: sellerUpdate };
+      return { select: sellerSelect, update: sellerUpdate };
     }
     if (table === 'push_tokens') {
       return { update: pushUpdate };
@@ -95,7 +138,7 @@ function installSupabaseMock(options: SetupOptions = {}) {
     createClient: vi.fn(() => ({
       auth: {
         getUser: vi.fn().mockResolvedValue({
-          data: { user: { id: ADMIN_ID, app_metadata: { role: 'admin' } } },
+          data: { user: { id: ADMIN_ID, email: 'admin@loadify.test', app_metadata: { role: 'admin' } } },
           error: null,
         }),
         admin: { updateUserById },
@@ -107,6 +150,7 @@ function installSupabaseMock(options: SetupOptions = {}) {
   return {
     updateUserById,
     usersUpdate,
+    sellerSelect,
     sellerUpdate,
     pushUpdate,
     auditInsert,
@@ -185,7 +229,7 @@ describe('admin-user-status', () => {
     expect(mocks.pushUpdate).not.toHaveBeenCalled();
   });
 
-  it('reactivates Auth and DB without resurrecting historical push tokens', async () => {
+  it('reactivates a ready seller to its derived active state without resurrecting push tokens', async () => {
     const mocks = installSupabaseMock({
       target: { id: TARGET_ID, role: 'seller', isActive: false },
     });
@@ -194,8 +238,15 @@ describe('admin-user-status', () => {
     const res = await handler(makeEvent({ op: 'reactivate', userId: TARGET_ID }), {} as never);
 
     expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({
+      ok: true,
+      userId: TARGET_ID,
+      isActive: true,
+      sellerStatus: 'active',
+    });
     expect(mocks.updateUserById).toHaveBeenCalledWith(TARGET_ID, { ban_duration: 'none' });
-    expect(mocks.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'submitted' });
+    expect(mocks.sellerSelect).toHaveBeenCalled();
+    expect(mocks.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'active' });
     expect(mocks.usersUpdate).toHaveBeenCalledWith({ isActive: true });
     expect(mocks.pushUpdate).not.toHaveBeenCalled();
     expect(mocks.auditInsert).toHaveBeenCalledWith(expect.objectContaining({
@@ -204,10 +255,53 @@ describe('admin-user-status', () => {
     }));
   });
 
+  it('derives submitted instead of active when admin approval is still required', async () => {
+    const mocks = installSupabaseMock({
+      target: { id: TARGET_ID, role: 'seller', isActive: false },
+      sellerProfile: {
+        userId: TARGET_ID,
+        sellerStatus: 'suspended',
+        storeName: 'Approval Required Ltd',
+        businessName: null,
+        contactPhone: '+441234567890',
+        businessAddress: { postcode: 'BB1 1AA' },
+        stripeConnectStatus: 'active',
+        sellerType: 'company',
+        companyRegistrationNumber: '12345678',
+        vatNumber: null,
+        isVatRegistered: false,
+        requiresAdminApproval: true,
+        isApproved: false,
+      },
+    });
+    const { handler } = await import('../admin-user-status');
+
+    const res = await handler(makeEvent({ op: 'reactivate', userId: TARGET_ID }), {} as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toMatchObject({ sellerStatus: 'submitted' });
+    expect(mocks.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'submitted' });
+  });
+
   it('re-bans immediately when seller reactivation cannot synchronize', async () => {
     const mocks = installSupabaseMock({
       target: { id: TARGET_ID, role: 'seller', isActive: false },
       sellerUpdateError: { message: 'seller write failed' },
+    });
+    const { handler } = await import('../admin-user-status');
+
+    const res = await handler(makeEvent({ op: 'reactivate', userId: TARGET_ID }), {} as never);
+
+    expect(res.statusCode).toBe(500);
+    expect(mocks.updateUserById).toHaveBeenNthCalledWith(1, TARGET_ID, { ban_duration: 'none' });
+    expect(mocks.updateUserById).toHaveBeenNthCalledWith(2, TARGET_ID, { ban_duration: '876000h' });
+    expect(mocks.usersUpdate).not.toHaveBeenCalled();
+  });
+
+  it('fails safely when the seller profile cannot be read during reactivation', async () => {
+    const mocks = installSupabaseMock({
+      target: { id: TARGET_ID, role: 'seller', isActive: false },
+      sellerProfileError: { message: 'profile unavailable' },
     });
     const { handler } = await import('../admin-user-status');
 

--- a/netlify/functions/__tests__/checkout-safety.test.ts
+++ b/netlify/functions/__tests__/checkout-safety.test.ts
@@ -64,6 +64,7 @@ type MockSellerProfile = {
   stripeAccountId: string | null;
   stripeConnectStatus: string | null;
   sellerStatus: string | null;
+  isPaused?: boolean | null;
 };
 
 /**
@@ -74,6 +75,7 @@ type MockSellerProfile = {
 function makeSupabaseMock(opts: {
   authUserId?: string;
   authError?: Error | null;
+  sellerAccount?: { id: string; role: string; isActive: boolean };
   // Products returned by from('products').select(...).in(...)
   products?: Array<{
     id: string;
@@ -100,11 +102,12 @@ function makeSupabaseMock(opts: {
   const {
     authUserId = 'buyer-1',
     authError = null,
+    sellerAccount = { id: 's1', role: 'seller', isActive: true },
     products = [
       { id: 'p1', price: 20, title: 'Widget', sellerId: 's1', isActive: true, isApproved: true, stockQuantity: 10 },
     ],
     productsError = null,
-    sellerProfile = { stripeAccountId: 'acct_123', stripeConnectStatus: 'active', sellerStatus: 'active' },
+    sellerProfile = { stripeAccountId: 'acct_123', stripeConnectStatus: 'active', sellerStatus: 'active', isPaused: false },
     sellerProfileError = null,
     sessionInsertError = null,
     productShippingRows = [{
@@ -122,16 +125,31 @@ function makeSupabaseMock(opts: {
     disputeInsert = { error: null },
   } = opts;
 
+  let userLookupIndex = 0;
+  const liveAccounts = [
+    { id: authUserId, role: 'buyer', isActive: true },
+    sellerAccount,
+  ];
+
   return {
     createClient: vi.fn(() => ({
       auth: {
         getUser: vi.fn().mockResolvedValue({
-          data: { user: authError ? null : { id: authUserId, email: 'buyer@test.com' } },
+          data: { user: authError ? null : { id: authUserId, email: 'buyer@test.com', app_metadata: {} } },
           error: authError ?? null,
         }),
       },
       from: vi.fn((table: string) => {
         switch (table) {
+          case 'users':
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn().mockImplementation(async () => ({
+                data: liveAccounts[Math.min(userLookupIndex++, liveAccounts.length - 1)] ?? null,
+                error: null,
+              })),
+            };
           case 'products':
             return {
               select: vi.fn().mockReturnThis(),

--- a/netlify/functions/__tests__/create-checkout.test.ts
+++ b/netlify/functions/__tests__/create-checkout.test.ts
@@ -38,6 +38,18 @@ function activeBuyerQuery() {
   };
 }
 
+function sequencedAccountQuery(accounts: Array<{ id: string; role: string; isActive: boolean }>) {
+  let lookupIndex = 0;
+  return () => ({
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockImplementation(async () => ({
+      data: accounts[Math.min(lookupIndex++, accounts.length - 1)] ?? null,
+      error: null,
+    })),
+  });
+}
+
 describe('create-checkout handler – request validation', () => {
   const originalEnv = { ...process.env };
 
@@ -120,6 +132,10 @@ describe('create-checkout handler – request validation', () => {
     process.env.STRIPE_SECRET_KEY = 'sk_test_abc123';
     process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
     process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+    const accountQuery = sequencedAccountQuery([
+      { id: 'buyer-1', role: 'buyer', isActive: true },
+      { id: 's1', role: 'seller', isActive: true },
+    ]);
     vi.doMock('stripe', () => ({
       default: vi.fn().mockImplementation(function () {
         return {};
@@ -141,7 +157,7 @@ describe('create-checkout handler – request validation', () => {
         },
         rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
         from: vi.fn((table: string) => {
-          if (table === 'users') return activeBuyerQuery();
+          if (table === 'users') return accountQuery();
           if (table === 'products') {
             return {
               select: vi.fn().mockReturnThis(),
@@ -203,5 +219,84 @@ describe('create-checkout handler – request validation', () => {
 
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body as string).error).toMatch(/shipping method/i);
+  });
+
+  it('rejects checkout when the listing seller account is inactive even if the seller profile is still active', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_abc123';
+    process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+    const accountQuery = sequencedAccountQuery([
+      { id: 'buyer-1', role: 'buyer', isActive: true },
+      { id: 's1', role: 'seller', isActive: false },
+    ]);
+
+    vi.doMock('stripe', () => ({
+      default: vi.fn().mockImplementation(function () {
+        return {};
+      }),
+    }));
+    vi.doMock('../_shared/platformFlags', () => ({
+      isMaintenanceMode: vi.fn().mockResolvedValue(false),
+    }));
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+    vi.doMock('@supabase/supabase-js', () => ({
+      createClient: vi.fn(() => ({
+        auth: {
+          getUser: vi.fn().mockResolvedValue({
+            data: { user: { id: 'buyer-1', email: 'buyer@test.com', app_metadata: {} } },
+            error: null,
+          }),
+        },
+        rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
+        from: vi.fn((table: string) => {
+          if (table === 'users') return accountQuery();
+          if (table === 'products') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              in: vi.fn().mockResolvedValue({
+                data: [{
+                  id: 'p1',
+                  price: 10,
+                  title: 'Widget',
+                  sellerId: 's1',
+                  isActive: true,
+                  isApproved: true,
+                  stockQuantity: 5,
+                  listingContext: 'product',
+                  listingStatus: 'active',
+                }],
+                error: null,
+              }),
+            };
+          }
+          if (table === 'seller_profiles') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn().mockResolvedValue({
+                data: { stripeAccountId: 'acct_123', stripeConnectStatus: 'active', sellerStatus: 'active', isPaused: false },
+                error: null,
+              }),
+            };
+          }
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+          };
+        }),
+      })),
+    }));
+
+    const { handler } = await import('../create-checkout');
+    const res = await handler(
+      makeEvent(validBody, 'POST', { authorization: 'Bearer valid-token' }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body as string).error).toMatch(/seller.*not currently available/i);
   });
 });

--- a/netlify/functions/__tests__/create-checkout.test.ts
+++ b/netlify/functions/__tests__/create-checkout.test.ts
@@ -1,8 +1,5 @@
 /**
  * Unit tests for the create-checkout Netlify function.
- *
- * Tests focus on the request-validation and early-return paths that can be
- * exercised without a real Stripe account or Supabase instance.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import type { HandlerEvent } from '@netlify/functions';
@@ -29,6 +26,17 @@ const validBody = {
   billingAddress: { line1: '1 High St', city: 'London', postal_code: 'E1 1AA', country: 'GB' },
   shippingMethodId: '11111111-1111-1111-1111-111111111111',
 };
+
+function activeBuyerQuery() {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    maybeSingle: vi.fn().mockResolvedValue({
+      data: { id: 'buyer-1', role: 'buyer', isActive: true },
+      error: null,
+    }),
+  };
+}
 
 describe('create-checkout handler – request validation', () => {
   const originalEnv = { ...process.env };
@@ -76,29 +84,33 @@ describe('create-checkout handler – request validation', () => {
     vi.doMock('@supabase/supabase-js', () => ({
       createClient: vi.fn(() => ({
         auth: {
-          // P1 gate: return a valid user so the auth check passes and the
-          // test can reach the product-availability check.
           getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: 'buyer-1', email: 'buyer@test.com' } },
+            data: { user: { id: 'buyer-1', email: 'buyer@test.com', app_metadata: {} } },
             error: null,
           }),
         },
-        from: vi.fn(() => ({
-          select: vi.fn().mockReturnThis(),
-          in: vi.fn().mockResolvedValue({
-            data: [{ id: 'p1', price: 10, title: 'Widget', sellerId: 's1', isActive: false, isApproved: true, stockQuantity: 5 }],
-            error: null,
-          }),
-          eq: vi.fn().mockReturnThis(),
-          maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
-          insert: vi.fn().mockResolvedValue({ error: null }),
-          update: vi.fn().mockReturnThis(),
-        })),
+        from: vi.fn((table: string) => {
+          if (table === 'users') return activeBuyerQuery();
+          if (table === 'products') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              in: vi.fn().mockResolvedValue({
+                data: [{ id: 'p1', price: 10, title: 'Widget', sellerId: 's1', isActive: false, isApproved: true, stockQuantity: 5 }],
+                error: null,
+              }),
+            };
+          }
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }),
+            insert: vi.fn().mockResolvedValue({ error: null }),
+            update: vi.fn().mockReturnThis(),
+          };
+        }),
       })),
     }));
     const { handler } = await import('../create-checkout');
-    // Pass a lowercase 'authorization' header so the P1 auth gate is satisfied.
-    // Netlify normalises headers to lowercase at the edge; unit test mocks do not.
     const res = await handler(makeEvent(validBody, 'POST', { authorization: 'Bearer valid-token' }), {} as never);
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body as string).error).toMatch(/no longer available/i);
@@ -113,21 +125,23 @@ describe('create-checkout handler – request validation', () => {
         return {};
       }),
     }));
-    vi.doMock('./_shared/platformFlags', () => ({
+    vi.doMock('../_shared/platformFlags', () => ({
       isMaintenanceMode: vi.fn().mockResolvedValue(false),
     }));
-    vi.doMock('./_shared/rateLimiter', () => ({
+    vi.doMock('../_shared/rateLimiter', () => ({
       checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
     }));
     vi.doMock('@supabase/supabase-js', () => ({
       createClient: vi.fn(() => ({
         auth: {
           getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: 'buyer-1', email: 'buyer@test.com' } },
+            data: { user: { id: 'buyer-1', email: 'buyer@test.com', app_metadata: {} } },
             error: null,
           }),
         },
+        rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
         from: vi.fn((table: string) => {
+          if (table === 'users') return activeBuyerQuery();
           if (table === 'products') {
             return {
               select: vi.fn().mockReturnThis(),
@@ -152,9 +166,16 @@ describe('create-checkout handler – request validation', () => {
               select: vi.fn().mockReturnThis(),
               eq: vi.fn().mockReturnThis(),
               maybeSingle: vi.fn().mockResolvedValue({
-                data: { stripeAccountId: 'acct_123', stripeConnectStatus: 'active', sellerStatus: 'active' },
+                data: { stripeAccountId: 'acct_123', stripeConnectStatus: 'active', sellerStatus: 'active', isPaused: false },
                 error: null,
               }),
+            };
+          }
+          if (table === 'buyer_profiles') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn().mockResolvedValue({ data: { accountType: 'individual', isVatVerified: false }, error: null }),
             };
           }
           return {

--- a/netlify/functions/__tests__/create-payment-intent.test.ts
+++ b/netlify/functions/__tests__/create-payment-intent.test.ts
@@ -47,21 +47,41 @@ describe('create-payment-intent – shipping tamper protection', () => {
     vi.restoreAllMocks();
   });
 
-  function mockCommonSupabase(overrides?: { productShippingRows?: unknown[] }) {
+  function mockCommonSupabase(overrides?: {
+    productShippingRows?: unknown[];
+    productRows?: Array<typeof productRow>;
+    sellerAccount?: { id: string; role: string; isActive: boolean };
+  }) {
+    let userLookupIndex = 0;
+    const userRows = [
+      { id: 'buyer-1', role: 'buyer', isActive: true },
+      overrides?.sellerAccount ?? { id: 'seller-1', role: 'seller', isActive: true },
+    ];
+
     vi.doMock('@supabase/supabase-js', () => ({
       createClient: vi.fn(() => ({
         auth: {
           getUser: vi.fn().mockResolvedValue({
-            data: { user: { id: 'buyer-1', email: 'buyer@test.com' } },
+            data: { user: { id: 'buyer-1', email: 'buyer@test.com', app_metadata: {} } },
             error: null,
           }),
         },
         rpc: vi.fn().mockResolvedValue({ data: null, error: null }),
         from: vi.fn((table: string) => {
+          if (table === 'users') {
+            return {
+              select: vi.fn().mockReturnThis(),
+              eq: vi.fn().mockReturnThis(),
+              maybeSingle: vi.fn().mockImplementation(async () => ({
+                data: userRows[Math.min(userLookupIndex++, userRows.length - 1)],
+                error: null,
+              })),
+            };
+          }
           if (table === 'products') {
             return {
               select: vi.fn().mockReturnThis(),
-              in: vi.fn().mockResolvedValue({ data: [productRow], error: null }),
+              in: vi.fn().mockResolvedValue({ data: overrides?.productRows ?? [productRow], error: null }),
             };
           }
           if (table === 'seller_profiles') {
@@ -69,7 +89,7 @@ describe('create-payment-intent – shipping tamper protection', () => {
               select: vi.fn().mockReturnThis(),
               eq: vi.fn().mockReturnThis(),
               maybeSingle: vi.fn().mockResolvedValue({
-                data: { stripeAccountId: 'acct_123', stripeConnectStatus: 'active', sellerStatus: 'active' },
+                data: { stripeAccountId: 'acct_123', stripeConnectStatus: 'active', sellerStatus: 'active', isPaused: false },
                 error: null,
               }),
             };
@@ -113,7 +133,7 @@ describe('create-payment-intent – shipping tamper protection', () => {
     const { handler } = await import('../create-payment-intent');
     const res = await handler(
       makeEvent(
-        { ...baseBody, shippingAmount: 0.01 }, // client-tampered value
+        { ...baseBody, shippingAmount: 0.01 },
         'POST',
         { authorization: 'Bearer valid-token' },
       ),
@@ -147,7 +167,7 @@ describe('create-payment-intent – shipping tamper protection', () => {
       makeEvent(
         {
           ...baseBody,
-          shippingAmount: 0.01, // client-tampered value
+          shippingAmount: 0.01,
           shippingMethodId: '11111111-1111-1111-1111-111111111111',
         },
         'POST',
@@ -158,5 +178,36 @@ describe('create-payment-intent – shipping tamper protection', () => {
 
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body as string).error).toMatch(/not available/i);
+  });
+
+  it('rejects a mobile payment when the seller live account is inactive even if the seller profile remains active', async () => {
+    process.env.STRIPE_SECRET_KEY = 'sk_test_abc123';
+    process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+
+    vi.doMock('stripe', () => ({
+      default: vi.fn().mockImplementation(function () {
+        return {};
+      }),
+    }));
+    vi.doMock('../_shared/platformFlags', () => ({
+      isMaintenanceMode: vi.fn().mockResolvedValue(false),
+    }));
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+    mockCommonSupabase({
+      productRows: [{ ...productRow, listingContext: 'service' }],
+      sellerAccount: { id: 'seller-1', role: 'seller', isActive: false },
+    });
+
+    const { handler } = await import('../create-payment-intent');
+    const res = await handler(
+      makeEvent(baseBody, 'POST', { authorization: 'Bearer valid-token' }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body as string).error).toMatch(/seller.*not currently available/i);
   });
 });

--- a/netlify/functions/__tests__/deactivate-account.test.ts
+++ b/netlify/functions/__tests__/deactivate-account.test.ts
@@ -133,7 +133,34 @@ describe('deactivate-account', () => {
     expect(mocks.pushUpdate).not.toHaveBeenCalled();
   });
 
-  it('reports committed deactivation if seller listing cleanup needs support intervention', async () => {
+  it('continues seller and push cleanup when the database account-state write fails', async () => {
+    const mocks = installMocks({ role: 'seller', userUpdateError: { message: 'users unavailable' } });
+    const { handler } = await import('../deactivate-account');
+
+    const res = await handler(makeEvent(), {} as never);
+    const body = JSON.parse(res.body);
+
+    expect(res.statusCode).toBe(500);
+    expect(body.deactivated).toBe(false);
+    expect(mocks.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'suspended', isPaused: true });
+    expect(mocks.productsUpdate).toHaveBeenCalledWith({ isActive: false });
+    expect(mocks.pushUpdate).toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('continues listing and push cleanup when seller-state synchronization fails', async () => {
+    const mocks = installMocks({ role: 'seller', sellerUpdateError: { message: 'seller unavailable' } });
+    const { handler } = await import('../deactivate-account');
+
+    const res = await handler(makeEvent(), {} as never);
+    const body = JSON.parse(res.body);
+
+    expect(res.statusCode).toBe(500);
+    expect(body.deactivated).toBe(true);
+    expect(mocks.productsUpdate).toHaveBeenCalledWith({ isActive: false });
+    expect(mocks.pushUpdate).toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('reports committed deactivation and still disables push if listing cleanup needs support intervention', async () => {
     const mocks = installMocks({ role: 'seller', productsUpdateError: { message: 'products unavailable' } });
     const { handler } = await import('../deactivate-account');
 
@@ -144,7 +171,7 @@ describe('deactivate-account', () => {
     expect(body.deactivated).toBe(true);
     expect(mocks.usersUpdate).toHaveBeenCalledWith({ isActive: false });
     expect(mocks.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'suspended', isPaused: true });
-    expect(mocks.pushUpdate).not.toHaveBeenCalled();
+    expect(mocks.pushUpdate).toHaveBeenCalledWith({ isActive: false });
   });
 
   it('reports partial secure deactivation when notification cleanup fails', async () => {

--- a/netlify/functions/__tests__/deactivate-account.test.ts
+++ b/netlify/functions/__tests__/deactivate-account.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HandlerEvent } from '@netlify/functions';
+
+const USER_ID = '22222222-2222-4222-8222-222222222222';
+
+function makeEvent(method = 'POST'): HandlerEvent {
+  return {
+    httpMethod: method,
+    body: null,
+    headers: { authorization: 'Bearer test-user-token' },
+    multiValueHeaders: {},
+    isBase64Encoded: false,
+    path: '/.netlify/functions/deactivate-account',
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    rawQuery: '',
+    rawUrl: 'http://localhost/.netlify/functions/deactivate-account',
+  };
+}
+
+interface SetupOptions {
+  role?: 'buyer' | 'seller' | 'admin';
+  banError?: { message: string } | null;
+  userUpdateError?: { message: string } | null;
+  sellerUpdateError?: { message: string } | null;
+  pushUpdateError?: { message: string } | null;
+}
+
+function installMocks(options: SetupOptions = {}) {
+  const role = options.role ?? 'buyer';
+
+  const updateUserById = vi.fn().mockResolvedValue({
+    data: options.banError ? null : { user: { id: USER_ID } },
+    error: options.banError ?? null,
+  });
+
+  const userEq = vi.fn().mockResolvedValue({ error: options.userUpdateError ?? null });
+  const usersUpdate = vi.fn(() => ({ eq: userEq }));
+
+  const sellerEq = vi.fn().mockResolvedValue({ error: options.sellerUpdateError ?? null });
+  const sellerUpdate = vi.fn(() => ({ eq: sellerEq }));
+
+  const pushSecondEq = vi.fn().mockResolvedValue({ error: options.pushUpdateError ?? null });
+  const pushFirstEq = vi.fn(() => ({ eq: pushSecondEq }));
+  const pushUpdate = vi.fn(() => ({ eq: pushFirstEq }));
+
+  const from = vi.fn((table: string) => {
+    if (table === 'users') return { update: usersUpdate };
+    if (table === 'seller_profiles') return { update: sellerUpdate };
+    if (table === 'push_tokens') return { update: pushUpdate };
+    throw new Error(`Unexpected table in test: ${table}`);
+  });
+
+  vi.doMock('@supabase/supabase-js', () => ({
+    createClient: vi.fn(() => ({
+      auth: { admin: { updateUserById } },
+      from,
+    })),
+  }));
+
+  vi.doMock('../_shared/activeAccountAuth', () => ({
+    authenticateActiveAccount: vi.fn().mockResolvedValue({
+      ok: true,
+      actor: { id: USER_ID, role, isActive: true },
+    }),
+  }));
+
+  vi.doMock('../_shared/rateLimiter', () => ({
+    checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+  }));
+
+  return { updateUserById, usersUpdate, sellerUpdate, pushUpdate };
+}
+
+describe('deactivate-account', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('deactivates a buyer with Auth revocation before the database write', async () => {
+    const mocks = installMocks({ role: 'buyer' });
+    const { handler } = await import('../deactivate-account');
+
+    const res = await handler(makeEvent(), {} as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.updateUserById).toHaveBeenCalledWith(USER_ID, { ban_duration: '876000h' });
+    expect(mocks.usersUpdate).toHaveBeenCalledWith({ isActive: false });
+    expect(mocks.sellerUpdate).not.toHaveBeenCalled();
+    expect(mocks.pushUpdate).toHaveBeenCalledWith({ isActive: false });
+    expect(mocks.updateUserById.mock.invocationCallOrder[0])
+      .toBeLessThan(mocks.usersUpdate.mock.invocationCallOrder[0]);
+  });
+
+  it('also suspends seller lifecycle state before completing deactivation', async () => {
+    const mocks = installMocks({ role: 'seller' });
+    const { handler } = await import('../deactivate-account');
+
+    const res = await handler(makeEvent(), {} as never);
+
+    expect(res.statusCode).toBe(200);
+    expect(mocks.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'suspended' });
+    expect(mocks.pushUpdate).toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('fails closed before database mutation when the Auth ban cannot be established', async () => {
+    const mocks = installMocks({ role: 'buyer', banError: { message: 'auth unavailable' } });
+    const { handler } = await import('../deactivate-account');
+
+    const res = await handler(makeEvent(), {} as never);
+
+    expect(res.statusCode).toBe(502);
+    expect(mocks.usersUpdate).not.toHaveBeenCalled();
+    expect(mocks.sellerUpdate).not.toHaveBeenCalled();
+    expect(mocks.pushUpdate).not.toHaveBeenCalled();
+  });
+
+  it('reports partial secure deactivation when notification cleanup fails', async () => {
+    const mocks = installMocks({ role: 'buyer', pushUpdateError: { message: 'push unavailable' } });
+    const { handler } = await import('../deactivate-account');
+
+    const res = await handler(makeEvent(), {} as never);
+    const body = JSON.parse(res.body);
+
+    expect(res.statusCode).toBe(500);
+    expect(body.deactivated).toBe(true);
+    expect(mocks.usersUpdate).toHaveBeenCalledWith({ isActive: false });
+  });
+
+  it('refuses self-service deactivation for admin accounts', async () => {
+    const mocks = installMocks({ role: 'admin' });
+    const { handler } = await import('../deactivate-account');
+
+    const res = await handler(makeEvent(), {} as never);
+
+    expect(res.statusCode).toBe(403);
+    expect(mocks.updateUserById).not.toHaveBeenCalled();
+    expect(mocks.usersUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/netlify/functions/__tests__/deactivate-account.test.ts
+++ b/netlify/functions/__tests__/deactivate-account.test.ts
@@ -23,6 +23,7 @@ interface SetupOptions {
   banError?: { message: string } | null;
   userUpdateError?: { message: string } | null;
   sellerUpdateError?: { message: string } | null;
+  productsUpdateError?: { message: string } | null;
   pushUpdateError?: { message: string } | null;
 }
 
@@ -40,6 +41,10 @@ function installMocks(options: SetupOptions = {}) {
   const sellerEq = vi.fn().mockResolvedValue({ error: options.sellerUpdateError ?? null });
   const sellerUpdate = vi.fn(() => ({ eq: sellerEq }));
 
+  const productsSecondEq = vi.fn().mockResolvedValue({ error: options.productsUpdateError ?? null });
+  const productsFirstEq = vi.fn(() => ({ eq: productsSecondEq }));
+  const productsUpdate = vi.fn(() => ({ eq: productsFirstEq }));
+
   const pushSecondEq = vi.fn().mockResolvedValue({ error: options.pushUpdateError ?? null });
   const pushFirstEq = vi.fn(() => ({ eq: pushSecondEq }));
   const pushUpdate = vi.fn(() => ({ eq: pushFirstEq }));
@@ -47,6 +52,7 @@ function installMocks(options: SetupOptions = {}) {
   const from = vi.fn((table: string) => {
     if (table === 'users') return { update: usersUpdate };
     if (table === 'seller_profiles') return { update: sellerUpdate };
+    if (table === 'products') return { update: productsUpdate };
     if (table === 'push_tokens') return { update: pushUpdate };
     throw new Error(`Unexpected table in test: ${table}`);
   });
@@ -69,7 +75,7 @@ function installMocks(options: SetupOptions = {}) {
     checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
   }));
 
-  return { updateUserById, usersUpdate, sellerUpdate, pushUpdate };
+  return { updateUserById, usersUpdate, sellerUpdate, productsUpdate, pushUpdate };
 }
 
 describe('deactivate-account', () => {
@@ -96,19 +102,21 @@ describe('deactivate-account', () => {
     expect(mocks.updateUserById).toHaveBeenCalledWith(USER_ID, { ban_duration: '876000h' });
     expect(mocks.usersUpdate).toHaveBeenCalledWith({ isActive: false });
     expect(mocks.sellerUpdate).not.toHaveBeenCalled();
+    expect(mocks.productsUpdate).not.toHaveBeenCalled();
     expect(mocks.pushUpdate).toHaveBeenCalledWith({ isActive: false });
     expect(mocks.updateUserById.mock.invocationCallOrder[0])
       .toBeLessThan(mocks.usersUpdate.mock.invocationCallOrder[0]);
   });
 
-  it('also suspends seller lifecycle state before completing deactivation', async () => {
+  it('suspends and pauses a seller and hides active listings before completing deactivation', async () => {
     const mocks = installMocks({ role: 'seller' });
     const { handler } = await import('../deactivate-account');
 
     const res = await handler(makeEvent(), {} as never);
 
     expect(res.statusCode).toBe(200);
-    expect(mocks.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'suspended' });
+    expect(mocks.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'suspended', isPaused: true });
+    expect(mocks.productsUpdate).toHaveBeenCalledWith({ isActive: false });
     expect(mocks.pushUpdate).toHaveBeenCalledWith({ isActive: false });
   });
 
@@ -121,6 +129,21 @@ describe('deactivate-account', () => {
     expect(res.statusCode).toBe(502);
     expect(mocks.usersUpdate).not.toHaveBeenCalled();
     expect(mocks.sellerUpdate).not.toHaveBeenCalled();
+    expect(mocks.productsUpdate).not.toHaveBeenCalled();
+    expect(mocks.pushUpdate).not.toHaveBeenCalled();
+  });
+
+  it('reports committed deactivation if seller listing cleanup needs support intervention', async () => {
+    const mocks = installMocks({ role: 'seller', productsUpdateError: { message: 'products unavailable' } });
+    const { handler } = await import('../deactivate-account');
+
+    const res = await handler(makeEvent(), {} as never);
+    const body = JSON.parse(res.body);
+
+    expect(res.statusCode).toBe(500);
+    expect(body.deactivated).toBe(true);
+    expect(mocks.usersUpdate).toHaveBeenCalledWith({ isActive: false });
+    expect(mocks.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'suspended', isPaused: true });
     expect(mocks.pushUpdate).not.toHaveBeenCalled();
   });
 

--- a/netlify/functions/__tests__/seller-activation-active-account.test.ts
+++ b/netlify/functions/__tests__/seller-activation-active-account.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { tryAutoActivateSeller } from '../_shared/sellerActivation';
+
+const completeProfile = {
+  userId: 'seller-1',
+  sellerStatus: 'submitted',
+  activatedAt: null,
+  storeName: 'Seller Store',
+  businessName: 'Seller Ltd',
+  contactPhone: '07123456789',
+  businessAddress: { postcode: 'BB1 1AA' },
+  stripeAccountId: 'acct_123',
+  stripeConnectStatus: 'active',
+  sellerType: 'individual',
+  companyRegistrationNumber: null,
+  vatNumber: null,
+  isVatRegistered: false,
+  requiresAdminApproval: false,
+  isApproved: true,
+};
+
+function client(options: {
+  account?: { role: string; isActive: boolean } | null;
+  accountError?: { message: string } | null;
+  profile?: typeof completeProfile;
+}) {
+  const profile = options.profile ?? completeProfile;
+  const sellerUpdateEq = vi.fn().mockResolvedValue({ error: null });
+  const sellerUpdate = vi.fn(() => ({ eq: sellerUpdateEq }));
+
+  const from = vi.fn((table: string) => {
+    if (table === 'seller_profiles') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            single: vi.fn().mockResolvedValue({ data: profile, error: null }),
+          }),
+        }),
+        update: sellerUpdate,
+      };
+    }
+
+    if (table === 'users') {
+      return {
+        select: vi.fn().mockReturnValue({
+          eq: vi.fn().mockReturnValue({
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: options.account ?? null,
+              error: options.accountError ?? null,
+            }),
+          }),
+        }),
+      };
+    }
+
+    throw new Error(`unexpected table ${table}`);
+  });
+
+  return {
+    api: { from } as unknown as SupabaseClient,
+    sellerUpdate,
+    sellerUpdateEq,
+  };
+}
+
+describe('tryAutoActivateSeller active-account gate', () => {
+  it('fails closed for an inactive live seller account and never promotes the profile', async () => {
+    const c = client({ account: { role: 'seller', isActive: false } });
+
+    const result = await tryAutoActivateSeller(c.api, 'seller-1', 'active');
+
+    expect(result).toMatchObject({
+      sellerStatus: 'suspended',
+      changed: false,
+      firstActivation: false,
+      stripeActive: true,
+    });
+    expect(c.sellerUpdate).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when the live account lookup cannot be trusted', async () => {
+    const c = client({ accountError: { message: 'db unavailable' } });
+
+    const result = await tryAutoActivateSeller(c.api, 'seller-1', 'active');
+
+    expect(result?.sellerStatus).toBe('suspended');
+    expect(result?.firstActivation).toBe(false);
+    expect(c.sellerUpdate).not.toHaveBeenCalled();
+  });
+
+  it('allows an active live seller to transition from submitted to active', async () => {
+    const c = client({ account: { role: 'seller', isActive: true } });
+
+    const result = await tryAutoActivateSeller(c.api, 'seller-1', 'active');
+
+    expect(result).toMatchObject({
+      sellerStatus: 'active',
+      changed: true,
+      firstActivation: true,
+      profileComplete: true,
+      stripeConnected: true,
+      stripeActive: true,
+    });
+    expect(c.sellerUpdate).toHaveBeenCalledWith({ sellerStatus: 'active' });
+    expect(c.sellerUpdateEq).toHaveBeenCalledWith('userId', 'seller-1');
+  });
+});

--- a/netlify/functions/_shared/activeAccountAuth.ts
+++ b/netlify/functions/_shared/activeAccountAuth.ts
@@ -6,6 +6,7 @@ export interface ActiveAccountActor {
   id: string;
   role: string;
   email: string | null;
+  appMetadata: Record<string, unknown>;
 }
 
 export type ActiveAccountAuthResult =
@@ -60,6 +61,7 @@ export async function authenticateActiveAccount(
       id: account.id,
       role: account.role,
       email,
+      appMetadata: (authData.user.app_metadata as Record<string, unknown> | undefined) ?? {},
     },
   };
 }

--- a/netlify/functions/_shared/activeAccountAuth.ts
+++ b/netlify/functions/_shared/activeAccountAuth.ts
@@ -1,0 +1,65 @@
+import type { HandlerEvent } from '@netlify/functions';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getBearerToken } from './http';
+
+export interface ActiveAccountActor {
+  id: string;
+  role: string;
+  email: string | null;
+}
+
+export type ActiveAccountAuthResult =
+  | { ok: true; actor: ActiveAccountActor }
+  | { ok: false; status: 401 | 403 };
+
+/**
+ * Canonical guard for user-authenticated server functions that operate with a
+ * service-role Supabase client. A valid JWT is necessary but is never sufficient:
+ * authorization is always re-read from public.users and the account must be live.
+ *
+ * This closes the stale-access-token window after an account is suspended. RLS
+ * cannot protect service-role operations, so every such boundary must establish
+ * the current account state before touching protected data or performing a write.
+ */
+export async function authenticateActiveAccount(
+  event: HandlerEvent,
+  admin: SupabaseClient,
+  allowedRoles?: readonly string[],
+): Promise<ActiveAccountAuthResult> {
+  const token = getBearerToken(event);
+  if (!token) {
+    return { ok: false, status: 401 };
+  }
+
+  const { data: authData, error: authError } = await admin.auth.getUser(token);
+  if (authError || !authData?.user) {
+    return { ok: false, status: 401 };
+  }
+
+  const { data: account, error: accountError } = await admin
+    .from('users')
+    .select('id, role, isActive')
+    .eq('id', authData.user.id)
+    .maybeSingle<{ id: string; role: string; isActive: boolean }>();
+
+  if (accountError || !account || account.isActive !== true) {
+    return { ok: false, status: 403 };
+  }
+
+  if (allowedRoles && !allowedRoles.includes(account.role)) {
+    return { ok: false, status: 403 };
+  }
+
+  const email = typeof authData.user.email === 'string'
+    ? authData.user.email.toLowerCase().trim() || null
+    : null;
+
+  return {
+    ok: true,
+    actor: {
+      id: account.id,
+      role: account.role,
+      email,
+    },
+  };
+}

--- a/netlify/functions/_shared/adminUserStatus.ts
+++ b/netlify/functions/_shared/adminUserStatus.ts
@@ -339,10 +339,34 @@ export async function applyAdminUserStatus(
   );
   if (auditError) {
     console.error('admin-user-status: reactivate audit failed:', auditError);
+
+    // Audit is part of the privileged state transition, not a best-effort side
+    // effect. Revoke Auth first, then restore the DB suspension state so a failed
+    // audit cannot leave a successfully reactivated but unaudited account.
+    await rebanBestEffort();
+
+    const { error: restoreUserError } = await supabase
+      .from('users')
+      .update({ isActive: false })
+      .eq('id', userId);
+    if (restoreUserError) {
+      console.error('admin-user-status: audit-failure users compensation failed:', restoreUserError.message);
+    }
+
+    if (target.role === 'seller') {
+      const { error: restoreSellerError } = await supabase
+        .from('seller_profiles')
+        .update({ sellerStatus: 'suspended' })
+        .eq('userId', userId);
+      if (restoreSellerError) {
+        console.error('admin-user-status: audit-failure seller compensation failed:', restoreSellerError.message);
+      }
+    }
+
     return {
       ok: false,
       status: 500,
-      body: { error: 'Account is active but audit persistence requires retry' },
+      body: { error: 'Account reactivation failed safely and remains blocked because audit persistence failed' },
     };
   }
 

--- a/netlify/functions/_shared/adminUserStatus.ts
+++ b/netlify/functions/_shared/adminUserStatus.ts
@@ -29,7 +29,7 @@ export type AdminUserStatusResult =
     }
   | {
       ok: false;
-      status: 400 | 403 | 404 | 500 | 502;
+      status: 400 | 403 | 404 | 500 | 502 | 503;
       body: { error: string };
     };
 
@@ -53,6 +53,23 @@ async function writeAdminAudit(
     metadata: { targetRole },
   });
   return error?.message ?? null;
+}
+
+async function requireActiveAccountDbGate(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient<any>,
+): Promise<boolean> {
+  // Runtime can safely ship before migration 608 because suspension is Auth-first.
+  // Reactivation is different: unbanning Auth is safe only after migration 608
+  // makes public.users.isActive the restrictive DB authorization backstop. The
+  // service-role call returns false (no auth.uid()) when installed; existence and
+  // successful execution of the function are the cutover precondition we need.
+  const { error } = await supabase.rpc('is_active_user');
+  if (error) {
+    console.error('admin-user-status: active-account DB gate is not ready:', error.message);
+    return false;
+  }
+  return true;
 }
 
 /**
@@ -199,6 +216,19 @@ export async function applyAdminUserStatus(
         isActive: false,
         ...(target.role === 'seller' ? { sellerStatus: 'suspended' as const } : {}),
       },
+    };
+  }
+
+  // A runtime-first rollout is required to close service-role bypasses before
+  // migration 608. During that interval suspension may operate safely because it
+  // is Auth-first, but reactivation MUST remain unavailable: unbanning an
+  // inactive account before the restrictive DB gate exists would reopen stale
+  // JWT/PostgREST authority. Fail closed until 608 is installed.
+  if (!(await requireActiveAccountDbGate(supabase))) {
+    return {
+      ok: false,
+      status: 503,
+      body: { error: 'Account reactivation is temporarily unavailable until the active-account database gate is installed' },
     };
   }
 

--- a/netlify/functions/_shared/adminUserStatus.ts
+++ b/netlify/functions/_shared/adminUserStatus.ts
@@ -124,17 +124,19 @@ export async function applyAdminUserStatus(
       };
     }
 
+    // After Auth is blocked, every independent cleanup step is attempted. A
+    // seller-state failure must never leave push delivery active, and a push
+    // cleanup failure must not prevent audit persistence for a committed DB ban.
+    const suspensionErrors: string[] = [];
+
     const { error: userError } = await supabase
       .from('users')
       .update({ isActive: false })
       .eq('id', userId);
+    const databaseInactive = !userError;
     if (userError) {
       console.error('admin-user-status: users suspension write failed:', userError.message);
-      return {
-        ok: false,
-        status: 500,
-        body: { error: 'Account is blocked in authentication but database suspension requires retry' },
-      };
+      suspensionErrors.push('database account state');
     }
 
     if (target.role === 'seller') {
@@ -144,11 +146,7 @@ export async function applyAdminUserStatus(
         .eq('userId', userId);
       if (sellerError) {
         console.error('admin-user-status: seller suspension sync failed:', sellerError.message);
-        return {
-          ok: false,
-          status: 500,
-          body: { error: 'Account is suspended but seller status synchronization requires retry' },
-        };
+        suspensionErrors.push('seller state');
       }
     }
 
@@ -159,26 +157,36 @@ export async function applyAdminUserStatus(
       .eq('isActive', true);
     if (pushError) {
       console.error('admin-user-status: push token deactivation failed:', pushError.message);
+      suspensionErrors.push('notification cleanup');
+    }
+
+    if (databaseInactive) {
+      const auditError = await writeAdminAudit(
+        supabase,
+        callerId,
+        'user_suspend',
+        userId,
+        target.role,
+      );
+      if (auditError) {
+        console.error('admin-user-status: suspend audit failed:', auditError);
+        suspensionErrors.push('audit persistence');
+      }
+    }
+
+    if (!databaseInactive) {
       return {
         ok: false,
         status: 500,
-        body: { error: 'Account is suspended but notification cleanup requires retry' },
+        body: { error: 'Account is blocked in authentication but database suspension requires retry' },
       };
     }
 
-    const auditError = await writeAdminAudit(
-      supabase,
-      callerId,
-      'user_suspend',
-      userId,
-      target.role,
-    );
-    if (auditError) {
-      console.error('admin-user-status: suspend audit failed:', auditError);
+    if (suspensionErrors.length > 0) {
       return {
         ok: false,
         status: 500,
-        body: { error: 'Account is suspended but audit persistence requires retry' },
+        body: { error: 'Account is suspended but follow-up cleanup requires retry' },
       };
     }
 

--- a/netlify/functions/_shared/adminUserStatus.ts
+++ b/netlify/functions/_shared/adminUserStatus.ts
@@ -1,0 +1,321 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  deriveSellerStatus,
+  isProfileComplete,
+  type SellerProfileSnapshot,
+} from './sellerActivation';
+
+export const LONG_BAN_DURATION = '876000h';
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export type AdminUserStatusOperation = 'suspend' | 'reactivate';
+
+interface PublicUserRow {
+  id: string;
+  role: string;
+  isActive: boolean;
+}
+
+export type AdminUserStatusResult =
+  | {
+      ok: true;
+      status: 200;
+      body: {
+        ok: true;
+        userId: string;
+        isActive: boolean;
+        sellerStatus?: 'draft' | 'submitted' | 'active' | 'suspended';
+      };
+    }
+  | {
+      ok: false;
+      status: 400 | 403 | 404 | 500 | 502;
+      body: { error: string };
+    };
+
+interface ApplyAdminUserStatusOptions {
+  requiredTargetRole?: string;
+}
+
+async function writeAdminAudit(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient<any>,
+  adminId: string,
+  actionType: string,
+  targetId: string,
+  targetRole: string,
+): Promise<string | null> {
+  const { error } = await supabase.from('admin_actions').insert({
+    adminId,
+    actionType,
+    targetType: 'user',
+    targetId,
+    metadata: { targetRole },
+  });
+  return error?.message ?? null;
+}
+
+/**
+ * Canonical account-status mutation used by every admin surface.
+ *
+ * This function assumes the caller has already been authenticated as a live
+ * admin. It owns the actual suspend/reactivate state transition so legacy admin
+ * surfaces cannot bypass the Auth ban, public.users.isActive, seller state,
+ * push-token cleanup or audit contract.
+ */
+export async function applyAdminUserStatus(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: SupabaseClient<any>,
+  callerId: string,
+  op: AdminUserStatusOperation,
+  userId: string,
+  options: ApplyAdminUserStatusOptions = {},
+): Promise<AdminUserStatusResult> {
+  if (!UUID_RE.test(userId)) {
+    return { ok: false, status: 400, body: { error: 'A valid userId is required' } };
+  }
+  if (op === 'suspend' && userId === callerId) {
+    return { ok: false, status: 400, body: { error: 'You cannot suspend your own admin account' } };
+  }
+
+  const { data: target, error: targetError } = await supabase
+    .from('users')
+    .select('id, role, isActive')
+    .eq('id', userId)
+    .maybeSingle<PublicUserRow>();
+
+  if (targetError) {
+    console.error('admin-user-status: target lookup failed:', targetError.message);
+    return { ok: false, status: 500, body: { error: 'Failed to load target account' } };
+  }
+  if (!target) {
+    return { ok: false, status: 404, body: { error: 'User not found' } };
+  }
+
+  if (options.requiredTargetRole && target.role !== options.requiredTargetRole) {
+    return {
+      ok: false,
+      status: 400,
+      body: { error: `Target account must have role ${options.requiredTargetRole}` },
+    };
+  }
+
+  // Standard admin tooling must not become an admin-recovery mechanism.
+  if (target.role === 'admin') {
+    return {
+      ok: false,
+      status: 403,
+      body: { error: 'Admin account status must be managed through the protected recovery process' },
+    };
+  }
+
+  if (op === 'suspend') {
+    // Security first: revoke Auth before changing database state. A partial
+    // database failure therefore leaves the account blocked, never silently open.
+    const { error: banError } = await supabase.auth.admin.updateUserById(userId, {
+      ban_duration: LONG_BAN_DURATION,
+    });
+    if (banError) {
+      console.error('admin-user-status: Auth ban failed:', banError.message);
+      return {
+        ok: false,
+        status: 502,
+        body: { error: 'Account suspension could not be secured in authentication' },
+      };
+    }
+
+    const { error: userError } = await supabase
+      .from('users')
+      .update({ isActive: false })
+      .eq('id', userId);
+    if (userError) {
+      console.error('admin-user-status: users suspension write failed:', userError.message);
+      return {
+        ok: false,
+        status: 500,
+        body: { error: 'Account is blocked in authentication but database suspension requires retry' },
+      };
+    }
+
+    if (target.role === 'seller') {
+      const { error: sellerError } = await supabase
+        .from('seller_profiles')
+        .update({ sellerStatus: 'suspended' })
+        .eq('userId', userId);
+      if (sellerError) {
+        console.error('admin-user-status: seller suspension sync failed:', sellerError.message);
+        return {
+          ok: false,
+          status: 500,
+          body: { error: 'Account is suspended but seller status synchronization requires retry' },
+        };
+      }
+    }
+
+    const { error: pushError } = await supabase
+      .from('push_tokens')
+      .update({ isActive: false })
+      .eq('userId', userId)
+      .eq('isActive', true);
+    if (pushError) {
+      console.error('admin-user-status: push token deactivation failed:', pushError.message);
+      return {
+        ok: false,
+        status: 500,
+        body: { error: 'Account is suspended but notification cleanup requires retry' },
+      };
+    }
+
+    const auditError = await writeAdminAudit(
+      supabase,
+      callerId,
+      'user_suspend',
+      userId,
+      target.role,
+    );
+    if (auditError) {
+      console.error('admin-user-status: suspend audit failed:', auditError);
+      return {
+        ok: false,
+        status: 500,
+        body: { error: 'Account is suspended but audit persistence requires retry' },
+      };
+    }
+
+    return {
+      ok: true,
+      status: 200,
+      body: {
+        ok: true,
+        userId,
+        isActive: false,
+        ...(target.role === 'seller' ? { sellerStatus: 'suspended' as const } : {}),
+      },
+    };
+  }
+
+  // Unban while public.users remains inactive. Migration 608 keeps direct
+  // PostgREST authority closed until the database activation succeeds.
+  const { error: unbanError } = await supabase.auth.admin.updateUserById(userId, {
+    ban_duration: 'none',
+  });
+  if (unbanError) {
+    console.error('admin-user-status: Auth unban failed:', unbanError.message);
+    return {
+      ok: false,
+      status: 502,
+      body: { error: 'Account reactivation could not be secured in authentication' },
+    };
+  }
+
+  const rebanBestEffort = async () => {
+    const { error } = await supabase.auth.admin.updateUserById(userId, {
+      ban_duration: LONG_BAN_DURATION,
+    });
+    if (error) {
+      console.error('admin-user-status: compensating Auth re-ban failed:', error.message);
+    }
+  };
+
+  let sellerStatus: 'draft' | 'submitted' | 'active' | 'suspended' | undefined;
+
+  if (target.role === 'seller') {
+    const { data: profile, error: profileError } = await supabase
+      .from('seller_profiles')
+      .select(
+        'userId, sellerStatus, storeName, businessName, contactPhone, businessAddress, stripeConnectStatus, sellerType, companyRegistrationNumber, vatNumber, isVatRegistered, requiresAdminApproval, isApproved',
+      )
+      .eq('userId', userId)
+      .maybeSingle<SellerProfileSnapshot>();
+
+    if (profileError || !profile) {
+      await rebanBestEffort();
+      console.error('admin-user-status: seller reactivation profile lookup failed:', profileError?.message);
+      return {
+        ok: false,
+        status: 500,
+        body: { error: 'Account reactivation failed safely and remains blocked' },
+      };
+    }
+
+    // Suspension is sticky inside deriveSellerStatus by design. Admin reactivation
+    // explicitly lifts that sticky state, then derives the seller's legitimate
+    // current status from profile/Stripe/approval readiness instead of blindly
+    // demoting every previously-active seller to `submitted`.
+    const profileComplete = isProfileComplete(profile, profile.sellerType);
+    sellerStatus = deriveSellerStatus(
+      'submitted',
+      profileComplete,
+      profile.stripeConnectStatus === 'active',
+      profile.requiresAdminApproval,
+      profile.isApproved,
+    );
+
+    const { error: sellerError } = await supabase
+      .from('seller_profiles')
+      .update({ sellerStatus })
+      .eq('userId', userId);
+    if (sellerError) {
+      await rebanBestEffort();
+      console.error('admin-user-status: seller reactivation sync failed:', sellerError.message);
+      return {
+        ok: false,
+        status: 500,
+        body: { error: 'Account reactivation failed safely and remains blocked' },
+      };
+    }
+  }
+
+  const { error: userError } = await supabase
+    .from('users')
+    .update({ isActive: true })
+    .eq('id', userId);
+  if (userError) {
+    if (target.role === 'seller') {
+      const { error: restoreError } = await supabase
+        .from('seller_profiles')
+        .update({ sellerStatus: 'suspended' })
+        .eq('userId', userId);
+      if (restoreError) {
+        console.error('admin-user-status: compensating seller re-suspension failed:', restoreError.message);
+      }
+    }
+    await rebanBestEffort();
+    console.error('admin-user-status: users reactivation write failed:', userError.message);
+    return {
+      ok: false,
+      status: 500,
+      body: { error: 'Account reactivation failed safely and remains blocked' },
+    };
+  }
+
+  // Historical push tokens deliberately stay inactive. A successfully
+  // authenticated device must register its current token through the #511 owner
+  // reconciliation boundary.
+  const auditError = await writeAdminAudit(
+    supabase,
+    callerId,
+    'user_reactivate',
+    userId,
+    target.role,
+  );
+  if (auditError) {
+    console.error('admin-user-status: reactivate audit failed:', auditError);
+    return {
+      ok: false,
+      status: 500,
+      body: { error: 'Account is active but audit persistence requires retry' },
+    };
+  }
+
+  return {
+    ok: true,
+    status: 200,
+    body: {
+      ok: true,
+      userId,
+      isActive: true,
+      ...(sellerStatus ? { sellerStatus } : {}),
+    },
+  };
+}

--- a/netlify/functions/_shared/sellerActivation.ts
+++ b/netlify/functions/_shared/sellerActivation.ts
@@ -136,12 +136,6 @@ export interface ActivationResult {
   firstActivation: boolean;
 }
 
-function normalizedStoredSellerStatus(status: string): ActivationResult['sellerStatus'] {
-  return status === 'submitted' || status === 'active' || status === 'suspended'
-    ? status
-    : 'draft';
-}
-
 /**
  * Checks all activation conditions for a seller and updates
  * seller_profiles.sellerStatus if the derived status differs from the stored one.
@@ -213,8 +207,7 @@ export async function tryAutoActivateSeller(
     profile.isApproved,
   );
 
-  const storedStatus = normalizedStoredSellerStatus(profile.sellerStatus);
-  const changed = newStatus !== storedStatus;
+  const changed = newStatus !== profile.sellerStatus;
   // firstActivation: true only if this call transitions the seller to 'active'
   // for the very first time (activatedAt was null before this update).
   // This prevents duplicate admin emails when both the Stripe webhook and a

--- a/netlify/functions/_shared/sellerActivation.ts
+++ b/netlify/functions/_shared/sellerActivation.ts
@@ -2,7 +2,7 @@
  * Shared seller auto-activation helper.
  *
  * A seller's account becomes ACTIVE only when ALL of the following are true:
- *   1. Their role is 'seller'
+ *   1. Their live public.users row has role = 'seller' and isActive = true
  *   2. Profile is complete: business/store name + phone + address postcode
  *      (companies also require companyRegistrationNumber + vatNumber)
  *   3. Stripe Connect account exists (stripeAccountId present)
@@ -136,12 +136,22 @@ export interface ActivationResult {
   firstActivation: boolean;
 }
 
+function normalizedStoredSellerStatus(status: string): ActivationResult['sellerStatus'] {
+  return status === 'submitted' || status === 'active' || status === 'suspended'
+    ? status
+    : 'draft';
+}
+
 /**
  * Checks all activation conditions for a seller and updates
  * seller_profiles.sellerStatus if the derived status differs from the stored one.
  *
  * Safe to call multiple times — only writes to the DB when the status changes.
  * Returns null if the seller profile cannot be found.
+ *
+ * public.users is the account-authorization source of truth. An absent,
+ * non-seller, inactive, or unreadable live account fails closed and can never be
+ * auto-promoted by a Stripe webhook or background/server-side activation path.
  *
  * @param liveStripeConnectStatus - When provided, this live value is used instead
  *   of the DB-stored stripeConnectStatus. Pass this from connect-status.ts so the
@@ -172,11 +182,29 @@ export async function tryAutoActivateSeller(
   }
 
   const profileComplete = isProfileComplete(profile, profile.sellerType);
-  // Use the caller-supplied live value when available so we don't depend on a
-  // DB read that might reflect a stale stripeConnectStatus (e.g., when the
-  // preceding update hasn't committed yet, or failed silently).
   const effectiveStripeConnectStatus = liveStripeConnectStatus ?? profile.stripeConnectStatus;
   const stripeActive = effectiveStripeConnectStatus === 'active';
+
+  const { data: account, error: accountError } = await supabase
+    .from('users')
+    .select('role, isActive')
+    .eq('id', sellerId)
+    .maybeSingle<{ role: string | null; isActive: boolean | null }>();
+
+  if (accountError || !account || account.role !== 'seller' || account.isActive !== true) {
+    if (accountError) {
+      console.warn('tryAutoActivateSeller: live account lookup failed for', sellerId, accountError.message);
+    }
+    return {
+      sellerStatus: 'suspended',
+      profileComplete,
+      stripeConnected: !!profile.stripeAccountId,
+      stripeActive,
+      changed: false,
+      firstActivation: false,
+    };
+  }
+
   const newStatus = deriveSellerStatus(
     profile.sellerStatus,
     profileComplete,
@@ -185,7 +213,8 @@ export async function tryAutoActivateSeller(
     profile.isApproved,
   );
 
-  const changed = newStatus !== profile.sellerStatus;
+  const storedStatus = normalizedStoredSellerStatus(profile.sellerStatus);
+  const changed = newStatus !== storedStatus;
   // firstActivation: true only if this call transitions the seller to 'active'
   // for the very first time (activatedAt was null before this update).
   // This prevents duplicate admin emails when both the Stripe webhook and a

--- a/netlify/functions/admin-orders.ts
+++ b/netlify/functions/admin-orders.ts
@@ -1,5 +1,6 @@
-import { Handler, HandlerEvent } from '@netlify/functions';
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import {
   assessAdminReleaseEligibility,
   enforcePaymentBackedTransition,
@@ -8,18 +9,6 @@ import {
 } from './_shared/orderTransitionGuards';
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
-
-// ── Types ─────────────────────────────────────────────────────────────────────
-
-interface AuthOk {
-  ok: true;
-  caller: { id: string; email: string; role: string };
-}
-interface AuthFail {
-  ok: false;
-  status: number;
-}
-type AuthResult = AuthOk | AuthFail;
 
 interface OrderListRow {
   id: string;
@@ -49,49 +38,6 @@ interface PaymentSessionMetaRow {
   stripePaymentIntent: string | null;
 }
 
-// ── Auth helper ────────────────────────────────────────────────────────────────
-
-async function authenticateAdmin(event: HandlerEvent, admin: SupabaseClient): Promise<AuthResult> {
-  const authHeader = event.headers['authorization'] || event.headers['Authorization'];
-
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return { ok: false, status: 401 };
-  }
-
-  const token = authHeader.substring(7).trim();
-  const { data, error } = await admin.auth.getUser(token);
-
-  if (error || !data?.user) {
-    return { ok: false, status: 401 };
-  }
-
-  const authUser = data.user;
-  const authEmail = (authUser.email || '').toLowerCase().trim();
-
-  if (!authEmail) {
-    return { ok: false, status: 401 };
-  }
-
-  const jwtRole = (authUser.app_metadata as Record<string, unknown> | undefined)?.role;
-  if (jwtRole === 'admin') {
-    return { ok: true, caller: { id: authUser.id, email: authEmail, role: 'admin' } };
-  }
-
-  const { data: dbUser, error: dbError } = await admin
-    .from('users')
-    .select('role')
-    .eq('id', authUser.id)
-    .maybeSingle();
-
-  if (dbError || !dbUser || dbUser.role !== 'admin') {
-    return { ok: false, status: 403 };
-  }
-
-  return { ok: true, caller: { id: authUser.id, email: authEmail, role: dbUser.role } };
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
 function formatDate(iso: string | null | undefined): string {
   if (!iso) return '—';
   return new Date(iso).toLocaleDateString('en-GB', {
@@ -101,10 +47,6 @@ function formatDate(iso: string | null | undefined): string {
   });
 }
 
-// ── Valid order statuses ──────────────────────────────────────────────────────
-// Must match the status values used throughout the platform. Any value not
-// in this set is rejected before hitting the database so that admin tooling
-// cannot silently set arbitrary, platform-breaking status strings.
 const VALID_ORDER_STATUSES = new Set([
   'pending',
   'paid',
@@ -118,11 +60,7 @@ const VALID_ORDER_STATUSES = new Set([
 ]);
 const BLOCKING_LISTING_STATUSES = ['awaiting_payment', 'paid', 'packed', 'shipped', 'delivered', 'completed'];
 
-// ── Handler ───────────────────────────────────────────────────────────────────
-
 export const handler: Handler = async (event) => {
-  // Support both SUPABASE_URL (Netlify dashboard convention) and the VITE_
-  // prefixed variant that build tooling also exports to the environment.
   const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
@@ -138,8 +76,7 @@ export const handler: Handler = async (event) => {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  const auth = await authenticateAdmin(event, admin);
-
+  const auth = await authenticateActiveAccount(event, admin, ['admin']);
   if (!auth.ok) {
     return {
       statusCode: auth.status,
@@ -149,7 +86,6 @@ export const handler: Handler = async (event) => {
   }
 
   try {
-    // ── GET — list all orders ─────────────────────────────────────────────────
     if (event.httpMethod === 'GET') {
       const { data: rows, error: ordersErr } = await admin
         .from('orders')
@@ -161,7 +97,6 @@ export const handler: Handler = async (event) => {
 
       const orderRows = (rows || []) as OrderListRow[];
 
-      // Resolve buyer names from users table
       const buyerIds = [...new Set(orderRows.map((o: { buyerId: string | null }) => o.buyerId).filter((id): id is string => !!id))];
       const buyerNames: Record<string, string> = {};
 
@@ -176,7 +111,6 @@ export const handler: Handler = async (event) => {
         });
       }
 
-      // Resolve product titles in a separate query (avoids FK hint issues with camelCase columns)
       const productIds = [...new Set(orderRows.map((o: { productId: string | null }) => o.productId).filter((id): id is string => !!id))];
       const productTitles: Record<string, string> = {};
       const productMeta = new Map<string, ProductMetaRow>();
@@ -251,7 +185,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // ── POST — update order status ────────────────────────────────────────────
     if (event.httpMethod === 'POST') {
       let body: Record<string, unknown> = {};
       try {
@@ -304,10 +237,6 @@ export const handler: Handler = async (event) => {
           };
         }
 
-        // Cancellation and refund are financial lifecycle operations, not
-        // cosmetic status changes. Keep them on their dedicated, audited paths:
-        // - unpaid/test orders -> release_unpaid_lock
-        // - paid orders -> create-refund (Stripe + transfer reconciliation)
         if (status === 'cancelled') {
           return {
             statusCode: 409,
@@ -370,7 +299,7 @@ export const handler: Handler = async (event) => {
         ) {
           await admin.from('order_events').insert({
             orderId,
-            actorId: auth.caller.id,
+            actorId: auth.actor.id,
             event: 'admin_unpaid_transition_override',
             metadata: {
               reason: overrideReason,
@@ -468,7 +397,7 @@ export const handler: Handler = async (event) => {
 
         await admin.from('order_events').insert({
           orderId,
-          actorId: auth.caller.id,
+          actorId: auth.actor.id,
           event: 'admin_unpaid_lock_release',
           metadata: {
             reason,

--- a/netlify/functions/admin-sellers.ts
+++ b/netlify/functions/admin-sellers.ts
@@ -1,6 +1,6 @@
-import { Handler, HandlerEvent } from '@netlify/functions';
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
-import { getBearerToken } from './_shared/http';
+import { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 
 const ALLOWED_ORIGIN = process.env.VITE_APP_URL || 'https://loadifymarket.co.uk';
 
@@ -12,18 +12,6 @@ const corsHeaders = {
 
 const JSON_HEADERS = { ...corsHeaders, 'Content-Type': 'application/json' };
 
-// ── Types ─────────────────────────────────────────────────────────────────────
-
-interface AuthOk {
-  ok: true;
-  caller: { id: string; email: string; role: string };
-}
-interface AuthFail {
-  ok: false;
-  status: number;
-}
-type AuthResult = AuthOk | AuthFail;
-
 interface SellerRow {
   userId: string;
   name: string;
@@ -33,63 +21,6 @@ interface SellerRow {
   sellerStatus: 'draft' | 'submitted' | 'active' | 'suspended';
   stripeConnectStatus: string | null;
 }
-
-// ── Auth helper ────────────────────────────────────────────────────────────────
-
-async function authenticateAdmin(event: HandlerEvent, admin: SupabaseClient): Promise<AuthResult> {
-  const token = getBearerToken(event);
-  if (!token) {
-    return { ok: false, status: 401 };
-  }
-
-  const { data, error } = await admin.auth.getUser(token);
-
-  if (error || !data?.user) {
-    return { ok: false, status: 401 };
-  }
-
-  const authUser = data.user;
-  const authEmail = (authUser.email || '').toLowerCase().trim();
-
-  if (!authEmail) {
-    return { ok: false, status: 401 };
-  }
-
-  // Fast-path: check app_metadata.role from the JWT claim (set by migration 340
-  // and kept in sync by the auth trigger).  This avoids an extra DB round-trip
-  // and works correctly even when the public.users row has a case mismatch on
-  // the email column.
-  const jwtRole = (authUser.app_metadata as Record<string, unknown> | undefined)?.role;
-  if (jwtRole === 'admin') {
-    return {
-      ok: true,
-      caller: { id: authUser.id, email: authEmail, role: 'admin' },
-    };
-  }
-
-  // Fallback: look up by user ID (not email) for robustness against email
-  // casing differences between auth.users and public.users.
-  const { data: dbUser, error: dbError } = await admin
-    .from('users')
-    .select('role')
-    .eq('id', authUser.id)
-    .maybeSingle();
-
-  if (dbError || !dbUser || dbUser.role !== 'admin') {
-    return { ok: false, status: 403 };
-  }
-
-  return {
-    ok: true,
-    caller: {
-      id: authUser.id,
-      email: authEmail,
-      role: dbUser.role,
-    },
-  };
-}
-
-// ── Helpers ───────────────────────────────────────────────────────────────────
 
 function formatDate(iso: string | null | undefined): string {
   if (!iso) return '—';
@@ -127,7 +58,6 @@ function sellerDisplayName(user: { firstName?: string | null; lastName?: string 
 const FORTY_EIGHT_HOURS_MS = 48 * 60 * 60 * 1000;
 
 export const handler: Handler = async (event) => {
-  // Handle CORS preflight (OPTIONS) before any auth or business logic.
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 204, headers: corsHeaders, body: '' };
   }
@@ -147,8 +77,7 @@ export const handler: Handler = async (event) => {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  const auth = await authenticateAdmin(event, admin);
-
+  const auth = await authenticateActiveAccount(event, admin, ['admin']);
   if (!auth.ok) {
     return {
       statusCode: auth.status,
@@ -160,7 +89,6 @@ export const handler: Handler = async (event) => {
   const appUrl = (process.env.URL || process.env.VITE_APP_URL || 'https://loadifymarket.co.uk').replace(/\/$/, '');
 
   try {
-    // ── GET — list all sellers ────────────────────────────────────────────────
     if (event.httpMethod === 'GET') {
       const { data: rows, error } = await admin
         .from('users')
@@ -211,7 +139,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // ── POST — operations ─────────────────────────────────────────────────────
     if (event.httpMethod === 'POST') {
       let body: Record<string, unknown> = {};
       try {
@@ -227,7 +154,6 @@ export const handler: Handler = async (event) => {
       const op = body.op as string | undefined;
       const userId = body.userId as string | undefined;
 
-      // ── get_seller_detail ──────────────────────────────────────────────────
       if (op === 'get_seller_detail') {
         if (!userId) {
           return {
@@ -246,7 +172,6 @@ export const handler: Handler = async (event) => {
 
         if (userRes.error) throw userRes.error;
 
-        // Count reports on the seller's products
         const productIds = (listingsCountRes.data || []).map((p: { id: string }) => p.id);
         let reportsCount = 0;
         if (productIds.length > 0) {
@@ -283,15 +208,10 @@ export const handler: Handler = async (event) => {
         };
       }
 
-      // ── approve ────────────────────────────────────────────────────────────
       if (op === 'approve') {
         if (!userId) return { statusCode: 400, headers: JSON_HEADERS, body: JSON.stringify({ error: 'userId required' }) };
-        // Set isApproved so the activation pipeline can promote the seller.
         const { error } = await admin.from('seller_profiles').update({ isApproved: true }).eq('userId', userId);
         if (error) throw error;
-        // Re-run the activation pipeline so the seller becomes 'active'
-        // immediately if Stripe and profile requirements are also met, rather
-        // than waiting for the next Stripe webhook or connect-status poll.
         let sellerStatus = 'submitted';
         try {
           const { tryAutoActivateSeller } = await import('./_shared/sellerActivation');
@@ -303,7 +223,6 @@ export const handler: Handler = async (event) => {
         return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ success: true, sellerStatus }) };
       }
 
-      // ── reject ─────────────────────────────────────────────────────────────
       if (op === 'reject') {
         if (!userId) return { statusCode: 400, headers: JSON_HEADERS, body: JSON.stringify({ error: 'userId required' }) };
         const { error } = await admin.from('seller_profiles').update({ sellerStatus: 'suspended' }).eq('userId', userId);
@@ -311,7 +230,6 @@ export const handler: Handler = async (event) => {
         return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ success: true }) };
       }
 
-      // ── suspend ────────────────────────────────────────────────────────────
       if (op === 'suspend') {
         if (!userId) return { statusCode: 400, headers: JSON_HEADERS, body: JSON.stringify({ error: 'userId required' }) };
         const { error } = await admin.from('seller_profiles').update({ sellerStatus: 'suspended' }).eq('userId', userId);
@@ -319,7 +237,6 @@ export const handler: Handler = async (event) => {
         return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ sellerStatus: 'suspended' }) };
       }
 
-      // ── reactivate ─────────────────────────────────────────────────────────
       if (op === 'reactivate') {
         if (!userId) return { statusCode: 400, headers: JSON_HEADERS, body: JSON.stringify({ error: 'userId required' }) };
         const { error } = await admin.from('seller_profiles').update({ sellerStatus: 'submitted' }).eq('userId', userId);
@@ -327,7 +244,6 @@ export const handler: Handler = async (event) => {
         return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ sellerStatus: 'submitted' }) };
       }
 
-      // ── force_activate ─────────────────────────────────────────────────────
       if (op === 'force_activate') {
         if (!userId) return { statusCode: 400, headers: JSON_HEADERS, body: JSON.stringify({ error: 'userId required' }) };
         const { error } = await admin.from('seller_profiles').update({ sellerStatus: 'active', isApproved: true }).eq('userId', userId);
@@ -335,7 +251,6 @@ export const handler: Handler = async (event) => {
         return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ success: true }) };
       }
 
-      // ── warn ───────────────────────────────────────────────────────────────
       if (op === 'warn') {
         if (!userId) return { statusCode: 400, headers: JSON_HEADERS, body: JSON.stringify({ error: 'userId required' }) };
         const { data: u, error: userError } = await admin
@@ -356,7 +271,6 @@ export const handler: Handler = async (event) => {
         return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ success: true }) };
       }
 
-      // ── onboarding_reminder ────────────────────────────────────────────────
       if (op === 'onboarding_reminder') {
         const cutoff = new Date(Date.now() - FORTY_EIGHT_HOURS_MS).toISOString();
         const { data: incomplete, error: qErr } = await admin

--- a/netlify/functions/admin-sellers.ts
+++ b/netlify/functions/admin-sellers.ts
@@ -1,6 +1,8 @@
 import { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
 import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { applyAdminUserStatus } from './_shared/adminUserStatus';
+import { checkRateLimit } from './_shared/rateLimiter';
 
 const ALLOWED_ORIGIN = process.env.VITE_APP_URL || 'https://loadifymarket.co.uk';
 
@@ -230,22 +232,64 @@ export const handler: Handler = async (event) => {
         return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ success: true }) };
       }
 
-      if (op === 'suspend') {
+      if (op === 'suspend' || op === 'reactivate') {
         if (!userId) return { statusCode: 400, headers: JSON_HEADERS, body: JSON.stringify({ error: 'userId required' }) };
-        const { error } = await admin.from('seller_profiles').update({ sellerStatus: 'suspended' }).eq('userId', userId);
-        if (error) throw error;
-        return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ sellerStatus: 'suspended' }) };
-      }
 
-      if (op === 'reactivate') {
-        if (!userId) return { statusCode: 400, headers: JSON_HEADERS, body: JSON.stringify({ error: 'userId required' }) };
-        const { error } = await admin.from('seller_profiles').update({ sellerStatus: 'submitted' }).eq('userId', userId);
-        if (error) throw error;
-        return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ sellerStatus: 'submitted' }) };
+        // Legacy seller-management callers must use the exact same canonical
+        // account-status transition as Admin Users. This prevents a second
+        // sellerStatus-only suspension path from bypassing Auth/users/push state.
+        const rateLimit = await checkRateLimit({
+          supabase: admin,
+          tableName: 'admin_sellers_rate_limits',
+          identifier: auth.actor.id,
+          windowMinutes: 1,
+          maxAttempts: 30,
+          policy: 'fail-closed',
+        });
+        if (rateLimit.exceeded) {
+          return {
+            statusCode: 429,
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ error: 'Too many admin actions. Please try again shortly.' }),
+          };
+        }
+
+        const result = await applyAdminUserStatus(
+          admin,
+          auth.actor.id,
+          op,
+          userId,
+          { requiredTargetRole: 'seller' },
+        );
+        return {
+          statusCode: result.status,
+          headers: JSON_HEADERS,
+          body: JSON.stringify(result.body),
+        };
       }
 
       if (op === 'force_activate') {
         if (!userId) return { statusCode: 400, headers: JSON_HEADERS, body: JSON.stringify({ error: 'userId required' }) };
+
+        // Never allow sellerStatus to contradict an account-level suspension.
+        // Account reactivation must happen through the canonical boundary first.
+        const { data: target, error: targetError } = await admin
+          .from('users')
+          .select('role, isActive')
+          .eq('id', userId)
+          .maybeSingle<{ role: string | null; isActive: boolean | null }>();
+        if (targetError) throw targetError;
+        if (!target || target.role !== 'seller') {
+          return { statusCode: 404, headers: JSON_HEADERS, body: JSON.stringify({ error: 'Seller not found' }) };
+        }
+        if (target.isActive !== true) {
+          return {
+            statusCode: 409,
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ error: 'Reactivate the account before force-activating the seller profile' }),
+          };
+        }
+
         const { error } = await admin.from('seller_profiles').update({ sellerStatus: 'active', isApproved: true }).eq('userId', userId);
         if (error) throw error;
         return { statusCode: 200, headers: JSON_HEADERS, body: JSON.stringify({ success: true }) };
@@ -277,6 +321,7 @@ export const handler: Handler = async (event) => {
           .from('users')
           .select('id, email, firstName, lastName')
           .eq('role', 'seller')
+          .eq('isActive', true)
           .or('onboardingCompleted.eq.false,onboardingCompleted.is.null')
           .lte('createdAt', cutoff);
         if (qErr) throw qErr;

--- a/netlify/functions/admin-user-status.ts
+++ b/netlify/functions/admin-user-status.ts
@@ -1,0 +1,254 @@
+import type { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+import { getBearerToken, jsonResponse, optionsResponse } from './_shared/http';
+import { checkRateLimit } from './_shared/rateLimiter';
+
+const METHODS = 'POST, OPTIONS';
+const LONG_BAN_DURATION = '876000h';
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+type UserStatusOperation = 'suspend' | 'reactivate';
+
+interface RequestBody {
+  op?: unknown;
+  userId?: unknown;
+}
+
+interface PublicUserRow {
+  id: string;
+  role: string;
+  isActive: boolean;
+}
+
+async function writeAdminAudit(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  supabase: any,
+  adminId: string,
+  actionType: string,
+  targetId: string,
+  targetRole: string,
+): Promise<string | null> {
+  const { error } = await supabase.from('admin_actions').insert({
+    adminId,
+    actionType,
+    targetType: 'user',
+    targetId,
+    metadata: { targetRole },
+  });
+  return error?.message ?? null;
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return optionsResponse(METHODS);
+  }
+  if (event.httpMethod !== 'POST') {
+    return jsonResponse(405, { error: 'Method not allowed' }, METHODS);
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    return jsonResponse(500, { error: 'Server configuration error' }, METHODS);
+  }
+
+  const token = getBearerToken(event);
+  if (!token) {
+    return jsonResponse(401, { error: 'Authentication required' }, METHODS);
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // Always validate against Supabase Auth. Banned callers are rejected by the
+  // Auth service even if they still possess a pre-ban access token.
+  const { data: authData, error: authError } = await supabase.auth.getUser(token);
+  if (authError || !authData?.user) {
+    return jsonResponse(401, { error: 'Invalid or expired authentication' }, METHODS);
+  }
+
+  // public.users is the live authorization source of truth. Do not trust a
+  // potentially stale app_metadata role claim for an admin operation.
+  const { data: caller, error: callerError } = await supabase
+    .from('users')
+    .select('id, role, isActive')
+    .eq('id', authData.user.id)
+    .maybeSingle<PublicUserRow>();
+
+  if (callerError || !caller || caller.role !== 'admin' || caller.isActive !== true) {
+    return jsonResponse(403, { error: 'Admin access required' }, METHODS);
+  }
+
+  const rateLimit = await checkRateLimit({
+    supabase,
+    tableName: 'admin_sellers_rate_limits',
+    identifier: caller.id,
+    windowMinutes: 1,
+    maxAttempts: 30,
+    policy: 'fail-closed',
+  });
+  if (rateLimit.exceeded) {
+    return jsonResponse(429, { error: 'Too many admin actions. Please try again shortly.' }, METHODS);
+  }
+
+  let body: RequestBody;
+  try {
+    body = JSON.parse(event.body || '{}') as RequestBody;
+  } catch {
+    return jsonResponse(400, { error: 'Invalid JSON body' }, METHODS);
+  }
+
+  const op = body.op === 'suspend' || body.op === 'reactivate'
+    ? body.op as UserStatusOperation
+    : null;
+  const userId = typeof body.userId === 'string' ? body.userId.trim() : '';
+
+  if (!op) {
+    return jsonResponse(400, { error: 'op must be suspend or reactivate' }, METHODS);
+  }
+  if (!UUID_RE.test(userId)) {
+    return jsonResponse(400, { error: 'A valid userId is required' }, METHODS);
+  }
+  if (op === 'suspend' && userId === caller.id) {
+    return jsonResponse(400, { error: 'You cannot suspend your own admin account' }, METHODS);
+  }
+
+  const { data: target, error: targetError } = await supabase
+    .from('users')
+    .select('id, role, isActive')
+    .eq('id', userId)
+    .maybeSingle<PublicUserRow>();
+
+  if (targetError) {
+    console.error('admin-user-status: target lookup failed:', targetError.message);
+    return jsonResponse(500, { error: 'Failed to load target account' }, METHODS);
+  }
+  if (!target) {
+    return jsonResponse(404, { error: 'User not found' }, METHODS);
+  }
+
+  // Standard Admin Users tooling must not become an admin-recovery mechanism.
+  // With the current single-admin contract this also prevents accidental
+  // lockout of the platform's administrative account.
+  if (target.role === 'admin') {
+    return jsonResponse(403, { error: 'Admin account status must be managed through the protected recovery process' }, METHODS);
+  }
+
+  if (op === 'suspend') {
+    // Security first: ban Auth before changing database state. If a later write
+    // fails, the account remains blocked rather than being silently re-opened.
+    const { error: banError } = await supabase.auth.admin.updateUserById(userId, {
+      ban_duration: LONG_BAN_DURATION,
+    });
+    if (banError) {
+      console.error('admin-user-status: Auth ban failed:', banError.message);
+      return jsonResponse(502, { error: 'Account suspension could not be secured in authentication' }, METHODS);
+    }
+
+    const { error: userError } = await supabase
+      .from('users')
+      .update({ isActive: false })
+      .eq('id', userId);
+    if (userError) {
+      console.error('admin-user-status: users suspension write failed:', userError.message);
+      return jsonResponse(500, { error: 'Account is blocked in authentication but database suspension requires retry' }, METHODS);
+    }
+
+    if (target.role === 'seller') {
+      const { error: sellerError } = await supabase
+        .from('seller_profiles')
+        .update({ sellerStatus: 'suspended' })
+        .eq('userId', userId);
+      if (sellerError) {
+        console.error('admin-user-status: seller suspension sync failed:', sellerError.message);
+        return jsonResponse(500, { error: 'Account is suspended but seller status synchronization requires retry' }, METHODS);
+      }
+    }
+
+    const { error: pushError } = await supabase
+      .from('push_tokens')
+      .update({ isActive: false })
+      .eq('userId', userId)
+      .eq('isActive', true);
+    if (pushError) {
+      console.error('admin-user-status: push token deactivation failed:', pushError.message);
+      return jsonResponse(500, { error: 'Account is suspended but notification cleanup requires retry' }, METHODS);
+    }
+
+    const auditError = await writeAdminAudit(
+      supabase,
+      caller.id,
+      'user_suspend',
+      userId,
+      target.role,
+    );
+    if (auditError) {
+      console.error('admin-user-status: suspend audit failed:', auditError);
+      return jsonResponse(500, { error: 'Account is suspended but audit persistence requires retry' }, METHODS);
+    }
+
+    return jsonResponse(200, { ok: true, userId, isActive: false }, METHODS);
+  }
+
+  // Reactivation starts by unbanning Auth while the database account remains
+  // inactive. Migration 608 therefore keeps direct PostgREST access closed until
+  // the database transition succeeds. If a DB step fails, re-ban as compensation.
+  const { error: unbanError } = await supabase.auth.admin.updateUserById(userId, {
+    ban_duration: 'none',
+  });
+  if (unbanError) {
+    console.error('admin-user-status: Auth unban failed:', unbanError.message);
+    return jsonResponse(502, { error: 'Account reactivation could not be secured in authentication' }, METHODS);
+  }
+
+  const rebanBestEffort = async () => {
+    const { error } = await supabase.auth.admin.updateUserById(userId, {
+      ban_duration: LONG_BAN_DURATION,
+    });
+    if (error) {
+      console.error('admin-user-status: compensating Auth re-ban failed:', error.message);
+    }
+  };
+
+  if (target.role === 'seller') {
+    const { error: sellerError } = await supabase
+      .from('seller_profiles')
+      .update({ sellerStatus: 'submitted' })
+      .eq('userId', userId);
+    if (sellerError) {
+      await rebanBestEffort();
+      console.error('admin-user-status: seller reactivation sync failed:', sellerError.message);
+      return jsonResponse(500, { error: 'Account reactivation failed safely and remains blocked' }, METHODS);
+    }
+  }
+
+  const { error: userError } = await supabase
+    .from('users')
+    .update({ isActive: true })
+    .eq('id', userId);
+  if (userError) {
+    await rebanBestEffort();
+    console.error('admin-user-status: users reactivation write failed:', userError.message);
+    return jsonResponse(500, { error: 'Account reactivation failed safely and remains blocked' }, METHODS);
+  }
+
+  // Deliberately do not reactivate historical push tokens. A successfully
+  // authenticated device must re-register its current token under the #511
+  // ownership boundary.
+  const auditError = await writeAdminAudit(
+    supabase,
+    caller.id,
+    'user_reactivate',
+    userId,
+    target.role,
+  );
+  if (auditError) {
+    // The account is already reactivated; record the operational inconsistency
+    // explicitly instead of pretending the action was fully reconciled.
+    console.error('admin-user-status: reactivate audit failed:', auditError);
+    return jsonResponse(500, { error: 'Account is active but audit persistence requires retry' }, METHODS);
+  }
+
+  return jsonResponse(200, { ok: true, userId, isActive: true }, METHODS);
+};

--- a/netlify/functions/admin-user-status.ts
+++ b/netlify/functions/admin-user-status.ts
@@ -1,41 +1,18 @@
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
-import { getBearerToken, jsonResponse, optionsResponse } from './_shared/http';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import {
+  applyAdminUserStatus,
+  type AdminUserStatusOperation,
+} from './_shared/adminUserStatus';
+import { jsonResponse, optionsResponse } from './_shared/http';
 import { checkRateLimit } from './_shared/rateLimiter';
 
 const METHODS = 'POST, OPTIONS';
-const LONG_BAN_DURATION = '876000h';
-const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
-
-type UserStatusOperation = 'suspend' | 'reactivate';
 
 interface RequestBody {
   op?: unknown;
   userId?: unknown;
-}
-
-interface PublicUserRow {
-  id: string;
-  role: string;
-  isActive: boolean;
-}
-
-async function writeAdminAudit(
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  supabase: any,
-  adminId: string,
-  actionType: string,
-  targetId: string,
-  targetRole: string,
-): Promise<string | null> {
-  const { error } = await supabase.from('admin_actions').insert({
-    adminId,
-    actionType,
-    targetType: 'user',
-    targetId,
-    metadata: { targetRole },
-  });
-  return error?.message ?? null;
 }
 
 export const handler: Handler = async (event) => {
@@ -52,38 +29,25 @@ export const handler: Handler = async (event) => {
     return jsonResponse(500, { error: 'Server configuration error' }, METHODS);
   }
 
-  const token = getBearerToken(event);
-  if (!token) {
-    return jsonResponse(401, { error: 'Authentication required' }, METHODS);
-  }
-
   const supabase = createClient(supabaseUrl, serviceRoleKey, {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  // Always validate against Supabase Auth. Banned callers are rejected by the
-  // Auth service even if they still possess a pre-ban access token.
-  const { data: authData, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !authData?.user) {
-    return jsonResponse(401, { error: 'Invalid or expired authentication' }, METHODS);
-  }
-
-  // public.users is the live authorization source of truth. Do not trust a
-  // potentially stale app_metadata role claim for an admin operation.
-  const { data: caller, error: callerError } = await supabase
-    .from('users')
-    .select('id, role, isActive')
-    .eq('id', authData.user.id)
-    .maybeSingle<PublicUserRow>();
-
-  if (callerError || !caller || caller.role !== 'admin' || caller.isActive !== true) {
-    return jsonResponse(403, { error: 'Admin access required' }, METHODS);
+  // A stale JWT is never sufficient for an administrative mutation. The shared
+  // account guard re-reads public.users and requires a live active admin.
+  const auth = await authenticateActiveAccount(event, supabase, ['admin']);
+  if (!auth.ok) {
+    return jsonResponse(
+      auth.status,
+      { error: auth.status === 401 ? 'Authentication required' : 'Admin access required' },
+      METHODS,
+    );
   }
 
   const rateLimit = await checkRateLimit({
     supabase,
     tableName: 'admin_sellers_rate_limits',
-    identifier: caller.id,
+    identifier: auth.actor.id,
     windowMinutes: 1,
     maxAttempts: 30,
     policy: 'fail-closed',
@@ -99,156 +63,20 @@ export const handler: Handler = async (event) => {
     return jsonResponse(400, { error: 'Invalid JSON body' }, METHODS);
   }
 
-  const op = body.op === 'suspend' || body.op === 'reactivate'
-    ? body.op as UserStatusOperation
-    : null;
+  const op: AdminUserStatusOperation | null =
+    body.op === 'suspend' || body.op === 'reactivate' ? body.op : null;
   const userId = typeof body.userId === 'string' ? body.userId.trim() : '';
 
   if (!op) {
     return jsonResponse(400, { error: 'op must be suspend or reactivate' }, METHODS);
   }
-  if (!UUID_RE.test(userId)) {
-    return jsonResponse(400, { error: 'A valid userId is required' }, METHODS);
-  }
-  if (op === 'suspend' && userId === caller.id) {
-    return jsonResponse(400, { error: 'You cannot suspend your own admin account' }, METHODS);
-  }
 
-  const { data: target, error: targetError } = await supabase
-    .from('users')
-    .select('id, role, isActive')
-    .eq('id', userId)
-    .maybeSingle<PublicUserRow>();
-
-  if (targetError) {
-    console.error('admin-user-status: target lookup failed:', targetError.message);
-    return jsonResponse(500, { error: 'Failed to load target account' }, METHODS);
-  }
-  if (!target) {
-    return jsonResponse(404, { error: 'User not found' }, METHODS);
-  }
-
-  // Standard Admin Users tooling must not become an admin-recovery mechanism.
-  // With the current single-admin contract this also prevents accidental
-  // lockout of the platform's administrative account.
-  if (target.role === 'admin') {
-    return jsonResponse(403, { error: 'Admin account status must be managed through the protected recovery process' }, METHODS);
-  }
-
-  if (op === 'suspend') {
-    // Security first: ban Auth before changing database state. If a later write
-    // fails, the account remains blocked rather than being silently re-opened.
-    const { error: banError } = await supabase.auth.admin.updateUserById(userId, {
-      ban_duration: LONG_BAN_DURATION,
-    });
-    if (banError) {
-      console.error('admin-user-status: Auth ban failed:', banError.message);
-      return jsonResponse(502, { error: 'Account suspension could not be secured in authentication' }, METHODS);
-    }
-
-    const { error: userError } = await supabase
-      .from('users')
-      .update({ isActive: false })
-      .eq('id', userId);
-    if (userError) {
-      console.error('admin-user-status: users suspension write failed:', userError.message);
-      return jsonResponse(500, { error: 'Account is blocked in authentication but database suspension requires retry' }, METHODS);
-    }
-
-    if (target.role === 'seller') {
-      const { error: sellerError } = await supabase
-        .from('seller_profiles')
-        .update({ sellerStatus: 'suspended' })
-        .eq('userId', userId);
-      if (sellerError) {
-        console.error('admin-user-status: seller suspension sync failed:', sellerError.message);
-        return jsonResponse(500, { error: 'Account is suspended but seller status synchronization requires retry' }, METHODS);
-      }
-    }
-
-    const { error: pushError } = await supabase
-      .from('push_tokens')
-      .update({ isActive: false })
-      .eq('userId', userId)
-      .eq('isActive', true);
-    if (pushError) {
-      console.error('admin-user-status: push token deactivation failed:', pushError.message);
-      return jsonResponse(500, { error: 'Account is suspended but notification cleanup requires retry' }, METHODS);
-    }
-
-    const auditError = await writeAdminAudit(
-      supabase,
-      caller.id,
-      'user_suspend',
-      userId,
-      target.role,
-    );
-    if (auditError) {
-      console.error('admin-user-status: suspend audit failed:', auditError);
-      return jsonResponse(500, { error: 'Account is suspended but audit persistence requires retry' }, METHODS);
-    }
-
-    return jsonResponse(200, { ok: true, userId, isActive: false }, METHODS);
-  }
-
-  // Reactivation starts by unbanning Auth while the database account remains
-  // inactive. Migration 608 therefore keeps direct PostgREST access closed until
-  // the database transition succeeds. If a DB step fails, re-ban as compensation.
-  const { error: unbanError } = await supabase.auth.admin.updateUserById(userId, {
-    ban_duration: 'none',
-  });
-  if (unbanError) {
-    console.error('admin-user-status: Auth unban failed:', unbanError.message);
-    return jsonResponse(502, { error: 'Account reactivation could not be secured in authentication' }, METHODS);
-  }
-
-  const rebanBestEffort = async () => {
-    const { error } = await supabase.auth.admin.updateUserById(userId, {
-      ban_duration: LONG_BAN_DURATION,
-    });
-    if (error) {
-      console.error('admin-user-status: compensating Auth re-ban failed:', error.message);
-    }
-  };
-
-  if (target.role === 'seller') {
-    const { error: sellerError } = await supabase
-      .from('seller_profiles')
-      .update({ sellerStatus: 'submitted' })
-      .eq('userId', userId);
-    if (sellerError) {
-      await rebanBestEffort();
-      console.error('admin-user-status: seller reactivation sync failed:', sellerError.message);
-      return jsonResponse(500, { error: 'Account reactivation failed safely and remains blocked' }, METHODS);
-    }
-  }
-
-  const { error: userError } = await supabase
-    .from('users')
-    .update({ isActive: true })
-    .eq('id', userId);
-  if (userError) {
-    await rebanBestEffort();
-    console.error('admin-user-status: users reactivation write failed:', userError.message);
-    return jsonResponse(500, { error: 'Account reactivation failed safely and remains blocked' }, METHODS);
-  }
-
-  // Deliberately do not reactivate historical push tokens. A successfully
-  // authenticated device must re-register its current token under the #511
-  // ownership boundary.
-  const auditError = await writeAdminAudit(
+  const result = await applyAdminUserStatus(
     supabase,
-    caller.id,
-    'user_reactivate',
+    auth.actor.id,
+    op,
     userId,
-    target.role,
   );
-  if (auditError) {
-    // The account is already reactivated; record the operational inconsistency
-    // explicitly instead of pretending the action was fully reconciled.
-    console.error('admin-user-status: reactivate audit failed:', auditError);
-    return jsonResponse(500, { error: 'Account is active but audit persistence requires retry' }, METHODS);
-  }
 
-  return jsonResponse(200, { ok: true, userId, isActive: true }, METHODS);
+  return jsonResponse(result.status, result.body, METHODS);
 };

--- a/netlify/functions/confirm-delivery.ts
+++ b/netlify/functions/confirm-delivery.ts
@@ -6,6 +6,7 @@
  *
  * Security:
  *   – Requires Authorization: Bearer <buyer-jwt>
+ *   – Caller must still be an active platform account
  *   – Order must belong to the authenticated buyer
  *   – Order must be in a releasable status: 'shipped' or 'delivered'
  *   – Uses service-role client for the DB write so RLS cannot be bypassed
@@ -17,6 +18,7 @@
 
 import { createClient } from '@supabase/supabase-js';
 import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 
 const RELEASABLE_STATUSES = new Set(['shipped', 'delivered']);
 
@@ -48,19 +50,20 @@ export const handler: Handler = async (event) => {
     return { statusCode: 500, headers: corsHeaders, body: JSON.stringify({ error: 'Server configuration error' }) };
   }
 
-  // ── Authenticate caller ───────────────────────────────────────────────────
-  const authHeader = event.headers['authorization'] || event.headers['Authorization'];
-  const token = authHeader?.replace(/^Bearer\s+/i, '').trim();
-  if (!token) {
-    return { statusCode: 401, headers: corsHeaders, body: JSON.stringify({ error: 'Unauthorized' }) };
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const auth = await authenticateActiveAccount(event, supabase);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: auth.status === 401 ? 'Unauthorized' : 'Account is suspended' }),
+    };
   }
 
-  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
-
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !user) {
-    return { statusCode: 401, headers: corsHeaders, body: JSON.stringify({ error: 'Invalid or expired token' }) };
-  }
+  const buyerId = auth.actor.id;
 
   // ── Parse body ────────────────────────────────────────────────────────────
   let orderId: string | undefined;
@@ -100,7 +103,7 @@ export const handler: Handler = async (event) => {
   }
 
   // Must be the buyer's own order
-  if (order.buyerId !== user.id) {
+  if (order.buyerId !== buyerId) {
     return { statusCode: 403, headers: corsHeaders, body: JSON.stringify({ error: 'Forbidden' }) };
   }
 

--- a/netlify/functions/connect-dashboard.ts
+++ b/netlify/functions/connect-dashboard.ts
@@ -1,16 +1,13 @@
 import Stripe from 'stripe';
 import { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 
 /**
  * POST /.netlify/functions/connect-dashboard
  *
- * Returns { url } — a short-lived Stripe Express dashboard login link for
- * the authenticated seller. Opens the seller's Stripe Express dashboard in
- * a new tab where they can view payouts, balance, and account settings.
- *
- * Requires: Authorization: Bearer <supabase-jwt>
- * Seller must have already completed Connect onboarding (stripeAccountId set).
+ * Returns { url } — a short-lived Stripe Express dashboard login link for the
+ * authenticated active seller.
  */
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== 'POST') {
@@ -28,37 +25,26 @@ export const handler: Handler = async (event) => {
     return { statusCode: 500, body: JSON.stringify({ error: 'Database not configured' }) };
   }
 
-  const authHeader = event.headers['authorization'] || event.headers['Authorization'];
-  const token = authHeader?.replace('Bearer ', '').trim();
-  if (!token) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required' }) };
-  }
-
-  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+  const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
   const stripe = new Stripe(stripeSecretKey, { apiVersion: '2025-08-27.basil' });
 
-  // Stripe key is present and loaded (do not log any part of the key).
-
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !user) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Invalid or expired token' }) };
+  const auth = await authenticateActiveAccount(event, supabase, ['seller']);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({ error: auth.status === 401 ? 'Authentication required' : 'Active seller account required' }),
+    };
   }
 
-  // Only sellers may access the Express dashboard.
-  const { data: userRow } = await supabase
-    .from('users')
-    .select('role')
-    .eq('id', user.id)
-    .single<{ role: string }>();
-  if (userRow?.role !== 'seller') {
-    return { statusCode: 403, body: JSON.stringify({ error: 'Seller account required' }) };
-  }
+  const sellerId = auth.actor.id;
 
   try {
     const { data: profile } = await supabase
       .from('seller_profiles')
       .select('stripeAccountId')
-      .eq('userId', user.id)
+      .eq('userId', sellerId)
       .single<{ stripeAccountId: string | null }>();
 
     if (!profile?.stripeAccountId) {
@@ -68,10 +54,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // ── Stale-account guard ─────────────────────────────────────────────────
-    // If the platform migrated to a new Stripe account, the seller's saved
-    // account ID won't exist on the new platform. Detect this early so the
-    // caller receives a 404 instead of an opaque Stripe error.
     try {
       await stripe.accounts.retrieve(profile.stripeAccountId);
     } catch (retrieveError) {
@@ -79,13 +61,12 @@ export const handler: Handler = async (event) => {
         retrieveError instanceof Stripe.errors.StripeInvalidRequestError &&
         /no such account/i.test(retrieveError.message)
       ) {
-        console.warn(
-          `connect-dashboard: stripeAccountId ${profile.stripeAccountId} not found on current platform — clearing stale record for user ${user.id}`
-        );
-        await supabase
+        console.warn(`connect-dashboard: stored Stripe account is not on current platform; clearing stale record for user ${sellerId}`);
+        const { error: clearError } = await supabase
           .from('seller_profiles')
           .update({ stripeAccountId: null, stripeConnectStatus: null })
-          .eq('userId', user.id);
+          .eq('userId', sellerId);
+        if (clearError) throw clearError;
         return {
           statusCode: 404,
           body: JSON.stringify({ error: 'No Stripe account connected. Please complete onboarding first.' }),
@@ -93,7 +74,6 @@ export const handler: Handler = async (event) => {
       }
       throw retrieveError;
     }
-    // ────────────────────────────────────────────────────────────────────────
 
     const loginLink = await stripe.accounts.createLoginLink(profile.stripeAccountId);
 
@@ -104,7 +84,6 @@ export const handler: Handler = async (event) => {
   } catch (error) {
     console.error('connect-dashboard error:', error);
 
-    // Detect when the platform Stripe account has not enrolled in Connect.
     if (
       error instanceof Stripe.errors.StripeInvalidRequestError &&
       (/signed up for connect/i.test(error.message) ||
@@ -114,10 +93,7 @@ export const handler: Handler = async (event) => {
       return {
         statusCode: 503,
         body: JSON.stringify({
-          error:
-            'Stripe Connect is not yet enabled on this platform. ' +
-            'The marketplace owner must activate Stripe Connect at ' +
-            'https://dashboard.stripe.com/connect/accounts/overview.',
+          error: 'Stripe Connect is not yet enabled on this platform.',
           platformNotConfigured: true,
         }),
       };

--- a/netlify/functions/connect-onboard.ts
+++ b/netlify/functions/connect-onboard.ts
@@ -1,20 +1,14 @@
 import Stripe from 'stripe';
 import { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { checkRateLimit } from './_shared/rateLimiter';
 
 /**
  * POST /.netlify/functions/connect-onboard
  *
  * Creates (or resumes) a Stripe Connect Express onboarding session for the
- * authenticated seller. Returns { url } — the caller should redirect the
- * seller's browser to that URL to complete Stripe's hosted onboarding flow.
- *
- * After completion Stripe redirects to:
- *   return_url  → /seller/setup?connect=success
- *   refresh_url → /seller/setup?connect=refresh  (link expired / back btn)
- *
- * Requires: Authorization: Bearer <supabase-jwt>
+ * authenticated active seller. Returns { url }.
  */
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== 'POST') {
@@ -32,36 +26,24 @@ export const handler: Handler = async (event) => {
     return { statusCode: 500, body: JSON.stringify({ error: 'Database not configured' }) };
   }
 
-  const authHeader = event.headers['authorization'] || event.headers['Authorization'];
-  const token = authHeader?.replace('Bearer ', '').trim();
-  if (!token) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required' }) };
-  }
-
-  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+  const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
   const stripe = new Stripe(stripeSecretKey, { apiVersion: '2025-08-27.basil' });
 
-  // Stripe key is present and loaded (do not log any part of the key).
-
-  // Verify the JWT and derive the seller's user ID from it.
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !user) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Invalid or expired token' }) };
+  // Stripe onboarding can create external financial accounts and persist their
+  // identifiers through service_role. Require the seller to be active now, not
+  // merely in possession of a still-valid access token.
+  const auth = await authenticateActiveAccount(event, supabase, ['seller']);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({ error: auth.status === 401 ? 'Authentication required' : 'Active seller account required' }),
+    };
   }
 
-  // Only sellers may initiate Connect onboarding.
-  const { data: userRow } = await supabase
-    .from('users')
-    .select('role')
-    .eq('id', user.id)
-    .maybeSingle<{ role: string }>();
-  if (userRow?.role !== 'seller') {
-    return { statusCode: 403, body: JSON.stringify({ error: 'Seller account required' }) };
-  }
+  const sellerId = auth.actor.id;
 
-  const sellerId = user.id;
-
-  // ── Rate limiting: 5 onboarding link requests per seller per hour ─────────
   const rl = await checkRateLimit({
     supabase,
     tableName: 'connect_onboard_rate_limits',
@@ -75,10 +57,8 @@ export const handler: Handler = async (event) => {
       body: JSON.stringify({ error: 'Too many onboarding requests. Please try again later.' }),
     };
   }
-  // ─────────────────────────────────────────────────────────────────────────
 
   try {
-    // Look up any existing Stripe account stored for this seller.
     const { data: profile, error: profileError } = await supabase
       .from('seller_profiles')
       .select('stripeAccountId, stripeConnectStatus')
@@ -93,13 +73,8 @@ export const handler: Handler = async (event) => {
       return { statusCode: 404, body: JSON.stringify({ error: 'Seller profile not found. Please contact support if you believe this is an error.' }) };
     }
 
-    let stripeAccountId = profile?.stripeAccountId ?? null;
+    let stripeAccountId = profile.stripeAccountId ?? null;
 
-    // ── Stale-account guard ─────────────────────────────────────────────────
-    // If the platform migrated to a new Stripe account, any Express accounts
-    // created on the old platform will return "No such account" on the new
-    // API key. Detect this and clear the stale ID so the seller can re-onboard
-    // from scratch on the current platform.
     if (stripeAccountId) {
       try {
         await stripe.accounts.retrieve(stripeAccountId);
@@ -108,33 +83,25 @@ export const handler: Handler = async (event) => {
           retrieveError instanceof Stripe.errors.StripeInvalidRequestError &&
           /no such account/i.test(retrieveError.message)
         ) {
-          console.warn(
-            `connect-onboard: stripeAccountId ${stripeAccountId} not found on current platform — clearing stale record for seller ${sellerId}`
-          );
+          console.warn(`connect-onboard: stored Stripe account is not on current platform; clearing stale record for seller ${sellerId}`);
           stripeAccountId = null;
-          await supabase
+          const { error: clearError } = await supabase
             .from('seller_profiles')
             .update({ stripeAccountId: null, stripeConnectStatus: null })
             .eq('userId', sellerId);
+          if (clearError) throw clearError;
         } else {
           throw retrieveError;
         }
       }
     }
-    // ────────────────────────────────────────────────────────────────────────
 
     if (!stripeAccountId) {
-      // Fetch the seller's email to pre-fill the Express account.
-      const { data: sellerUser } = await supabase
-        .from('users')
-        .select('email')
-        .eq('id', sellerId)
-        .maybeSingle<{ email: string }>();
-
+      const sellerEmail = auth.actor.email;
       const account = await stripe.accounts.create({
         type: 'express',
         country: 'GB',
-        ...(sellerUser?.email ? { email: sellerUser.email } : {}),
+        ...(sellerEmail ? { email: sellerEmail } : {}),
         capabilities: {
           card_payments: { requested: true },
           transfers: { requested: true },
@@ -151,11 +118,13 @@ export const handler: Handler = async (event) => {
 
       stripeAccountId = account.id;
 
-      // Persist immediately so we can resume onboarding if the link expires.
-      await supabase
+      const { error: persistError } = await supabase
         .from('seller_profiles')
         .update({ stripeAccountId, stripeConnectStatus: 'pending' })
         .eq('userId', sellerId);
+      if (persistError) {
+        throw new Error(`Failed to persist Stripe onboarding account: ${persistError.message}`);
+      }
     }
 
     const appUrl = (process.env.URL || process.env.VITE_APP_URL || 'https://loadifymarket.co.uk').replace(/\/$/, '');
@@ -174,12 +143,6 @@ export const handler: Handler = async (event) => {
   } catch (error) {
     console.error('connect-onboard error:', error);
 
-    // Detect when the platform Stripe account has not enrolled in Connect.
-    // Stripe returns an InvalidRequestError with a message containing
-    // "signed up for Connect" or similar variants in this case.
-    // This fires when either accounts.create() or accountLinks.create() is
-    // rejected because the STRIPE_SECRET_KEY belongs to an account that is
-    // not a Connect platform.
     if (
       error instanceof Stripe.errors.StripeInvalidRequestError &&
       (/signed up for connect/i.test(error.message) ||
@@ -189,11 +152,7 @@ export const handler: Handler = async (event) => {
       return {
         statusCode: 503,
         body: JSON.stringify({
-          error:
-            'Stripe Connect is not yet enabled on this platform. ' +
-            'The marketplace owner must activate Stripe Connect by visiting ' +
-            'https://dashboard.stripe.com/connect/accounts/overview and completing ' +
-            'the platform onboarding before sellers can connect their accounts.',
+          error: 'Stripe Connect is not yet enabled on this platform.',
           platformNotConfigured: true,
         }),
       };

--- a/netlify/functions/connect-platform-check.ts
+++ b/netlify/functions/connect-platform-check.ts
@@ -1,18 +1,13 @@
 import Stripe from 'stripe';
 import { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 
 /**
  * POST /.netlify/functions/connect-platform-check
  *
  * Admin-only endpoint that verifies whether the platform Stripe account has
- * enrolled in Stripe Connect. Returns { platformConfigured: boolean }.
- *
- * Called by the admin dashboard to surface a warning when Connect is not yet
- * enabled so the platform owner can take action before sellers attempt to
- * onboard and receive confusing error messages.
- *
- * Requires: Authorization: Bearer <supabase-jwt> (admin role)
+ * enrolled in Stripe Connect. No secret-key material is returned to the client.
  */
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== 'POST') {
@@ -30,43 +25,23 @@ export const handler: Handler = async (event) => {
     return { statusCode: 500, body: JSON.stringify({ error: 'Database not configured' }) };
   }
 
-  const authHeader = event.headers['authorization'] || event.headers['Authorization'];
-  const token = authHeader?.replace('Bearer ', '').trim();
-  if (!token) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required' }) };
-  }
+  const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
 
-  const supabase = createClient(supabaseUrl, supabaseServiceKey);
-
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !user) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Invalid or expired token' }) };
-  }
-
-  // Verify the caller is an admin.
-  const { data: userRow } = await supabase
-    .from('users')
-    .select('role')
-    .eq('id', user.id)
-    .single<{ role: string }>();
-
-  if (userRow?.role !== 'admin') {
-    return { statusCode: 403, body: JSON.stringify({ error: 'Admin access required' }) };
+  const auth = await authenticateActiveAccount(event, supabase, ['admin']);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({ error: auth.status === 401 ? 'Authentication required' : 'Admin access required' }),
+    };
   }
 
   const stripe = new Stripe(stripeSecretKey, { apiVersion: '2025-08-27.basil' });
 
-  // Safe key prefix: first 12 characters (e.g. "sk_live_XXXX") — never the full secret.
-  const keyPrefix = stripeSecretKey.slice(0, 12) + '…';
-
   try {
-    // stripe.accounts.list() is only available to Connect platforms.
-    // A successful response (even with an empty list) confirms the platform
-    // account has enrolled in Stripe Connect.
     await stripe.accounts.list({ limit: 1 });
 
-    // Also retrieve the platform account ID so the admin can confirm which
-    // Stripe account is active without needing to see the secret key.
     let platformAccountId: string | null = null;
     try {
       const platformAccount = await stripe.account.retrieve();
@@ -77,10 +52,9 @@ export const handler: Handler = async (event) => {
 
     return {
       statusCode: 200,
-      body: JSON.stringify({ platformConfigured: true, keyPrefix, platformAccountId }),
+      body: JSON.stringify({ platformConfigured: true, platformAccountId }),
     };
   } catch (error) {
-    // Detect the specific "not signed up for Connect" error from Stripe.
     if (
       error instanceof Stripe.errors.StripeInvalidRequestError &&
       (/signed up for connect/i.test(error.message) ||
@@ -91,7 +65,6 @@ export const handler: Handler = async (event) => {
         statusCode: 200,
         body: JSON.stringify({
           platformConfigured: false,
-          keyPrefix,
           setupUrl: 'https://dashboard.stripe.com/connect/accounts/overview',
         }),
       };

--- a/netlify/functions/connect-status.ts
+++ b/netlify/functions/connect-status.ts
@@ -1,19 +1,13 @@
 import Stripe from 'stripe';
 import { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 
 /**
  * POST /.netlify/functions/connect-status
  *
- * Fetches the live Stripe Connect account status for the authenticated seller
- * and persists the result in seller_profiles.stripeConnectStatus. Called by
- * the seller dashboard when the seller returns from Stripe onboarding
- * (?connect=success | ?connect=refresh) or when they open the payouts tab.
- *
- * Returns:
- *   { stripeConnectStatus, chargesEnabled, payoutsEnabled, detailsSubmitted }
- *
- * Requires: Authorization: Bearer <supabase-jwt>
+ * Fetches the live Stripe Connect account status for the authenticated active
+ * seller and persists the result in seller_profiles.stripeConnectStatus.
  */
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== 'POST') {
@@ -31,44 +25,34 @@ export const handler: Handler = async (event) => {
     return { statusCode: 500, body: JSON.stringify({ error: 'Database not configured' }) };
   }
 
-  const authHeader = event.headers['authorization'] || event.headers['Authorization'];
-  const token = authHeader?.replace('Bearer ', '').trim();
-  if (!token) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required' }) };
-  }
-
-  const supabase = createClient(supabaseUrl, supabaseServiceKey);
+  const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
   const stripe = new Stripe(stripeSecretKey, { apiVersion: '2025-08-27.basil' });
 
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !user) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Invalid or expired token' }) };
+  const auth = await authenticateActiveAccount(event, supabase, ['seller']);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({ error: auth.status === 401 ? 'Authentication required' : 'Active seller account required' }),
+    };
   }
 
-  // Only sellers may poll their own Connect status.
-  const { data: userRow } = await supabase
-    .from('users')
-    .select('role')
-    .eq('id', user.id)
-    .single<{ role: string }>();
-  if (userRow?.role !== 'seller') {
-    return { statusCode: 403, body: JSON.stringify({ error: 'Seller account required' }) };
-  }
+  const sellerId = auth.actor.id;
 
   try {
     const { data: profile } = await supabase
       .from('seller_profiles')
       .select('stripeAccountId')
-      .eq('userId', user.id)
+      .eq('userId', sellerId)
       .single<{ stripeAccountId: string | null }>();
 
     if (!profile?.stripeAccountId) {
-      // No Stripe account yet — check profile completeness and return current status.
       let sellerStatus: string | null = null;
       let profileComplete = false;
       try {
         const { tryAutoActivateSeller } = await import('./_shared/sellerActivation');
-        const result = await tryAutoActivateSeller(supabase, user.id);
+        const result = await tryAutoActivateSeller(supabase, sellerId);
         if (result) {
           sellerStatus = result.sellerStatus;
           profileComplete = result.profileComplete;
@@ -86,20 +70,16 @@ export const handler: Handler = async (event) => {
     try {
       account = await stripe.accounts.retrieve(profile.stripeAccountId);
     } catch (retrieveError) {
-      // If the account doesn't exist on THIS platform (e.g. after a platform
-      // migration to a new Stripe account), clear the stale record so the
-      // seller can re-onboard from scratch.
       if (
         retrieveError instanceof Stripe.errors.StripeInvalidRequestError &&
         /no such account/i.test(retrieveError.message)
       ) {
-        console.warn(
-          `connect-status: stripeAccountId ${profile.stripeAccountId} not found on current platform — clearing stale record for user ${user.id}`
-        );
-        await supabase
+        console.warn(`connect-status: stored Stripe account is not on current platform; clearing stale record for user ${sellerId}`);
+        const { error: clearError } = await supabase
           .from('seller_profiles')
           .update({ stripeAccountId: null, stripeConnectStatus: null })
-          .eq('userId', user.id);
+          .eq('userId', sellerId);
+        if (clearError) throw clearError;
         return {
           statusCode: 200,
           body: JSON.stringify({ stripeConnectStatus: null }),
@@ -117,54 +97,33 @@ export const handler: Handler = async (event) => {
       stripeConnectStatus = 'pending';
     }
 
-    // Persist the refreshed status and granular Stripe flags so the dashboard
-    // doesn't need to poll Stripe and onboarding completion can be computed.
     const stripeUpdate: Record<string, unknown> = {
       stripeConnectStatus,
       stripeChargesEnabled: account.charges_enabled,
       stripePayoutsEnabled: account.payouts_enabled,
       stripeDetailsSubmitted: account.details_submitted,
     };
-    // storeCreated: when Stripe is active the seller has completed KYC and
-    // confirmed their identity. We treat this as store-created because the
-    // /onboarding wizard sends sellers through Stripe before store setup.
-    // Sellers who complete Stripe without filling store details will have
-    // the flag set to true but can still continue filling in store details
-    // via /seller/profile — the checklist shows the remaining items.
     if (stripeConnectStatus === 'active') {
       stripeUpdate.storeCreated = true;
     }
     const { error: stripeStatusUpdateError } = await supabase
       .from('seller_profiles')
       .update(stripeUpdate)
-      .eq('userId', user.id);
+      .eq('userId', sellerId);
 
     if (stripeStatusUpdateError) {
-      // Non-fatal: log and continue. tryAutoActivateSeller will use the live
-      // stripeConnectStatus value passed below, so activation still proceeds.
-      console.warn(
-        'connect-status: failed to persist stripeConnectStatus for',
-        user.id,
-        stripeStatusUpdateError.message,
-      );
+      console.warn('connect-status: failed to persist stripeConnectStatus for', sellerId, stripeStatusUpdateError.message);
     }
 
-    // ── Auto-activation check ──────────────────────────────────────────────
-    // After updating stripeConnectStatus, re-evaluate whether the seller now
-    // meets all activation conditions.  tryAutoActivateSeller only writes to
-    // the DB when the derived status differs from the stored one.
-    // Pass the live stripeConnectStatus so activation doesn't depend on the DB
-    // having persisted the preceding update (guards against silent failures).
     let sellerStatus: string | null = null;
     let profileComplete = false;
     try {
       const { tryAutoActivateSeller } = await import('./_shared/sellerActivation');
-      const result = await tryAutoActivateSeller(supabase, user.id, stripeConnectStatus);
+      const result = await tryAutoActivateSeller(supabase, sellerId, stripeConnectStatus);
       if (result) {
         sellerStatus = result.sellerStatus;
         profileComplete = result.profileComplete;
 
-        // Send notifications if seller just became active for the first time
         if (result.firstActivation) {
           const adminEmail = process.env.ADMIN_NOTIFICATION_EMAIL;
           const appUrl = (process.env.URL || process.env.VITE_APP_URL || 'https://loadifymarket.co.uk').replace(/\/$/, '');
@@ -174,7 +133,6 @@ export const handler: Handler = async (event) => {
             ...(process.env.NETLIFY_INTERNAL_SECRET ? { 'x-internal-secret': process.env.NETLIFY_INTERNAL_SECRET } : {}),
           };
 
-          // Notify admin
           if (adminEmail) {
             fetch(`${appUrl}/.netlify/functions/send-email`, {
               method: 'POST',
@@ -190,13 +148,12 @@ export const handler: Handler = async (event) => {
             );
           }
 
-          // Notify the seller themselves
-          if (user.email) {
+          if (auth.actor.email) {
             fetch(`${appUrl}/.netlify/functions/send-email`, {
               method: 'POST',
               headers: internalHeaders,
               body: JSON.stringify({
-                to: user.email,
+                to: auth.actor.email,
                 subject: 'Your Loadify Market store is now live!',
                 template: 'seller_account_active',
                 data: { activatedAt },
@@ -208,10 +165,8 @@ export const handler: Handler = async (event) => {
         }
       }
     } catch (activationError) {
-      // Non-fatal: Stripe status was already updated above.
       console.warn('connect-status: auto-activation check failed (non-fatal):', activationError);
     }
-    // ──────────────────────────────────────────────────────────────────────
 
     return {
       statusCode: 200,
@@ -227,7 +182,6 @@ export const handler: Handler = async (event) => {
   } catch (error) {
     console.error('connect-status error:', error);
 
-    // Detect when the platform Stripe account has not enrolled in Connect.
     if (
       error instanceof Stripe.errors.StripeInvalidRequestError &&
       (/signed up for connect/i.test(error.message) ||
@@ -237,8 +191,7 @@ export const handler: Handler = async (event) => {
       return {
         statusCode: 503,
         body: JSON.stringify({
-          error:
-            'Stripe Connect is not yet enabled on this platform.',
+          error: 'Stripe Connect is not yet enabled on this platform.',
           platformNotConfigured: true,
         }),
       };

--- a/netlify/functions/conversation-get-or-create.ts
+++ b/netlify/functions/conversation-get-or-create.ts
@@ -10,6 +10,7 @@
 
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 
 interface RequestBody {
   productId?: string;
@@ -39,19 +40,17 @@ export const handler: Handler = async (event) => {
   }
 
   const supabase = createClient(supabaseUrl, serviceRoleKey, {
-    auth: { persistSession: false },
+    auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  const authHeader = event.headers.authorization ?? '';
-  if (!authHeader.startsWith('Bearer ')) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required' }) };
+  const auth = await authenticateActiveAccount(event, supabase);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({ error: auth.status === 401 ? 'Authentication required' : 'Account is suspended' }),
+    };
   }
-
-  const token = authHeader.slice(7);
-  const { data: { user: authUser }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !authUser) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Invalid authentication token' }) };
-  }
+  const callerId = auth.actor.id;
 
   let body: RequestBody;
   try {
@@ -67,7 +66,7 @@ export const handler: Handler = async (event) => {
   if (!sellerId || typeof sellerId !== 'string') {
     return { statusCode: 400, body: JSON.stringify({ error: 'sellerId is required' }) };
   }
-  if (authUser.id === sellerId) {
+  if (callerId === sellerId) {
     return { statusCode: 400, body: JSON.stringify({ error: 'You cannot message your own listing' }) };
   }
 
@@ -92,8 +91,8 @@ export const handler: Handler = async (event) => {
     .select('id')
     .eq('productId', productId)
     .or(
-      `and(user1Id.eq.${authUser.id},user2Id.eq.${sellerId}),` +
-      `and(user1Id.eq.${sellerId},user2Id.eq.${authUser.id})`
+      `and(user1Id.eq.${callerId},user2Id.eq.${sellerId}),` +
+      `and(user1Id.eq.${sellerId},user2Id.eq.${callerId})`
     )
     .maybeSingle<ConversationRow>();
 
@@ -107,7 +106,7 @@ export const handler: Handler = async (event) => {
   const { data: created, error: createError } = await supabase
     .from('conversations')
     .insert({
-      user1Id: authUser.id,
+      user1Id: callerId,
       user2Id: sellerId,
       productId,
       subject: product.title ? `Re: ${product.title}` : null,
@@ -122,8 +121,8 @@ export const handler: Handler = async (event) => {
         .select('id')
         .eq('productId', productId)
         .or(
-          `and(user1Id.eq.${authUser.id},user2Id.eq.${sellerId}),` +
-          `and(user1Id.eq.${sellerId},user2Id.eq.${authUser.id})`
+          `and(user1Id.eq.${callerId},user2Id.eq.${sellerId}),` +
+          `and(user1Id.eq.${sellerId},user2Id.eq.${callerId})`
         )
         .maybeSingle<ConversationRow>();
 
@@ -144,4 +143,3 @@ export const handler: Handler = async (event) => {
     body: JSON.stringify({ conversationId: created.id, created: true }),
   };
 };
-

--- a/netlify/functions/create-checkout.ts
+++ b/netlify/functions/create-checkout.ts
@@ -226,23 +226,38 @@ export const handler: Handler = async (event) => {
   }
 
   const checkoutSellerId = uniqueSellerIds[0];
-  const { data: sellerProfile, error: sellerProfileError } = await supabase
-    .from('seller_profiles')
-    .select('stripeAccountId, stripeConnectStatus, sellerStatus, isPaused')
-    .eq('userId', checkoutSellerId)
-    .maybeSingle<{
-      stripeAccountId: string | null;
-      stripeConnectStatus: string | null;
-      sellerStatus: string | null;
-      isPaused: boolean | null;
-    }>();
+  const [sellerAccountResult, sellerProfileResult] = await Promise.all([
+    supabase
+      .from('users')
+      .select('role, isActive')
+      .eq('id', checkoutSellerId)
+      .maybeSingle<{ role: string | null; isActive: boolean | null }>(),
+    supabase
+      .from('seller_profiles')
+      .select('stripeAccountId, stripeConnectStatus, sellerStatus, isPaused')
+      .eq('userId', checkoutSellerId)
+      .maybeSingle<{
+        stripeAccountId: string | null;
+        stripeConnectStatus: string | null;
+        sellerStatus: string | null;
+        isPaused: boolean | null;
+      }>(),
+  ]);
 
-  if (sellerProfileError) {
-    console.error('create-checkout: seller profile query failed:', sellerProfileError.message);
+  if (sellerAccountResult.error || sellerProfileResult.error) {
+    console.error(
+      'create-checkout: seller eligibility query failed:',
+      sellerAccountResult.error?.message ?? sellerProfileResult.error?.message,
+    );
     return { statusCode: 500, body: JSON.stringify({ error: 'Unable to verify seller status. Please try again.' }) };
   }
 
+  const sellerAccount = sellerAccountResult.data;
+  const sellerProfile = sellerProfileResult.data;
   if (
+    !sellerAccount ||
+    sellerAccount.role !== 'seller' ||
+    sellerAccount.isActive !== true ||
     !sellerProfile?.stripeAccountId ||
     sellerProfile.stripeConnectStatus !== 'active' ||
     sellerProfile.sellerStatus !== 'active' ||

--- a/netlify/functions/create-checkout.ts
+++ b/netlify/functions/create-checkout.ts
@@ -2,6 +2,7 @@ import Stripe from 'stripe';
 import { createClient } from '@supabase/supabase-js';
 import { randomUUID } from 'crypto';
 import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { isMaintenanceMode } from './_shared/platformFlags';
 import { checkRateLimit } from './_shared/rateLimiter';
 
@@ -88,7 +89,30 @@ export const handler: Handler = async (event) => {
     };
   }
 
-  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // Checkout uses service_role for reservations and payment-session materialisation.
+  // A stale but valid access token from a suspended account must stop before any
+  // reservation, rate-limit write, Stripe creation, or payment-session write.
+  const auth = await authenticateActiveAccount(event, supabase);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({
+        error: auth.status === 401
+          ? 'Authentication required. Please sign in to complete your purchase.'
+          : 'This account is not active and cannot place orders.',
+      }),
+    };
+  }
+
+  const verifiedBuyerId = auth.actor.id;
+  if (buyerId && buyerId !== verifiedBuyerId) {
+    return { statusCode: 403, body: JSON.stringify({ error: 'buyerId does not match authenticated user' }) };
+  }
+
   const reservationToken = randomUUID();
   let reservedProductIds: string[] = [];
   const releaseReservedProducts = async () => {
@@ -104,27 +128,6 @@ export const handler: Handler = async (event) => {
       });
     reservedProductIds = [];
   };
-
-  let verifiedBuyerId = '';
-  const authHeader = event.headers['authorization'];
-  if (authHeader?.startsWith('Bearer ')) {
-    const token = authHeader.substring(7);
-    const { data: { user: authUser }, error: authError } = await supabase.auth.getUser(token);
-    if (authError || !authUser) {
-      return { statusCode: 401, body: JSON.stringify({ error: 'Invalid authentication token' }) };
-    }
-    if (buyerId && buyerId !== authUser.id) {
-      return { statusCode: 403, body: JSON.stringify({ error: 'buyerId does not match authenticated user' }) };
-    }
-    verifiedBuyerId = authUser.id;
-  }
-
-  if (!verifiedBuyerId) {
-    return {
-      statusCode: 401,
-      body: JSON.stringify({ error: 'Authentication required. Please sign in to complete your purchase.' }),
-    };
-  }
 
   const checkoutRl = await checkRateLimit({
     supabase,
@@ -142,15 +145,8 @@ export const handler: Handler = async (event) => {
   }
 
   const maintenance = await isMaintenanceMode(supabase);
-  if (maintenance) {
-    const { data: callerRow } = await supabase
-      .from('users')
-      .select('role')
-      .eq('id', verifiedBuyerId)
-      .maybeSingle<{ role: string | null }>();
-    if (callerRow?.role !== 'admin') {
-      return { statusCode: 503, body: JSON.stringify({ error: 'Platform is temporarily under maintenance' }) };
-    }
+  if (maintenance && auth.actor.role !== 'admin') {
+    return { statusCode: 503, body: JSON.stringify({ error: 'Platform is temporarily under maintenance' }) };
   }
 
   const maybeRpc = (supabase as typeof supabase & { rpc?: (fn: string) => Promise<unknown> }).rpc;

--- a/netlify/functions/create-payment-intent.ts
+++ b/netlify/functions/create-payment-intent.ts
@@ -7,6 +7,7 @@ import Stripe from 'stripe';
 import { createClient } from '@supabase/supabase-js';
 import { randomUUID } from 'crypto';
 import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { isMaintenanceMode } from './_shared/platformFlags';
 import { checkRateLimit } from './_shared/rateLimiter';
 
@@ -81,26 +82,31 @@ export const handler: Handler = async (event) => {
     };
   }
 
-  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // Mobile checkout uses service_role for reservation and payment-session writes.
+  // Resolve live account state before any rate-limit write, reservation, Stripe
+  // PaymentIntent creation, or commercial persistence.
+  const auth = await authenticateActiveAccount(event, supabase);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({
+        error: auth.status === 401
+          ? 'Authentication required. Please sign in to complete your purchase.'
+          : 'This account is not active and cannot place orders.',
+      }),
+    };
+  }
+
+  const verifiedBuyerId = auth.actor.id;
+  if (buyerId && buyerId !== verifiedBuyerId) {
+    return { statusCode: 403, body: JSON.stringify({ error: 'buyerId does not match authenticated user' }) };
+  }
+
   const reservationToken = randomUUID();
-
-  let verifiedBuyerId = '';
-  const authHeader = event.headers['authorization'];
-  if (authHeader?.startsWith('Bearer ')) {
-    const token = authHeader.substring(7);
-    const { data: { user: authUser }, error: authError } = await supabase.auth.getUser(token);
-    if (authError || !authUser) {
-      return { statusCode: 401, body: JSON.stringify({ error: 'Invalid authentication token' }) };
-    }
-    if (buyerId && buyerId !== authUser.id) {
-      return { statusCode: 403, body: JSON.stringify({ error: 'buyerId does not match authenticated user' }) };
-    }
-    verifiedBuyerId = authUser.id;
-  }
-
-  if (!verifiedBuyerId) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required. Please sign in to complete your purchase.' }) };
-  }
 
   const piRl = await checkRateLimit({
     supabase,
@@ -115,15 +121,8 @@ export const handler: Handler = async (event) => {
   }
 
   const maintenance = await isMaintenanceMode(supabase);
-  if (maintenance) {
-    const { data: callerRow } = await supabase
-      .from('users')
-      .select('role')
-      .eq('id', verifiedBuyerId)
-      .maybeSingle<{ role: string | null }>();
-    if (callerRow?.role !== 'admin') {
-      return { statusCode: 503, body: JSON.stringify({ error: 'Platform is temporarily under maintenance' }) };
-    }
+  if (maintenance && auth.actor.role !== 'admin') {
+    return { statusCode: 503, body: JSON.stringify({ error: 'Platform is temporarily under maintenance' }) };
   }
 
   await supabase.rpc('release_expired_reservations').catch((err: unknown) => {

--- a/netlify/functions/create-payment-intent.ts
+++ b/netlify/functions/create-payment-intent.ts
@@ -241,22 +241,38 @@ export const handler: Handler = async (event) => {
   }
 
   const checkoutSellerId = uniqueSellerIds[0];
-  const { data: sellerProfile, error: sellerProfileError } = await supabase
-    .from('seller_profiles')
-    .select('stripeAccountId, stripeConnectStatus, sellerStatus, isPaused')
-    .eq('userId', checkoutSellerId)
-    .maybeSingle<{
-      stripeAccountId: string | null;
-      stripeConnectStatus: string | null;
-      sellerStatus: string | null;
-      isPaused: boolean | null;
-    }>();
+  const [sellerAccountResult, sellerProfileResult] = await Promise.all([
+    supabase
+      .from('users')
+      .select('role, isActive')
+      .eq('id', checkoutSellerId)
+      .maybeSingle<{ role: string | null; isActive: boolean | null }>(),
+    supabase
+      .from('seller_profiles')
+      .select('stripeAccountId, stripeConnectStatus, sellerStatus, isPaused')
+      .eq('userId', checkoutSellerId)
+      .maybeSingle<{
+        stripeAccountId: string | null;
+        stripeConnectStatus: string | null;
+        sellerStatus: string | null;
+        isPaused: boolean | null;
+      }>(),
+  ]);
 
-  if (sellerProfileError) {
-    console.error('create-payment-intent: seller profile query failed:', sellerProfileError.message);
+  if (sellerAccountResult.error || sellerProfileResult.error) {
+    console.error(
+      'create-payment-intent: seller eligibility query failed:',
+      sellerAccountResult.error?.message ?? sellerProfileResult.error?.message,
+    );
     return { statusCode: 500, body: JSON.stringify({ error: 'Unable to verify seller status. Please try again.' }) };
   }
+
+  const sellerAccount = sellerAccountResult.data;
+  const sellerProfile = sellerProfileResult.data;
   if (
+    !sellerAccount ||
+    sellerAccount.role !== 'seller' ||
+    sellerAccount.isActive !== true ||
     !sellerProfile?.stripeAccountId ||
     sellerProfile.stripeConnectStatus !== 'active' ||
     sellerProfile.sellerStatus !== 'active' ||

--- a/netlify/functions/create-product.ts
+++ b/netlify/functions/create-product.ts
@@ -11,6 +11,7 @@
 
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { isMaintenanceMode, getFeatureFlags } from './_shared/platformFlags';
 import { checkRateLimit } from './_shared/rateLimiter';
 
@@ -74,19 +75,22 @@ export const handler: Handler = async (event) => {
   }
 
   const supabase = createClient(supabaseUrl, serviceRoleKey, {
-    auth: { persistSession: false },
+    auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  const authHeader = event.headers['authorization'] || '';
-  if (!authHeader.startsWith('Bearer ')) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required' }) };
+  const auth = await authenticateActiveAccount(event, supabase, ['seller', 'admin']);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({
+        error: auth.status === 401 ? 'Authentication required' : 'Only active sellers can create listings',
+      }),
+    };
   }
-  const token = authHeader.substring(7);
-  const { data: authData, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !authData?.user) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Invalid or expired token' }) };
-  }
-  const callerId = authData.user.id;
+
+  const callerId = auth.actor.id;
+  const role = auth.actor.role;
+  const isAdmin = role === 'admin';
 
   const rl = await checkRateLimit({
     supabase,
@@ -99,19 +103,6 @@ export const handler: Handler = async (event) => {
   if (rl.exceeded) {
     return { statusCode: 429, body: JSON.stringify({ error: 'Too many listings created. Please try again later.' }) };
   }
-
-  const { data: userRow } = await supabase
-    .from('users')
-    .select('role')
-    .eq('id', callerId)
-    .maybeSingle<{ role: string | null }>();
-  const role = userRow?.role ?? null;
-
-  if (role !== 'seller' && role !== 'admin') {
-    return { statusCode: 403, body: JSON.stringify({ error: 'Only sellers can create listings' }) };
-  }
-
-  const isAdmin = role === 'admin';
 
   const maintenance = await isMaintenanceMode(supabase);
   if (maintenance && !isAdmin) {

--- a/netlify/functions/create-refund.ts
+++ b/netlify/functions/create-refund.ts
@@ -1,6 +1,7 @@
 import Stripe from 'stripe';
 import { createClient } from '@supabase/supabase-js';
 import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { checkRateLimit } from './_shared/rateLimiter';
 import {
   findOrderTransfer,
@@ -32,33 +33,28 @@ export const handler: Handler = async (event) => {
     return { statusCode: 500, headers: corsHeaders, body: JSON.stringify({ error: 'Server configuration error' }) };
   }
 
-  const authHeader = event.headers['authorization'] || event.headers['Authorization'];
-  const token = authHeader?.replace(/^Bearer\s+/i, '').trim();
-  if (!token) {
-    return { statusCode: 401, headers: corsHeaders, body: JSON.stringify({ error: 'Unauthorized' }) };
-  }
-
   const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
     auth: { autoRefreshToken: false, persistSession: false },
   });
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !user) {
-    return { statusCode: 401, headers: corsHeaders, body: JSON.stringify({ error: 'Invalid or expired token' }) };
+
+  // Refunds mutate Stripe and financial history through service_role. A stale
+  // admin JWT is never sufficient; the caller must still be an active admin in
+  // the live platform account table before rate limiting or any financial read.
+  const auth = await authenticateActiveAccount(event, supabase, ['admin']);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: auth.status === 401 ? 'Unauthorized' : 'Admin access required' }),
+    };
   }
 
-  const { data: callerRow } = await supabase
-    .from('users')
-    .select('role')
-    .eq('id', user.id)
-    .maybeSingle<{ role: string }>();
-  if (callerRow?.role !== 'admin') {
-    return { statusCode: 403, headers: corsHeaders, body: JSON.stringify({ error: 'Admin access required' }) };
-  }
+  const adminId = auth.actor.id;
 
   const refundRl = await checkRateLimit({
     supabase,
     tableName: 'create_refund_rate_limits',
-    identifier: user.id,
+    identifier: adminId,
     windowMinutes: 60,
     maxAttempts: 10,
     policy: 'fail-closed',
@@ -161,7 +157,7 @@ export const handler: Handler = async (event) => {
         metadata: {
           orderId,
           orderNumber: order.orderNumber,
-          issuedByAdminId: user.id,
+          issuedByAdminId: adminId,
         },
       },
       { idempotencyKey: `order-refund:${orderId}` },
@@ -276,7 +272,7 @@ export const handler: Handler = async (event) => {
 
   if (transferRecoveryWarning) {
     await supabase.from('notifications').insert({
-      userId: user.id,
+      userId: adminId,
       type: 'payment',
       title: 'Refund requires payout review',
       message: `${order.orderNumber}: ${transferRecoveryWarning}`,

--- a/netlify/functions/deactivate-account.ts
+++ b/netlify/functions/deactivate-account.ts
@@ -87,7 +87,7 @@ export const handler: Handler = async (event) => {
   }
 
   // Revoke authentication first. If a later write fails, the account remains
-  // blocked from creating/refeshing sessions rather than being silently open.
+  // blocked from creating/refreshing sessions rather than being silently open.
   const { error: banError } = await supabase.auth.admin.updateUserById(auth.actor.id, {
     ban_duration: LONG_BAN_DURATION,
   });
@@ -121,7 +121,7 @@ export const handler: Handler = async (event) => {
   if (auth.actor.role === 'seller') {
     const { error: sellerError } = await supabase
       .from('seller_profiles')
-      .update({ sellerStatus: 'suspended' })
+      .update({ sellerStatus: 'suspended', isPaused: true })
       .eq('userId', auth.actor.id);
     if (sellerError) {
       console.error('deactivate-account: seller suspension sync failed:', sellerError.message);
@@ -131,6 +131,27 @@ export const handler: Handler = async (event) => {
         body: JSON.stringify({
           deactivated: true,
           error: 'Account is deactivated but seller-state synchronization requires support intervention',
+        }),
+      };
+    }
+
+    // Self-deactivation promises that the storefront stops advertising the
+    // seller's inventory. Keep listings inactive after a later account restore;
+    // the seller can explicitly Resume when ready, rather than silently
+    // republishing everything during admin reactivation.
+    const { error: productsError } = await supabase
+      .from('products')
+      .update({ isActive: false })
+      .eq('sellerId', auth.actor.id)
+      .eq('isActive', true);
+    if (productsError) {
+      console.error('deactivate-account: seller listing hide failed:', productsError.message);
+      return {
+        statusCode: 500,
+        headers: corsHeaders,
+        body: JSON.stringify({
+          deactivated: true,
+          error: 'Account is deactivated but listing visibility cleanup requires support intervention',
         }),
       };
     }

--- a/netlify/functions/deactivate-account.ts
+++ b/netlify/functions/deactivate-account.ts
@@ -1,0 +1,165 @@
+import type { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { checkRateLimit } from './_shared/rateLimiter';
+
+const ALLOWED_ORIGIN = process.env.VITE_APP_URL || 'https://loadifymarket.co.uk';
+const METHODS = 'POST, OPTIONS';
+const LONG_BAN_DURATION = '876000h';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': ALLOWED_ORIGIN,
+  'Access-Control-Allow-Methods': METHODS,
+  'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+  'Content-Type': 'application/json',
+};
+
+/**
+ * Self-service reversible account deactivation.
+ *
+ * This is intentionally distinct from delete-account: deactivation preserves
+ * account data so support can restore the account later. The security boundary
+ * still has to revoke Auth authority, public.users authority and notification
+ * delivery together instead of relying on a client-side isActive update.
+ */
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') {
+    return { statusCode: 204, headers: corsHeaders, body: '' };
+  }
+  if (event.httpMethod !== 'POST') {
+    return {
+      statusCode: 405,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: 'Method not allowed' }),
+    };
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    return {
+      statusCode: 500,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: 'Server configuration error' }),
+    };
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  // Deactivation is available only to the live active account that owns the
+  // current token. Suspended/stale sessions cannot use this endpoint as a way to
+  // mutate account state through service_role.
+  const auth = await authenticateActiveAccount(event, supabase);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: auth.status === 401 ? 'Authentication required' : 'Account access denied' }),
+    };
+  }
+
+  // Admin accounts require the protected recovery/administration process and
+  // must never be disabled through an ordinary self-service screen.
+  if (auth.actor.role === 'admin') {
+    return {
+      statusCode: 403,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: 'Admin accounts cannot be deactivated through self-service' }),
+    };
+  }
+
+  const rateLimit = await checkRateLimit({
+    supabase,
+    tableName: 'delete_account_rate_limits',
+    identifier: auth.actor.id,
+    windowMinutes: 60,
+    maxAttempts: 3,
+    policy: 'fail-closed',
+  });
+  if (rateLimit.exceeded) {
+    return {
+      statusCode: 429,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: 'Too many deactivation requests. Please try again later.' }),
+    };
+  }
+
+  // Revoke authentication first. If a later write fails, the account remains
+  // blocked from creating/refeshing sessions rather than being silently open.
+  const { error: banError } = await supabase.auth.admin.updateUserById(auth.actor.id, {
+    ban_duration: LONG_BAN_DURATION,
+  });
+  if (banError) {
+    console.error('deactivate-account: Auth ban failed:', banError.message);
+    return {
+      statusCode: 502,
+      headers: corsHeaders,
+      body: JSON.stringify({ error: 'Account deactivation could not be secured in authentication' }),
+    };
+  }
+
+  // The database flag is the stale-JWT backstop used by migration 608. It must
+  // be written before any best-effort cleanup is considered successful.
+  const { error: userError } = await supabase
+    .from('users')
+    .update({ isActive: false })
+    .eq('id', auth.actor.id);
+  if (userError) {
+    console.error('deactivate-account: users.isActive update failed:', userError.message);
+    return {
+      statusCode: 500,
+      headers: corsHeaders,
+      body: JSON.stringify({
+        deactivated: false,
+        error: 'Authentication is blocked but account deactivation requires support intervention',
+      }),
+    };
+  }
+
+  if (auth.actor.role === 'seller') {
+    const { error: sellerError } = await supabase
+      .from('seller_profiles')
+      .update({ sellerStatus: 'suspended' })
+      .eq('userId', auth.actor.id);
+    if (sellerError) {
+      console.error('deactivate-account: seller suspension sync failed:', sellerError.message);
+      return {
+        statusCode: 500,
+        headers: corsHeaders,
+        body: JSON.stringify({
+          deactivated: true,
+          error: 'Account is deactivated but seller-state synchronization requires support intervention',
+        }),
+      };
+    }
+  }
+
+  const { error: pushError } = await supabase
+    .from('push_tokens')
+    .update({ isActive: false })
+    .eq('userId', auth.actor.id)
+    .eq('isActive', true);
+  if (pushError) {
+    console.error('deactivate-account: push token cleanup failed:', pushError.message);
+    return {
+      statusCode: 500,
+      headers: corsHeaders,
+      body: JSON.stringify({
+        deactivated: true,
+        error: 'Account is deactivated but notification cleanup requires support intervention',
+      }),
+    };
+  }
+
+  return {
+    statusCode: 200,
+    headers: corsHeaders,
+    body: JSON.stringify({
+      success: true,
+      deactivated: true,
+      message: 'Account deactivated. Contact support if you want to restore access.',
+    }),
+  };
+};

--- a/netlify/functions/deactivate-account.ts
+++ b/netlify/functions/deactivate-account.ts
@@ -100,22 +100,19 @@ export const handler: Handler = async (event) => {
     };
   }
 
-  // The database flag is the stale-JWT backstop used by migration 608. It must
-  // be written before any best-effort cleanup is considered successful.
+  // Once Auth is blocked, every independent cleanup step is attempted even if a
+  // sibling write fails. A seller-state/listing failure must never prevent push
+  // token deactivation, and a push failure must not undo the account boundary.
+  const cleanupErrors: string[] = [];
+
   const { error: userError } = await supabase
     .from('users')
     .update({ isActive: false })
     .eq('id', auth.actor.id);
+  const databaseInactive = !userError;
   if (userError) {
     console.error('deactivate-account: users.isActive update failed:', userError.message);
-    return {
-      statusCode: 500,
-      headers: corsHeaders,
-      body: JSON.stringify({
-        deactivated: false,
-        error: 'Authentication is blocked but account deactivation requires support intervention',
-      }),
-    };
+    cleanupErrors.push('database account state');
   }
 
   if (auth.actor.role === 'seller') {
@@ -125,14 +122,7 @@ export const handler: Handler = async (event) => {
       .eq('userId', auth.actor.id);
     if (sellerError) {
       console.error('deactivate-account: seller suspension sync failed:', sellerError.message);
-      return {
-        statusCode: 500,
-        headers: corsHeaders,
-        body: JSON.stringify({
-          deactivated: true,
-          error: 'Account is deactivated but seller-state synchronization requires support intervention',
-        }),
-      };
+      cleanupErrors.push('seller state');
     }
 
     // Self-deactivation promises that the storefront stops advertising the
@@ -146,14 +136,7 @@ export const handler: Handler = async (event) => {
       .eq('isActive', true);
     if (productsError) {
       console.error('deactivate-account: seller listing hide failed:', productsError.message);
-      return {
-        statusCode: 500,
-        headers: corsHeaders,
-        body: JSON.stringify({
-          deactivated: true,
-          error: 'Account is deactivated but listing visibility cleanup requires support intervention',
-        }),
-      };
+      cleanupErrors.push('listing visibility');
     }
   }
 
@@ -164,12 +147,27 @@ export const handler: Handler = async (event) => {
     .eq('isActive', true);
   if (pushError) {
     console.error('deactivate-account: push token cleanup failed:', pushError.message);
+    cleanupErrors.push('notification cleanup');
+  }
+
+  if (!databaseInactive) {
+    return {
+      statusCode: 500,
+      headers: corsHeaders,
+      body: JSON.stringify({
+        deactivated: false,
+        error: 'Authentication is blocked but database deactivation requires support intervention',
+      }),
+    };
+  }
+
+  if (cleanupErrors.length > 0) {
     return {
       statusCode: 500,
       headers: corsHeaders,
       body: JSON.stringify({
         deactivated: true,
-        error: 'Account is deactivated but notification cleanup requires support intervention',
+        error: 'Account is deactivated but follow-up cleanup requires support intervention',
       }),
     };
   }

--- a/netlify/functions/delete-account.ts
+++ b/netlify/functions/delete-account.ts
@@ -71,17 +71,21 @@ export const handler: Handler = async (event) => {
     return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'Invalid request body' }) };
   }
 
+  // Self-deletion remains available to an authenticated account even if it has
+  // been suspended. Cross-account deletion is privileged and therefore requires
+  // the caller to be a live active admin in public.users, not merely to hold a
+  // still-valid JWT/admin claim.
   const { data: callerRow } = await supabase
     .from('users')
-    .select('role')
+    .select('role, isActive')
     .eq('id', callerAuth.id)
-    .maybeSingle<{ role: string | null }>();
+    .maybeSingle<{ role: string | null; isActive: boolean | null }>();
 
-  const isAdmin = callerRow?.role === 'admin';
-  const targetUserId = body.targetUserId && isAdmin ? body.targetUserId : callerAuth.id;
+  const isActiveAdmin = callerRow?.role === 'admin' && callerRow.isActive === true;
+  const targetUserId = body.targetUserId && isActiveAdmin ? body.targetUserId : callerAuth.id;
 
-  if (body.targetUserId && body.targetUserId !== callerAuth.id && !isAdmin) {
-    return { statusCode: 403, headers: corsHeaders, body: JSON.stringify({ error: 'You can only delete your own account' }) };
+  if (body.targetUserId && body.targetUserId !== callerAuth.id && !isActiveAdmin) {
+    return { statusCode: 403, headers: corsHeaders, body: JSON.stringify({ error: 'Only an active admin can delete another account' }) };
   }
 
   const { data: targetUser, error: targetLookupError } = await supabase

--- a/netlify/functions/delete-product.ts
+++ b/netlify/functions/delete-product.ts
@@ -1,5 +1,6 @@
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { isMaintenanceMode } from './_shared/platformFlags';
 
 type DeleteProductStatus = 'deleted' | 'not_found' | 'forbidden' | 'retained_history';
@@ -19,30 +20,18 @@ export const handler: Handler = async (event) => {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  const authHeader = event.headers.authorization || '';
-  if (!authHeader.startsWith('Bearer ')) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required' }) };
+  const auth = await authenticateActiveAccount(event, supabase, ['seller', 'admin']);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({
+        error: auth.status === 401 ? 'Authentication required' : 'Only active sellers can delete listings',
+      }),
+    };
   }
 
-  const { data: authData, error: authError } = await supabase.auth.getUser(authHeader.substring(7));
-  if (authError || !authData?.user) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Invalid or expired token' }) };
-  }
-  const callerId = authData.user.id;
-
-  const { data: userRow, error: userError } = await supabase
-    .from('users')
-    .select('role')
-    .eq('id', callerId)
-    .maybeSingle<{ role: string | null }>();
-  if (userError) {
-    return { statusCode: 500, body: JSON.stringify({ error: 'Unable to verify account role.' }) };
-  }
-
-  const role = userRow?.role ?? null;
-  if (role !== 'seller' && role !== 'admin') {
-    return { statusCode: 403, body: JSON.stringify({ error: 'Only sellers can delete listings' }) };
-  }
+  const callerId = auth.actor.id;
+  const role = auth.actor.role;
   const isAdmin = role === 'admin';
 
   if (await isMaintenanceMode(supabase) && !isAdmin) {

--- a/netlify/functions/escrow-release.ts
+++ b/netlify/functions/escrow-release.ts
@@ -144,25 +144,36 @@ export const handler = schedule('0 2 * * *', async () => {
         continue;
       }
 
-      const { data: sellerProfile, error: sellerError } = await supabase
-        .from('seller_profiles')
-        .select('stripeAccountId, stripeConnectStatus, sellerStatus, isPaused')
-        .eq('userId', order.sellerId)
-        .maybeSingle<{
-          stripeAccountId: string | null;
-          stripeConnectStatus: string | null;
-          sellerStatus: string | null;
-          isPaused: boolean | null;
-        }>();
+      const [{ data: sellerAccount, error: sellerAccountError }, { data: sellerProfile, error: sellerError }] = await Promise.all([
+        supabase
+          .from('users')
+          .select('role, isActive')
+          .eq('id', order.sellerId)
+          .maybeSingle<{ role: string | null; isActive: boolean | null }>(),
+        supabase
+          .from('seller_profiles')
+          .select('stripeAccountId, stripeConnectStatus, sellerStatus, isPaused')
+          .eq('userId', order.sellerId)
+          .maybeSingle<{
+            stripeAccountId: string | null;
+            stripeConnectStatus: string | null;
+            sellerStatus: string | null;
+            isPaused: boolean | null;
+          }>(),
+      ]);
 
+      if (sellerAccountError) throw sellerAccountError;
       if (sellerError) throw sellerError;
       if (
+        !sellerAccount ||
+        sellerAccount.role !== 'seller' ||
+        sellerAccount.isActive !== true ||
         !sellerProfile?.stripeAccountId ||
         sellerProfile.stripeConnectStatus !== 'active' ||
         sellerProfile.sellerStatus !== 'active' ||
         sellerProfile.isPaused === true
       ) {
-        console.warn(`escrow-release: ${order.orderNumber} retained because seller payout capability is not active`);
+        console.warn(`escrow-release: ${order.orderNumber} retained because seller account/payout capability is not active`);
         continue;
       }
 

--- a/netlify/functions/generate-invoice.ts
+++ b/netlify/functions/generate-invoice.ts
@@ -2,24 +2,19 @@
  * generate-invoice
  *
  * Generates a printable HTML invoice for a given order and streams it
- * back to the buyer's browser.  The buyer uses their browser's built-in
+ * back to the buyer's browser. The buyer uses their browser's built-in
  * Print → Save as PDF to create a PDF copy.
  *
- * This approach avoids bundling a large PDF library into the serverless
- * function and works reliably in all browsers.
- *
  * Security:
- *   – Requires a valid JWT (Authorization: Bearer <token>).
+ *   – Requires a valid JWT and a live active platform account.
  *   – The authenticated user must be the order's buyer OR an admin.
- *   – Uses the service-role client to query order data (bypasses RLS for
- *     admin use) but enforces ownership check in application code.
- *
- * Method: POST
- * Body:   { orderId: string }
+ *   – Uses the service-role client to query order data but enforces live
+ *     authorization before accessing commercial history.
  */
 
 import { createClient } from '@supabase/supabase-js';
 import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL!;
 const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
@@ -53,42 +48,21 @@ export const handler: Handler = async (event) => {
     };
   }
 
-  // ── Authenticate caller ───────────────────────────────────────────────────
-  const authHeader = event.headers['authorization'] || event.headers['Authorization'];
-  const token = authHeader?.replace(/^Bearer\s+/i, '').trim();
-  if (!token) {
-    return { statusCode: 401, headers: corsHeaders, body: JSON.stringify({ error: 'Unauthorized' }) };
-  }
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
 
-  const anonKey = process.env.VITE_SUPABASE_ANON_KEY;
-  if (!anonKey) {
+  const auth = await authenticateActiveAccount(event, supabase);
+  if (!auth.ok) {
     return {
-      statusCode: 500,
+      statusCode: auth.status,
       headers: corsHeaders,
-      body: JSON.stringify({ error: 'Server configuration error: VITE_SUPABASE_ANON_KEY not set' }),
+      body: JSON.stringify({ error: auth.status === 401 ? 'Unauthorized' : 'Account is suspended' }),
     };
   }
 
-  // Use anon client to verify token (getUser validates with Supabase auth server)
-  const anonClient = createClient(supabaseUrl, anonKey);
-  const { data: { user }, error: authError } = await anonClient.auth.getUser(token);
-  if (authError || !user) {
-    return { statusCode: 401, headers: corsHeaders, body: JSON.stringify({ error: 'Invalid or expired token' }) };
-  }
+  const isAdmin = auth.actor.role === 'admin';
 
-  // Service-role client for data access
-  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
-
-  // Check caller role
-  const { data: callerRow } = await supabase
-    .from('users')
-    .select('role, firstName, lastName')
-    .eq('id', user.id)
-    .single<{ role: string; firstName?: string; lastName?: string }>();
-
-  const isAdmin = callerRow?.role === 'admin';
-
-  // ── Parse body ────────────────────────────────────────────────────────────
   let body: { orderId?: string };
   try {
     body = JSON.parse(event.body || '{}') as { orderId?: string };
@@ -101,7 +75,6 @@ export const handler: Handler = async (event) => {
     return { statusCode: 400, headers: corsHeaders, body: JSON.stringify({ error: 'orderId is required' }) };
   }
 
-  // ── Fetch order ───────────────────────────────────────────────────────────
   const { data: order, error: orderError } = await supabase
     .from('orders')
     .select(`
@@ -138,18 +111,15 @@ export const handler: Handler = async (event) => {
     return { statusCode: 404, headers: corsHeaders, body: JSON.stringify({ error: 'Order not found' }) };
   }
 
-  // ── Ownership check ───────────────────────────────────────────────────────
-  if (!isAdmin && order.buyerId !== user.id) {
+  if (!isAdmin && order.buyerId !== auth.actor.id) {
     return { statusCode: 403, headers: corsHeaders, body: JSON.stringify({ error: 'Forbidden' }) };
   }
 
-  // ── Fetch order items ─────────────────────────────────────────────────────
   const { data: items } = await supabase
     .from('order_items')
     .select('quantity, pricePerUnit, subtotal, products ( title )')
     .eq('orderId', orderId);
 
-  // ── Fetch buyer name & B2B profile ────────────────────────────────────────
   const buyerRow = order.buyerId
     ? (await supabase
         .from('users')
@@ -178,14 +148,12 @@ export const handler: Handler = async (event) => {
     buyerProfileRow?.accountType !== 'individual';
   const isReverseCharge = isB2B && Boolean(buyerProfileRow?.isVatVerified);
 
-  // ── Fetch seller name ─────────────────────────────────────────────────────
   const { data: sellerRow } = await supabase
     .from('seller_profiles')
     .select('businessName')
     .eq('userId', order.sellerId)
     .single<{ businessName?: string }>();
 
-  // ── Build HTML invoice ────────────────────────────────────────────────────
   const addr = order.shippingAddress ?? {};
   const buyerName = [buyerRow?.firstName, buyerRow?.lastName].filter(Boolean).join(' ') || 'Customer';
   const sellerName = sellerRow?.businessName || 'Seller';
@@ -194,8 +162,6 @@ export const handler: Handler = async (event) => {
     : '—';
   const orderNum = order.orderNumber || order.id.slice(0, 8).toUpperCase();
 
-  // For B2B invoices the primary display name is the company, with the
-  // contact person listed underneath. For B2C it's the buyer's full name.
   const billToName = isB2B && buyerProfileRow?.companyName
     ? buyerProfileRow.companyName
     : buyerName;
@@ -359,7 +325,6 @@ export const handler: Handler = async (event) => {
   };
 };
 
-/** Escape HTML special characters to prevent XSS in the generated document. */
 function escapeHtml(str: unknown): string {
   if (str === null || str === undefined) return '';
   return String(str)

--- a/netlify/functions/onboarding-reminder.ts
+++ b/netlify/functions/onboarding-reminder.ts
@@ -4,7 +4,7 @@ import { createClient } from '@supabase/supabase-js';
 /**
  * onboarding-reminder — scheduled Netlify function
  *
- * Fires daily and sends reminder emails to sellers who have not
+ * Fires daily and sends reminder emails to active sellers who have not
  * completed onboarding after 1 day, 3 days, and 7 days.
  *
  * Schedule: every day at 09:00 UTC
@@ -72,7 +72,7 @@ export const handler = schedule('0 9 * * *', async () => {
     const windowStart = new Date(now.getTime() - (window.days * 24 + 1) * 60 * 60 * 1000).toISOString();
     const windowEnd   = new Date(now.getTime() - window.days * 24 * 60 * 60 * 1000).toISOString();
 
-    // Find sellers registered in this window who have NOT completed onboarding.
+    // Find active sellers registered in this window who have NOT completed onboarding.
     // Include rows where onboardingCompleted is false OR NULL (pre-migration rows).
     // NOTE: column names inside .or() filter strings use PostgREST quoting ("col"),
     // but supabase-js .gte()/.lte() take the raw column name without extra quotes.
@@ -80,6 +80,7 @@ export const handler = schedule('0 9 * * *', async () => {
       .from('users')
       .select('id, email, "firstName", "lastName", "createdAt"')
       .eq('role', 'seller')
+      .eq('isActive', true)
       .or('"onboardingCompleted".eq.false,"onboardingCompleted".is.null')
       .gte('createdAt', windowStart)
       .lte('createdAt', windowEnd);
@@ -132,8 +133,8 @@ export const handler = schedule('0 9 * * *', async () => {
   }
 
   // ── Stripe Connect-specific reminders ─────────────────────────────────────
-  // These fire for sellers who have been registered for 2, 5, or 10 days but
-  // still have no Stripe account connected (stripeConnectStatus IS NULL or
+  // These fire for active sellers who have been registered for 2, 5, or 10 days
+  // but still have no Stripe account connected (stripeConnectStatus IS NULL or
   // 'pending'). They are sent regardless of whether general onboarding is done
   // because a seller may have completed their profile but stalled on Stripe.
 
@@ -141,12 +142,13 @@ export const handler = schedule('0 9 * * *', async () => {
     const windowStart = new Date(now.getTime() - (window.days * 24 + 1) * 60 * 60 * 1000).toISOString();
     const windowEnd   = new Date(now.getTime() - window.days * 24 * 60 * 60 * 1000).toISOString();
 
-    // Fetch sellers registered in this window who have NOT completed Stripe Connect.
+    // Fetch active sellers registered in this window who have NOT completed Stripe Connect.
     // Join seller_profiles to check stripeConnectStatus.
     const { data: sellerRows, error: stripeErr } = await supabase
       .from('users')
       .select('id, email, "firstName", "lastName", "createdAt", seller_profiles!userId(stripeConnectStatus)')
       .eq('role', 'seller')
+      .eq('isActive', true)
       .gte('createdAt', windowStart)
       .lte('createdAt', windowEnd);
 

--- a/netlify/functions/push-token.ts
+++ b/netlify/functions/push-token.ts
@@ -1,21 +1,12 @@
 /**
  * push-token
  *
- * Registers or unregisters a push token for the authenticated user.
- *
- * POST body:
- *   { op: 'register',   token: string, platform: 'ios' | 'android' | 'web' }
- *   { op: 'unregister', token: string }
- *
- * Authentication: Bearer <supabase access token> (required)
- *
- * On register  → reassigns the physical device token to the authenticated user
- *                and upserts push_tokens (userId, token, platform, isActive=true)
- * On unregister → sets isActive=false for the matching (userId, token) row
+ * Registers or unregisters a push token for the authenticated active user.
  */
 
 import { createClient } from '@supabase/supabase-js';
 import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { checkRateLimit } from './_shared/rateLimiter';
 
 interface RegisterBody {
@@ -36,39 +27,36 @@ export const handler: Handler = async (event) => {
     return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) };
   }
 
-  // Supabase guard
   const supabaseUrl = process.env.VITE_SUPABASE_URL ?? '';
   const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
   if (!supabaseUrl || !supabaseServiceRoleKey) {
     return { statusCode: 500, body: JSON.stringify({ error: 'Database configuration is missing' }) };
   }
 
-  // Authentication — required for all operations
-  const authHeader = event.headers['authorization'];
-  if (!authHeader?.startsWith('Bearer ')) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required' }) };
-  }
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
 
-  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
-  const token = authHeader.substring(7);
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !user) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Invalid authentication token' }) };
+  const auth = await authenticateActiveAccount(event, supabase);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({ error: auth.status === 401 ? 'Authentication required' : 'Account is suspended' }),
+    };
   }
+  const userId = auth.actor.id;
 
-  // ── Rate limiting — 10 registrations per hour per user ─────────────────────
   const rl = await checkRateLimit({
     supabase,
-    tableName:     'push_token_rate_limits',
-    identifier:    user.id,
+    tableName: 'push_token_rate_limits',
+    identifier: userId,
     windowMinutes: 60,
-    maxAttempts:   10,
+    maxAttempts: 10,
   });
   if (rl.exceeded) {
     return { statusCode: 429, body: JSON.stringify({ error: 'Too many token registration requests. Please try again later.' }) };
   }
 
-  // Parse body
   let body: PushTokenBody;
   try {
     body = JSON.parse(event.body ?? '{}') as PushTokenBody;
@@ -86,15 +74,11 @@ export const handler: Handler = async (event) => {
       return { statusCode: 400, body: JSON.stringify({ error: 'platform must be ios, android, or web' }) };
     }
 
-    // A native push token identifies one physical app installation. It must not
-    // remain active for a previous account after another user signs in on the
-    // same device, otherwise notifications can leak across accounts. Deactivate
-    // historical ownership first, then activate the row for the current user.
     const { error: deactivateError } = await supabase
       .from('push_tokens')
       .update({ isActive: false })
       .eq('token', body.token)
-      .neq('userId', user.id)
+      .neq('userId', userId)
       .eq('isActive', true);
 
     if (deactivateError) {
@@ -102,11 +86,10 @@ export const handler: Handler = async (event) => {
       return { statusCode: 500, body: JSON.stringify({ error: 'Failed to register push token' }) };
     }
 
-    // Upsert: create or reactivate token row for this user+token combination.
     const { error } = await supabase
       .from('push_tokens')
       .upsert(
-        { userId: user.id, token: body.token, platform, isActive: true },
+        { userId, token: body.token, platform, isActive: true },
         { onConflict: 'userId,token' },
       );
 
@@ -122,7 +105,7 @@ export const handler: Handler = async (event) => {
     const { error } = await supabase
       .from('push_tokens')
       .update({ isActive: false })
-      .eq('userId', user.id)
+      .eq('userId', userId)
       .eq('token', body.token);
 
     if (error) {

--- a/netlify/functions/recheck-activation.ts
+++ b/netlify/functions/recheck-activation.ts
@@ -1,24 +1,12 @@
 import { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 
 /**
  * POST /.netlify/functions/recheck-activation
  *
  * Re-evaluates a seller's activation status using only data already persisted
- * in the database — no live Stripe API call is made. This makes it suitable
- * as a fast, reliable trigger after a profile save (where stripeConnectStatus
- * is already known) or as a fallback when connect-status cannot reach Stripe.
- *
- * Use-cases:
- *   - Called by SellerProfile after every profile save (replaces the previous
- *     fire-and-forget connect-status call).
- *   - Called by SellerSetupPage when the DB already shows stripeConnectStatus
- *     = 'active' — avoids a redundant Stripe API round-trip.
- *
- * Returns:
- *   { sellerStatus, profileComplete }
- *
- * Requires: Authorization: Bearer <supabase-jwt>
+ * in the database — no live Stripe API call is made.
  */
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== 'POST') {
@@ -31,30 +19,19 @@ export const handler: Handler = async (event) => {
     return { statusCode: 500, body: JSON.stringify({ error: 'Database not configured' }) };
   }
 
-  const authHeader = event.headers['authorization'] || event.headers['Authorization'];
-  const token = authHeader?.replace('Bearer ', '').trim();
-  if (!token) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required' }) };
+  const supabase = createClient(supabaseUrl, supabaseServiceKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const auth = await authenticateActiveAccount(event, supabase, ['seller', 'admin']);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({ error: auth.status === 401 ? 'Authentication required' : 'Active seller account required' }),
+    };
   }
 
-  const supabase = createClient(supabaseUrl, supabaseServiceKey);
-
-  const { data: { user }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !user) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Invalid or expired token' }) };
-  }
-
-  // Resolve the caller's role from the users table.
-  const { data: userRow } = await supabase
-    .from('users')
-    .select('role')
-    .eq('id', user.id)
-    .single<{ role: string }>();
-
-  // Admin accounts bypass the entire seller activation pipeline.
-  // They are never blocked by seller setup requirements and always appear
-  // as "active" from the perspective of RequireSeller.
-  if (userRow?.role === 'admin') {
+  if (auth.actor.role === 'admin') {
     return {
       statusCode: 200,
       body: JSON.stringify({
@@ -69,19 +46,11 @@ export const handler: Handler = async (event) => {
     };
   }
 
-  // Non-seller, non-admin accounts have no seller profile to evaluate.
-  if (userRow?.role !== 'seller') {
-    return { statusCode: 403, body: JSON.stringify({ error: 'Seller account required' }) };
-  }
+  const sellerId = auth.actor.id;
 
   try {
     const { tryAutoActivateSeller } = await import('./_shared/sellerActivation');
-    // No liveStripeConnectStatus passed — uses the persisted DB value.
-    // This is intentional: stripeConnectStatus was already set by either the
-    // Stripe webhook (account.updated) or a prior connect-status call. We are
-    // only re-evaluating whether all conditions are simultaneously met NOW
-    // (e.g., profile was just completed while Stripe was already active).
-    const result = await tryAutoActivateSeller(supabase, user.id);
+    const result = await tryAutoActivateSeller(supabase, sellerId);
     if (!result) {
       return {
         statusCode: 404,
@@ -90,7 +59,6 @@ export const handler: Handler = async (event) => {
     }
 
     if (result.firstActivation) {
-      // Send notifications fire-and-forget — same as connect-status/stripe-webhook.
       const adminEmail = process.env.ADMIN_NOTIFICATION_EMAIL;
       const appUrl = (process.env.URL || process.env.VITE_APP_URL || 'https://loadifymarket.co.uk').replace(/\/$/, '');
       const activatedAt = new Date().toLocaleString('en-GB');
@@ -114,12 +82,12 @@ export const handler: Handler = async (event) => {
         );
       }
 
-      if (user.email) {
+      if (auth.actor.email) {
         fetch(`${appUrl}/.netlify/functions/send-email`, {
           method: 'POST',
           headers: internalHeaders,
           body: JSON.stringify({
-            to: user.email,
+            to: auth.actor.email,
             subject: 'Your Loadify Market store is now live!',
             template: 'seller_account_active',
             data: { activatedAt },
@@ -137,8 +105,6 @@ export const handler: Handler = async (event) => {
         sellerStatus: result.sellerStatus,
         profileComplete: result.profileComplete,
         stripeConnected: result.stripeConnected,
-        // chargesEnabled / payoutsEnabled are both true when stripeActive is true,
-        // since stripeActive === (charges_enabled && payouts_enabled) per connect-status.
         chargesEnabled: result.stripeActive,
         payoutsEnabled: result.stripeActive,
         changed: result.changed,
@@ -152,4 +118,5 @@ export const handler: Handler = async (event) => {
         error: error instanceof Error ? error.message : 'Activation check failed',
       }),
     };
-  }};
+  }
+};

--- a/netlify/functions/resend-verification.ts
+++ b/netlify/functions/resend-verification.ts
@@ -1,5 +1,6 @@
-import { Handler, HandlerEvent } from '@netlify/functions';
+import { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { checkRateLimit } from './_shared/rateLimiter';
 import { getClientIp } from './_shared/getClientIp';
 
@@ -7,43 +8,11 @@ import { getClientIp } from './_shared/getClientIp';
  * POST /.netlify/functions/resend-verification
  *
  * Admin-only endpoint that resends a verification / magic-link sign-in email
- * to any user.  Uses the Supabase Auth Admin API so no client-side rate
+ * to any user. Uses the Supabase Auth Admin API so no client-side rate
  * limits apply.
  *
- * Required env vars:
- *   VITE_SUPABASE_URL
- *   SUPABASE_SERVICE_ROLE_KEY
- *
- * Request body (JSON):
- *   { userId: string }
- *
- * The caller must be an authenticated admin — verified via the
- * Authorization: Bearer <token> header (Supabase session token).
+ * The caller must be an authenticated, live active admin.
  */
-
-// Verify the caller's JWT and return their public.users row, or null.
-async function getAuthUser(
-  event: HandlerEvent,
-  adminClient: ReturnType<typeof createClient>,
-) {
-  const authHeader = event.headers['authorization'] || event.headers['Authorization'];
-  if (!authHeader || !authHeader.startsWith('Bearer ')) {
-    return null;
-  }
-  const token = authHeader.substring(7);
-  const { data, error } = await adminClient.auth.getUser(token);
-  const user = data?.user;
-  if (error || !user) return null;
-
-  const { data: userData } = await adminClient
-    .from('users')
-    .select('id, role')
-    .eq('id', user.id)
-    .single();
-
-  return userData ?? null;
-}
-
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== 'POST') {
     return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) };
@@ -64,7 +33,14 @@ export const handler: Handler = async (event) => {
       auth: { autoRefreshToken: false, persistSession: false },
     });
 
-    // ── Rate limiting: 10 verification resend requests per IP per hour ────────
+    const auth = await authenticateActiveAccount(event, adminClient, ['admin']);
+    if (!auth.ok) {
+      return {
+        statusCode: auth.status,
+        body: JSON.stringify({ error: auth.status === 401 ? 'Unauthorized' : 'Forbidden – active admin role required' }),
+      };
+    }
+
     const ip = getClientIp(event);
     if (ip) {
       const rl = await checkRateLimit({
@@ -81,17 +57,6 @@ export const handler: Handler = async (event) => {
         };
       }
     }
-    // ─────────────────────────────────────────────────────────────────────────
-
-    // ── JWT authentication ───────────────────────────────────────────────────
-    const caller = await getAuthUser(event, adminClient);
-    if (!caller) {
-      return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
-    }
-    if (caller.role !== 'admin') {
-      return { statusCode: 403, body: JSON.stringify({ error: 'Forbidden – admin role required' }) };
-    }
-    // ─────────────────────────────────────────────────────────────────────────
 
     let body: { userId?: string };
     try {
@@ -106,7 +71,6 @@ export const handler: Handler = async (event) => {
       return { statusCode: 400, body: JSON.stringify({ error: 'userId is required' }) };
     }
 
-    // Look up the target user's email and name
     const { data: targetUser, error: targetErr } = await adminClient
       .from('users')
       .select('email, "firstName", "lastName"')
@@ -120,9 +84,6 @@ export const handler: Handler = async (event) => {
     const targetFullName =
       [targetUser.firstName, targetUser.lastName].filter(Boolean).join(' ') || targetUser.email;
 
-    // Generate a magic-link via the Admin API.
-    // generateLink returns the action_link URL but does NOT send any email on
-    // its own — we deliver it via the centralised send-email function below.
     const appUrl = (process.env.URL || process.env.VITE_APP_URL || 'https://loadifymarket.co.uk').replace(/\/$/, '');
     const { data: linkData, error: linkErr } = await adminClient.auth.admin.generateLink({
       type: 'magiclink',
@@ -149,9 +110,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Deliver the magic link via the centralised send-email function.
-    // This mirrors the pattern used by register.ts and stripe-webhook.ts and
-    // ensures the email is sent through the same verified SendGrid pipeline.
     const emailRes = await fetch(`${appUrl}/.netlify/functions/send-email`, {
       method: 'POST',
       headers: {

--- a/netlify/functions/rfq.ts
+++ b/netlify/functions/rfq.ts
@@ -27,13 +27,11 @@
 
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { getFeatureFlags, isMaintenanceMode } from './_shared/platformFlags';
 import { checkRateLimit } from './_shared/rateLimiter';
 
 const RFQ_EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-
-// ISO 4217 currency codes accepted for RFQ submissions and responses.
-// Extend this list as the platform expands to new markets.
 const ALLOWED_RFQ_CURRENCIES = new Set(['GBP', 'USD', 'EUR']);
 
 function isValidRfqEmail(value: unknown): boolean {
@@ -52,10 +50,9 @@ export const handler: Handler = async (event) => {
   }
 
   const supabase = createClient(supabaseUrl, serviceRoleKey, {
-    auth: { persistSession: false },
+    auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  // ── Parse body ────────────────────────────────────────────────────────────
   let body: Record<string, unknown>;
   try {
     body = JSON.parse(event.body || '{}');
@@ -68,28 +65,27 @@ export const handler: Handler = async (event) => {
     return { statusCode: 400, body: JSON.stringify({ error: '"op" must be one of: create, respond, accept, withdraw' }) };
   }
 
-  // ── Auth (required for respond and accept; optional for create) ──────────
-  const authHeader = event.headers['authorization'] || '';
+  // Anonymous RFQ creation remains supported. If a caller does supply a token,
+  // however, it must resolve to a live active account; a suspended account may
+  // not downgrade itself to an anonymous actor by presenting a stale JWT.
+  const authHeader = event.headers['authorization'] || event.headers['Authorization'] || '';
   let callerId: string | null = null;
   let userRole: string | null = null;
 
   if (authHeader.startsWith('Bearer ')) {
-    const token = authHeader.substring(7);
-    const { data: authData } = await supabase.auth.getUser(token);
-    if (authData?.user) {
-      callerId = authData.user.id;
-      const { data: userRow } = await supabase
-        .from('users')
-        .select('role')
-        .eq('id', callerId)
-        .maybeSingle<{ role: string | null }>();
-      userRole = userRow?.role ?? null;
+    const auth = await authenticateActiveAccount(event, supabase);
+    if (!auth.ok) {
+      return {
+        statusCode: auth.status,
+        body: JSON.stringify({ error: auth.status === 401 ? 'Invalid authentication token' : 'Account is suspended' }),
+      };
     }
+    callerId = auth.actor.id;
+    userRole = auth.actor.role;
   }
 
   const isAdmin = userRole === 'admin';
 
-  // ── RFQ system flag (Step 5.4) ────────────────────────────────────────────
   const flags = await getFeatureFlags(supabase);
   if (!flags.rfqSystem && !isAdmin) {
     return {
@@ -98,7 +94,6 @@ export const handler: Handler = async (event) => {
     };
   }
 
-  // ── Maintenance mode guard ────────────────────────────────────────────────
   const maintenance = await isMaintenanceMode(supabase);
   if (maintenance && !isAdmin) {
     return {
@@ -107,9 +102,6 @@ export const handler: Handler = async (event) => {
     };
   }
 
-  // ── Rate limit ────────────────────────────────────────────────────────────
-  // Use authenticated user ID when available; fall back to IP for anonymous
-  // RFQ submissions so unauthenticated spam is also caught.
   const rlIdentifier =
     callerId ??
     (event.headers['x-nf-client-connection-ip'] ??
@@ -129,9 +121,6 @@ export const handler: Handler = async (event) => {
     };
   }
 
-  // ── Route to operation ────────────────────────────────────────────────────
-
-  // ── create ────────────────────────────────────────────────────────────────
   if (op === 'create') {
     const {
       product_name,
@@ -222,7 +211,6 @@ export const handler: Handler = async (event) => {
     return { statusCode: 200, body: JSON.stringify({ id: rfq.id }) };
   }
 
-  // ── respond ───────────────────────────────────────────────────────────────
   if (op === 'respond') {
     if (!callerId || userRole !== 'seller' && !isAdmin) {
       return { statusCode: 401, body: JSON.stringify({ error: 'Seller authentication required' }) };
@@ -258,7 +246,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Verify the RFQ exists
     const { data: rfq } = await supabase
       .from('rfq_requests')
       .select('id, status')
@@ -296,7 +283,6 @@ export const handler: Handler = async (event) => {
     return { statusCode: 200, body: JSON.stringify({ id: response.id }) };
   }
 
-  // ── accept ────────────────────────────────────────────────────────────────
   if (op === 'accept') {
     if (!callerId) {
       return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required' }) };
@@ -307,7 +293,6 @@ export const handler: Handler = async (event) => {
       return { statusCode: 400, body: JSON.stringify({ error: 'rfqId and responseId are required' }) };
     }
 
-    // Fetch the RFQ (caller must be the buyer)
     const { data: rfq } = await supabase
       .from('rfq_requests')
       .select('id, buyerId, buyer_email, product_name, status')
@@ -324,7 +309,6 @@ export const handler: Handler = async (event) => {
       return { statusCode: 404, body: JSON.stringify({ error: 'RFQ not found' }) };
     }
 
-    // Allow: the buyer who created the RFQ (or admin)
     const isBuyer = rfq.buyerId === callerId;
     if (!isBuyer && !isAdmin) {
       return { statusCode: 403, body: JSON.stringify({ error: 'Only the buyer who submitted this RFQ can accept a quote' }) };
@@ -334,7 +318,6 @@ export const handler: Handler = async (event) => {
       return { statusCode: 409, body: JSON.stringify({ error: 'This RFQ has already been fulfilled' }) };
     }
 
-    // Fetch the accepted response
     const { data: response } = await supabase
       .from('rfq_responses')
       .select('id, sellerId, quotedPrice, currency, status')
@@ -352,9 +335,6 @@ export const handler: Handler = async (event) => {
       return { statusCode: 404, body: JSON.stringify({ error: 'Quote not found' }) };
     }
 
-    // Create an order/job from the accepted quote.
-    // Status 'paid' is the service-doctrine equivalent of "accepted" per migration 448
-    // (paid → accepted in service lifecycle semantics).
     const { data: order, error: orderError } = await supabase
       .from('orders')
       .insert([
@@ -363,17 +343,14 @@ export const handler: Handler = async (event) => {
           sellerId: response.sellerId,
           status: 'paid',
           escrowStatus: 'held',
-          // Financial amounts from the accepted quote
           subtotal: response.quotedPrice,
           vatAmount: 0,
           shippingAmount: 0,
           discountAmount: 0,
           total: response.quotedPrice,
           commission: 0,
-          // RFQ linkage (requires migration 452_rfq_orders_linkage.sql)
           rfqId,
           rfqResponseId: responseId,
-          // Service orders have no shipping
           shippingAddress: {},
           billingAddress: {},
           deliveryMethod: 'delivery',
@@ -387,7 +364,6 @@ export const handler: Handler = async (event) => {
       return { statusCode: 500, body: JSON.stringify({ error: 'Failed to create job from quote. Please try again.' }) };
     }
 
-    // Mark RFQ as closed and the accepted response as accepted; reject others
     await Promise.all([
       supabase.from('rfq_requests').update({ status: 'closed' }).eq('id', rfqId),
       supabase.from('rfq_responses').update({ status: 'accepted', acceptedAt: new Date().toISOString() }).eq('id', responseId),
@@ -405,7 +381,6 @@ export const handler: Handler = async (event) => {
     };
   }
 
-  // ── withdraw ──────────────────────────────────────────────────────────────
   if (op === 'withdraw') {
     if (!callerId || (userRole !== 'seller' && !isAdmin)) {
       return { statusCode: 401, body: JSON.stringify({ error: 'Seller authentication required' }) };
@@ -416,7 +391,6 @@ export const handler: Handler = async (event) => {
       return { statusCode: 400, body: JSON.stringify({ error: 'responseId is required' }) };
     }
 
-    // Fetch the response — seller can only withdraw their own quote
     const { data: existingResponse } = await supabase
       .from('rfq_responses')
       .select('id, sellerId, status')

--- a/netlify/functions/save-admin-settings.ts
+++ b/netlify/functions/save-admin-settings.ts
@@ -1,14 +1,15 @@
 /**
  * save-admin-settings
  *
- * Persists platform_settings rows on behalf of an authenticated admin user.
- * Uses the Supabase service-role key to bypass RLS, so the admin JWT only
- * needs to be valid — no INSERT/UPDATE RLS policy is evaluated.
+ * Persists platform_settings rows on behalf of an authenticated active admin.
+ * Uses the Supabase service-role key to bypass RLS, so the server boundary must
+ * re-read live account state before any write.
  *
  * Security:
  *   – Requires Authorization: Bearer <admin-jwt>
  *   – JWT is validated via admin.auth.getUser()
- *   – Caller must have app_metadata.role === 'admin' OR users.role === 'admin'
+ *   – public.users must still exist with role=admin and isActive=true
+ *   – stale app_metadata claims are never sufficient
  *   – Only the three canonical keys are accepted: feature_flags,
  *     maintenance_mode, platform_config (unknown keys are rejected)
  *
@@ -17,44 +18,14 @@
  */
 
 import { createClient } from '@supabase/supabase-js';
-import type { Handler, HandlerEvent } from '@netlify/functions';
-import { getBearerToken, jsonResponse, optionsResponse } from './_shared/http';
+import type { Handler } from '@netlify/functions';
+import { jsonResponse, optionsResponse } from './_shared/http';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 
 const METHODS = 'POST, OPTIONS';
 
 // Only these keys may be upserted via this endpoint.
 const ALLOWED_KEYS = new Set(['feature_flags', 'maintenance_mode', 'platform_config']);
-
-async function authenticateAdmin(event: HandlerEvent) {
-  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
-  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  if (!supabaseUrl || !serviceRoleKey) return null;
-
-  const token = getBearerToken(event);
-  if (!token) return null;
-  const admin = createClient(supabaseUrl, serviceRoleKey, {
-    auth: { persistSession: false },
-  });
-
-  const { data, error } = await admin.auth.getUser(token);
-  if (error || !data?.user) return null;
-
-  const authUser = data.user;
-
-  // JWT fast-path: app_metadata.role (set by migration 340 sync trigger)
-  const jwtRole = (authUser.app_metadata as Record<string, unknown> | undefined)?.role;
-  if (jwtRole === 'admin') return { admin, userId: authUser.id };
-
-  // DB fallback: query by user ID (not email) to handle edge-cases
-  const { data: dbUser } = await admin
-    .from('users')
-    .select('role')
-    .eq('id', authUser.id)
-    .maybeSingle();
-
-  if (dbUser?.role === 'admin') return { admin, userId: authUser.id };
-  return null;
-}
 
 export const handler: Handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
@@ -70,9 +41,13 @@ export const handler: Handler = async (event) => {
     return jsonResponse(500, { error: 'Server configuration error' }, METHODS);
   }
 
-  const auth = await authenticateAdmin(event);
-  if (!auth) {
-    return jsonResponse(401, { error: 'Unauthorized' }, METHODS);
+  const admin = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const auth = await authenticateActiveAccount(event, admin, ['admin']);
+  if (!auth.ok) {
+    return jsonResponse(auth.status, { error: 'Unauthorized' }, METHODS);
   }
 
   let body: { settings?: Array<{ key: string; value: unknown }> } = {};
@@ -87,20 +62,16 @@ export const handler: Handler = async (event) => {
     return jsonResponse(400, { error: 'settings must be a non-empty array' }, METHODS);
   }
 
-  // Validate all keys before writing anything
+  // Validate all keys before writing anything.
   for (const row of settings) {
     if (!ALLOWED_KEYS.has(row.key)) {
       return jsonResponse(400, { error: `Unknown settings key: ${row.key}` }, METHODS);
     }
   }
 
-  const supabase = createClient(supabaseUrl, serviceRoleKey, {
-    auth: { persistSession: false },
-  });
-
   const errors: string[] = [];
   for (const row of settings) {
-    const { error } = await supabase
+    const { error } = await admin
       .from('platform_settings')
       .upsert({ key: row.key, value: row.value }, { onConflict: 'key' });
     if (error) errors.push(`${row.key}: ${error.message}`);

--- a/netlify/functions/seller-order-status.ts
+++ b/netlify/functions/seller-order-status.ts
@@ -1,5 +1,6 @@
 import { createClient } from '@supabase/supabase-js';
 import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { checkRateLimit } from './_shared/rateLimiter';
 import { enforcePaymentBackedTransition } from './_shared/orderTransitionGuards';
 
@@ -53,35 +54,24 @@ export const handler: Handler = async (event) => {
     return { statusCode: 500, body: JSON.stringify({ error: 'Server misconfiguration' }) };
   }
 
-  const authHeader = event.headers.authorization || event.headers.Authorization || '';
-  if (!authHeader.startsWith('Bearer ')) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required' }) };
-  }
-
   const supabase = createClient(supabaseUrl, serviceRoleKey, {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  const token = authHeader.substring(7);
-  const { data: { user: authUser }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !authUser) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Invalid authentication token' }) };
+  const auth = await authenticateActiveAccount(event, supabase, ['seller', 'admin']);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({ error: auth.status === 401 ? 'Authentication required' : 'Seller account required' }),
+    };
   }
 
-  const { data: caller } = await supabase
-    .from('users')
-    .select('id, role')
-    .eq('id', authUser.id)
-    .maybeSingle<{ id: string; role: string | null }>();
-
-  if (!caller || (caller.role !== 'seller' && caller.role !== 'admin')) {
-    return { statusCode: 403, body: JSON.stringify({ error: 'Seller account required' }) };
-  }
+  const caller = auth.actor;
 
   const rl = await checkRateLimit({
     supabase,
     tableName: 'seller_order_status_rate_limits',
-    identifier: authUser.id,
+    identifier: caller.id,
     windowMinutes: 60,
     maxAttempts: 60,
   });
@@ -116,7 +106,7 @@ export const handler: Handler = async (event) => {
   if (!order) {
     return { statusCode: 404, body: JSON.stringify({ error: 'Order not found' }) };
   }
-  if (caller.role !== 'admin' && order.sellerId !== authUser.id) {
+  if (caller.role !== 'admin' && order.sellerId !== caller.id) {
     return { statusCode: 403, body: JSON.stringify({ error: 'Not authorized for this order' }) };
   }
 

--- a/netlify/functions/send-message.ts
+++ b/netlify/functions/send-message.ts
@@ -7,22 +7,11 @@
  * Using a Netlify function (rather than a direct Supabase client insert) allows
  * the server to deliver a "new_message" push notification without requiring a
  * database trigger or a background job.
- *
- * Authentication: Bearer <supabase access token> (required)
- *
- * Body:
- *   { conversationId: string, receiverId: string, message: string }
- *
- * Returns the inserted message row:
- *   { id, senderId, message, isRead, createdAt }
- *
- * Notes:
- *   - Structured system messages are not pushed from here.
- *   - This function is for plain-text messages sent by humans from the chat UI.
  */
 
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { sendPushToUser } from './_shared/pushNotifications';
 import { checkRateLimit } from './_shared/rateLimiter';
 
@@ -90,7 +79,6 @@ export const handler: Handler = async (event) => {
     return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) };
   }
 
-  // ── Environment guards ──────────────────────────────────────────────────────
   const supabaseUrl = process.env.VITE_SUPABASE_URL ?? '';
   const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY ?? '';
   if (!supabaseUrl || !serviceRoleKey) {
@@ -98,23 +86,20 @@ export const handler: Handler = async (event) => {
   }
 
   const supabase = createClient(supabaseUrl, serviceRoleKey, {
-    auth: { persistSession: false },
+    auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  // ── Auth ────────────────────────────────────────────────────────────────────
-  const authHeader = event.headers['authorization'] ?? '';
-  if (!authHeader.startsWith('Bearer ')) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required' }) };
+  const auth = await authenticateActiveAccount(event, supabase);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({ error: auth.status === 401 ? 'Authentication required' : 'Account is suspended' }),
+    };
   }
-  const token = authHeader.substring(7);
-  const { data: { user: authUser }, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !authUser) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Invalid authentication token' }) };
-  }
-  const callerId = authUser.id;
+
+  const callerId = auth.actor.id;
   const appUrl = (process.env.URL || process.env.VITE_APP_URL || 'https://loadifymarket.co.uk').replace(/\/$/, '');
 
-  // ── Rate limiting — 60 messages per minute per user ────────────────────────
   const rl = await checkRateLimit({
     supabase,
     tableName:     'send_message_rate_limits',
@@ -126,7 +111,6 @@ export const handler: Handler = async (event) => {
     return { statusCode: 429, body: JSON.stringify({ error: 'Too many messages. Please slow down.' }) };
   }
 
-  // ── Parse body ──────────────────────────────────────────────────────────────
   let body: RequestBody;
   try {
     body = JSON.parse(event.body ?? '{}') as RequestBody;
@@ -149,13 +133,10 @@ export const handler: Handler = async (event) => {
     return { statusCode: 400, body: JSON.stringify({ error: 'Message is too long (max 4000 characters)' }) };
   }
 
-  // Reject messages containing HTML tags to prevent stored XSS.
-  // Structured system messages use a JSON envelope; plain-text human messages must never contain markup.
   if (/<[a-z!/?][^>]{0,2000}>/i.test(message)) {
     return { statusCode: 400, body: JSON.stringify({ error: 'Message must not contain HTML markup' }) };
   }
 
-  // ── Verify caller is a conversation participant ─────────────────────────────
   const { data: conv, error: convError } = await supabase
     .from('conversations')
     .select('id, user1Id, user2Id, subject')
@@ -174,14 +155,13 @@ export const handler: Handler = async (event) => {
     return { statusCode: 400, body: JSON.stringify({ error: 'Receiver is not a participant of this conversation' }) };
   }
 
-  // ── Insert the message ──────────────────────────────────────────────────────
   const { data: inserted, error: insertError } = await supabase
     .from('messages')
     .insert({
       conversationId,
-      senderId:   callerId,
+      senderId: callerId,
       receiverId,
-      message:    message.trim(),
+      message: message.trim(),
     })
     .select('id, senderId, message, isRead, createdAt')
     .single<MessageRow>();
@@ -191,11 +171,8 @@ export const handler: Handler = async (event) => {
     return { statusCode: 500, body: JSON.stringify({ error: 'Failed to send message' }) };
   }
 
-  // ── Push notification to receiver ───────────────────────────────────────────
-  // Only for human plain-text messages. Structured system events are ignored here.
   const isStructuredJson = message.trim().startsWith('{');
   if (!isStructuredJson) {
-    // Fetch sender name for the notification title.
     const { data: sender } = await supabase
       .from('users')
       .select('id, firstName, lastName, email, role')
@@ -222,7 +199,6 @@ export const handler: Handler = async (event) => {
       data:  { type: 'new_message', conversationId, path: `/inbox/${conversationId}` },
     });
 
-    // In-app notification in website account.
     await supabase
       .from('notifications')
       .insert({
@@ -236,7 +212,6 @@ export const handler: Handler = async (event) => {
         if (error) console.warn('send-message: notifications insert failed (non-fatal):', error.message);
       });
 
-    // Transactional email for sellers (opt-in gate via notification_settings.orderConfirmation).
     if (receiver?.role === 'seller' && receiver.email) {
       let allowEmail = true;
       const { data: settings } = await supabase

--- a/netlify/functions/set-account-role.ts
+++ b/netlify/functions/set-account-role.ts
@@ -1,6 +1,7 @@
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
-import { getBearerToken, jsonResponse, optionsResponse } from './_shared/http';
+import { jsonResponse, optionsResponse } from './_shared/http';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 
 const METHODS = 'POST, OPTIONS';
 const SELLER_INITIAL_STEP = 1;
@@ -20,20 +21,21 @@ export const handler: Handler = async (event) => {
     return jsonResponse(500, { error: 'Server configuration error' }, METHODS);
   }
 
-  const token = getBearerToken(event);
-  if (!token) {
-    return jsonResponse(401, { error: 'Authentication required' }, METHODS);
-  }
-
   const supabase = createClient(supabaseUrl, serviceRoleKey, {
-    auth: { persistSession: false },
+    auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  const { data: authData, error: authError } = await supabase.auth.getUser(token);
-  if (authError || !authData?.user) {
-    return jsonResponse(401, { error: 'Invalid or expired token' }, METHODS);
+  // This endpoint writes through service_role. A still-valid access token from a
+  // suspended account must never be sufficient to change role/onboarding state.
+  const auth = await authenticateActiveAccount(event, supabase);
+  if (!auth.ok) {
+    return jsonResponse(auth.status, { error: 'Authentication required' }, METHODS);
   }
-  const userId = authData.user.id;
+
+  const userId = auth.actor.id;
+  if (auth.actor.role === 'admin') {
+    return jsonResponse(403, { error: 'Admin role cannot be changed through self-service onboarding' }, METHODS);
+  }
 
   let parsedBody: { role?: unknown } = {};
   try {
@@ -48,8 +50,8 @@ export const handler: Handler = async (event) => {
   }
 
   // public.users remains the canonical database source of truth for role and
-  // onboarding state. The authenticated user can only update their own account
-  // through this service-role endpoint, never an attacker-supplied user id.
+  // onboarding state. The authenticated active user can only update their own
+  // account through this service-role endpoint, never an attacker-supplied id.
   const { error: userUpdateError } = await supabase
     .from('users')
     .update({
@@ -105,12 +107,11 @@ export const handler: Handler = async (event) => {
     }
   }
 
-  // Mirror the server-validated role into app_metadata so an auth-session
-  // fallback never has to trust user-editable user_metadata for authorization.
-  // Preserve provider/custom metadata already maintained by Supabase.
+  // Mirror the server-validated role into app_metadata so session consumers can
+  // observe the current role. Authorization still re-checks the live DB account.
   const { error: appMetadataError } = await supabase.auth.admin.updateUserById(userId, {
     app_metadata: {
-      ...(authData.user.app_metadata ?? {}),
+      ...auth.actor.appMetadata,
       role,
     },
   });

--- a/netlify/functions/update-product.ts
+++ b/netlify/functions/update-product.ts
@@ -4,6 +4,7 @@
 
 import type { Handler } from '@netlify/functions';
 import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { isMaintenanceMode } from './_shared/platformFlags';
 import { checkRateLimit } from './_shared/rateLimiter';
 import {
@@ -60,17 +61,23 @@ export const handler: Handler = async (event) => {
     return { statusCode: 503, body: JSON.stringify({ error: 'Server misconfiguration' }) };
   }
 
-  const supabase = createClient(supabaseUrl, serviceRoleKey, { auth: { persistSession: false } });
-  const authHeader = event.headers['authorization'] || '';
-  if (!authHeader.startsWith('Bearer ')) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required' }) };
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const auth = await authenticateActiveAccount(event, supabase, ['seller', 'admin']);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({
+        error: auth.status === 401 ? 'Authentication required' : 'Only active sellers can update listings',
+      }),
+    };
   }
 
-  const { data: authData, error: authError } = await supabase.auth.getUser(authHeader.substring(7));
-  if (authError || !authData?.user) {
-    return { statusCode: 401, body: JSON.stringify({ error: 'Invalid or expired token' }) };
-  }
-  const callerId = authData.user.id;
+  const callerId = auth.actor.id;
+  const role = auth.actor.role;
+  const isAdmin = role === 'admin';
 
   const rl = await checkRateLimit({
     supabase,
@@ -83,17 +90,6 @@ export const handler: Handler = async (event) => {
   if (rl.exceeded) {
     return { statusCode: 429, body: JSON.stringify({ error: 'Too many listing updates. Please try again later.' }) };
   }
-
-  const { data: userRow } = await supabase
-    .from('users')
-    .select('role')
-    .eq('id', callerId)
-    .maybeSingle<{ role: string | null }>();
-  const role = userRow?.role ?? null;
-  if (role !== 'seller' && role !== 'admin') {
-    return { statusCode: 403, body: JSON.stringify({ error: 'Only sellers can update listings' }) };
-  }
-  const isAdmin = role === 'admin';
 
   if (await isMaintenanceMode(supabase) && !isAdmin) {
     return { statusCode: 503, body: JSON.stringify({ error: 'Platform is temporarily under maintenance. Listings cannot be modified right now.' }) };

--- a/src/pages/AdminSellerDetailPage.tsx
+++ b/src/pages/AdminSellerDetailPage.tsx
@@ -107,16 +107,24 @@ export default function AdminSellerDetailPage() {
     fetchSeller();
   }, [fetchSeller]);
 
+  const changeAccountStatus = async (op: 'suspend' | 'reactivate') => {
+    if (!id) return;
+    const response = await authorizedFetch('/.netlify/functions/admin-user-status', {
+      method: 'POST',
+      body: JSON.stringify({ op, userId: id }),
+    });
+    const payload = await response.json() as { error?: string };
+    if (!response.ok) {
+      throw new Error(payload.error ?? `HTTP ${response.status}`);
+    }
+    await fetchSeller();
+  };
+
   const suspendSeller = async () => {
     if (!id || !confirm('Suspend this seller? They will not be able to use seller features.')) return;
     setActionLoading(true);
     try {
-      const { error } = await supabase
-        .from('seller_profiles')
-        .update({ sellerStatus: 'suspended' })
-        .eq('userId', id);
-      if (error) throw error;
-      await fetchSeller();
+      await changeAccountStatus('suspend');
     } catch (err) {
       console.error('Error suspending seller:', err);
     } finally {
@@ -128,14 +136,7 @@ export default function AdminSellerDetailPage() {
     if (!id) return;
     setActionLoading(true);
     try {
-      // Set back to 'submitted' — the auto-activation logic will promote to
-      // 'active' automatically if all conditions are already met.
-      const { error } = await supabase
-        .from('seller_profiles')
-        .update({ sellerStatus: 'submitted' })
-        .eq('userId', id);
-      if (error) throw error;
-      await fetchSeller();
+      await changeAccountStatus('reactivate');
     } catch (err) {
       console.error('Error reactivating seller:', err);
     } finally {
@@ -147,12 +148,7 @@ export default function AdminSellerDetailPage() {
     if (!id || !confirm('Block this user? They will not be able to log in.')) return;
     setActionLoading(true);
     try {
-      const { error } = await supabase
-        .from('users')
-        .update({ isActive: false })
-        .eq('id', id);
-      if (error) throw error;
-      await fetchSeller();
+      await changeAccountStatus('suspend');
     } catch (err) {
       console.error('Error blocking user:', err);
     } finally {
@@ -164,12 +160,7 @@ export default function AdminSellerDetailPage() {
     if (!id) return;
     setActionLoading(true);
     try {
-      const { error } = await supabase
-        .from('users')
-        .update({ isActive: true })
-        .eq('id', id);
-      if (error) throw error;
-      await fetchSeller();
+      await changeAccountStatus('reactivate');
     } catch (err) {
       console.error('Error unblocking user:', err);
     } finally {

--- a/src/pages/pixel-perfect/admin/AdminBuyers.tsx
+++ b/src/pages/pixel-perfect/admin/AdminBuyers.tsx
@@ -16,6 +16,7 @@ import {
   DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { supabase } from "@/lib/supabase";
+import { authorizedFetch } from "@/lib/authorizedFetch";
 import { toast } from "@/hooks/use-toast";
 
 interface Buyer {
@@ -146,14 +147,22 @@ const AdminBuyers = () => {
     setActionLoading(userId);
     setError(null);
     try {
-      const { error } = await supabase
-        .from("users")
-        .update({ isActive: !currentlyActive })
-        .eq("id", userId);
-      if (error) throw error;
-      setBuyers((prev) => prev.map((b) => b.id === userId ? { ...b, isActive: !currentlyActive } : b));
-      if (selected?.id === userId) setSelected((s) => s ? { ...s, isActive: !currentlyActive } : s);
-      if (detail?.id === userId) setDetail((d) => d ? { ...d, isActive: !currentlyActive } : d);
+      const response = await authorizedFetch('/.netlify/functions/admin-user-status', {
+        method: 'POST',
+        body: JSON.stringify({
+          op: currentlyActive ? 'suspend' : 'reactivate',
+          userId,
+        }),
+      });
+      const payload = await response.json() as { error?: string };
+      if (!response.ok) {
+        throw new Error(payload.error ?? `HTTP ${response.status}`);
+      }
+
+      const nextActive = !currentlyActive;
+      setBuyers((prev) => prev.map((b) => b.id === userId ? { ...b, isActive: nextActive } : b));
+      if (selected?.id === userId) setSelected((s) => s ? { ...s, isActive: nextActive } : s);
+      if (detail?.id === userId) setDetail((d) => d ? { ...d, isActive: nextActive } : d);
       toast({ title: currentlyActive ? "Buyer suspended" : "Buyer reactivated" });
     } catch (err: unknown) {
       const msg = (err as Error).message || "Failed to update buyer";

--- a/src/pages/pixel-perfect/admin/AdminUsers.tsx
+++ b/src/pages/pixel-perfect/admin/AdminUsers.tsx
@@ -17,6 +17,7 @@ import {
   Select, SelectContent, SelectItem, SelectTrigger, SelectValue,
 } from "@/components/ui/select";
 import { supabase } from "@/lib/supabase";
+import { authorizedFetch } from "@/lib/authorizedFetch";
 import { toast } from "@/hooks/use-toast";
 import { useAuthStore } from "@/store";
 
@@ -206,33 +207,39 @@ const AdminUsers = () => {
       toast({ title: "Not allowed", description: "You cannot suspend your own account.", variant: "destructive" });
       return;
     }
-    // Safety guard — direct DB access is required to re-enable a suspended admin.
-    if (targetRole === 'admin' && !currentlyActive) {
-      toast({ title: "Use DB console", description: "Reactivating an admin account requires direct database access.", variant: "destructive" });
+    // Admin recovery is deliberately outside standard User Management.
+    if (targetRole === 'admin') {
+      toast({ title: "Protected Account", description: "Admin account status uses the protected recovery process.", variant: "destructive" });
       return;
     }
+
     setActionLoading(userId);
     setError(null);
     try {
-      const { error } = await supabase
-        .from("users")
-        .update({ isActive: !currentlyActive })
-        .eq("id", userId);
-      if (error) throw error;
-
-      // For seller accounts, keep seller_profiles.sellerStatus in sync so that
-      // catalog queries filtering on sellerStatus reflect the suspension immediately.
-      if (targetRole === 'seller') {
-        const nextSellerStatus = currentlyActive ? 'suspended' : 'submitted';
-        await supabase
-          .from("seller_profiles")
-          .update({ sellerStatus: nextSellerStatus })
-          .eq("userId", userId);
+      const response = await authorizedFetch('/.netlify/functions/admin-user-status', {
+        method: 'POST',
+        body: JSON.stringify({
+          op: currentlyActive ? 'suspend' : 'reactivate',
+          userId,
+        }),
+      });
+      const payload = await response.json() as { error?: string };
+      if (!response.ok) {
+        throw new Error(payload.error ?? `HTTP ${response.status}`);
       }
 
-      setUsers((prev) => prev.map((u) => u.id === userId ? { ...u, isActive: !currentlyActive } : u));
-      if (selected?.id === userId) setSelected((s) => s ? { ...s, isActive: !currentlyActive } : s);
-      if (detail?.id === userId) setDetail((d) => d ? { ...d, isActive: !currentlyActive } : d);
+      const nextActive = !currentlyActive;
+      setUsers((prev) => prev.map((u) => u.id === userId ? { ...u, isActive: nextActive } : u));
+      if (selected?.id === userId) setSelected((s) => s ? { ...s, isActive: nextActive } : s);
+      if (detail?.id === userId) {
+        setDetail((d) => d ? {
+          ...d,
+          isActive: nextActive,
+          ...(targetRole === 'seller'
+            ? { sellerStatus: currentlyActive ? 'suspended' : 'submitted' }
+            : {}),
+        } : d);
+      }
       toast({ title: currentlyActive ? "User suspended" : "User reactivated" });
     } catch (err: unknown) {
       setError((err as Error).message || "Failed to update user");
@@ -619,4 +626,3 @@ function StatCard({ icon, label, value, colorClass, bgClass }: { icon: React.Rea
 }
 
 export default AdminUsers;
-

--- a/src/pages/pixel-perfect/buyer/BuyerSettings.tsx
+++ b/src/pages/pixel-perfect/buyer/BuyerSettings.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/components/ui/select";
 import { useToast } from "@/hooks/use-toast";
 import { supabase } from "@/lib/supabase";
+import { authorizedFetch } from "@/lib/authorizedFetch";
 import { useAuthStore } from "@/store";
 
 interface BuyerPrefs {
@@ -197,14 +198,22 @@ const BuyerSettings = () => {
     }
     setDeletingAccount(true);
     try {
-      // Soft-delete: mark user as inactive and sign out.
-      // Hard deletion requires a server-side admin call; soft-delete
-      // immediately disables the account and clears the session.
-      await supabase.from("users").update({ isActive: false }).eq("id", user.id);
+      const response = await authorizedFetch("/.netlify/functions/deactivate-account", {
+        method: "POST",
+      });
+      let payload: { error?: string; deactivated?: boolean } = {};
+      try { payload = await response.json(); } catch { /* non-JSON response */ }
+
+      // Once the server has committed deactivation, clear the local session even
+      // if a secondary cleanup step reported that support intervention is needed.
+      if (!response.ok && payload.deactivated !== true) {
+        throw new Error(payload.error || "Unable to deactivate your account.");
+      }
+
       await supabase.auth.signOut();
       toast({ title: "Account deactivated", description: "Your account has been deactivated. Contact support to restore it." });
-    } catch {
-      toast({ title: "Deletion failed", description: "Unable to delete your account. Please contact support.", variant: "destructive" });
+    } catch (err) {
+      toast({ title: "Deletion failed", description: err instanceof Error ? err.message : "Unable to delete your account. Please contact support.", variant: "destructive" });
     } finally {
       setDeletingAccount(false);
     }

--- a/src/pages/pixel-perfect/seller/SellerSettings.tsx
+++ b/src/pages/pixel-perfect/seller/SellerSettings.tsx
@@ -113,7 +113,7 @@ const SellerSettings = () => {
           userId: user.id,
           orderConfirmation: notifications.orderAlerts,
           shippingUpdates: notifications.returnAlerts,
-          deliveryConfirmation: notifications.orderAlerts,  // mirrors orderAlerts
+          deliveryConfirmation: notifications.orderAlerts,
           promotionalEmails: notifications.marketingEmails,
         },
         { onConflict: "userId" }
@@ -300,12 +300,22 @@ const SellerSettings = () => {
     }
     setDeleteSellerLoading(true);
     try {
-      // Soft-delete: set user as inactive and sign out.
-      await supabase.from("users").update({ isActive: false }).eq("id", user.id);
+      const response = await authorizedFetch("/.netlify/functions/deactivate-account", {
+        method: "POST",
+      });
+      let payload: { error?: string; deactivated?: boolean } = {};
+      try { payload = await response.json(); } catch { /* non-JSON response */ }
+
+      // The server owns Auth + users + seller-state + push cleanup. Once the
+      // account is committed inactive, clear the local session immediately.
+      if (!response.ok && payload.deactivated !== true) {
+        throw new Error(payload.error || "Unable to deactivate your seller account.");
+      }
+
       await supabase.auth.signOut();
       toast({ title: "Account deactivated", description: "Your seller account has been deactivated. Contact support to restore it." });
-    } catch {
-      toast({ title: "Deletion failed", description: "Unable to delete your account. Please contact support.", variant: "destructive" });
+    } catch (err) {
+      toast({ title: "Deletion failed", description: err instanceof Error ? err.message : "Unable to delete your account. Please contact support.", variant: "destructive" });
     } finally {
       setDeleteSellerLoading(false);
     }

--- a/supabase/608_enforce_active_account_authorization.sql
+++ b/supabase/608_enforce_active_account_authorization.sql
@@ -61,6 +61,41 @@ AS $$
   );
 $$;
 
+-- id / role / isActive are account-control columns. They must only be changed
+-- through a trusted server boundary running as service_role. Historical users
+-- RLS permits an authenticated owner to UPDATE their own row and permits active
+-- admins to UPDATE other rows; without this trigger either caller could mutate
+-- isActive directly and bypass the Auth-ban / push-cleanup contract.
+--
+-- auth.role() is the PostgREST JWT database role (authenticated/service_role),
+-- not application app_metadata. SQL migrations/direct database maintenance have
+-- no authenticated JWT role and service_role remains intentionally permitted.
+CREATE OR REPLACE FUNCTION public.enforce_user_account_control_boundary()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF auth.role() = 'authenticated'
+     AND (
+       NEW.id IS DISTINCT FROM OLD.id
+       OR NEW.role IS DISTINCT FROM OLD.role
+       OR NEW."isActive" IS DISTINCT FROM OLD."isActive"
+     ) THEN
+    RAISE EXCEPTION 'Account control columns are server-managed.'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS enforce_user_account_control_boundary ON public.users;
+CREATE TRIGGER enforce_user_account_control_boundary
+BEFORE UPDATE OF id, role, "isActive" ON public.users
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_user_account_control_boundary();
+
 -- Keep the denormalised seller lifecycle state fail-closed with the canonical
 -- account state. The user row and this seller-status update execute in the same
 -- database transaction, so a server-side suspension cannot leave an inactive
@@ -157,6 +192,18 @@ BEGIN
   END LOOP;
 END
 $$;
+
+-- public.users is not an account-deletion API. Historical users_delete allows an
+-- active admin to DELETE another users row directly, which would bypass Auth
+-- deletion/anonymisation/audit and cascade dependent public data. Force every
+-- authenticated deletion through the trusted server-side account process.
+DROP POLICY IF EXISTS account_control_delete_server_only ON public.users;
+CREATE POLICY account_control_delete_server_only
+ON public.users
+AS RESTRICTIVE
+FOR DELETE
+TO authenticated
+USING (FALSE);
 
 -- Public marketplace content remains readable while signed in, even for an
 -- account that has been suspended. Only authenticated writes are restricted.

--- a/supabase/608_enforce_active_account_authorization.sql
+++ b/supabase/608_enforce_active_account_authorization.sql
@@ -20,7 +20,7 @@ AS $$
   SELECT EXISTS (
     SELECT 1
     FROM public.users u
-    WHERE u.id = auth.uid()
+    WHERE u.id = (SELECT auth.uid())
       AND u."isActive" = TRUE
   );
 $$;
@@ -39,7 +39,7 @@ AS $$
   SELECT EXISTS (
     SELECT 1
     FROM public.users u
-    WHERE u.id = auth.uid()
+    WHERE u.id = (SELECT auth.uid())
       AND u.role = 'admin'
       AND u."isActive" = TRUE
   );
@@ -55,7 +55,7 @@ AS $$
   SELECT EXISTS (
     SELECT 1
     FROM public.users u
-    WHERE u.id = auth.uid()
+    WHERE u.id = (SELECT auth.uid())
       AND u.role = 'seller'
       AND u."isActive" = TRUE
   );
@@ -137,7 +137,9 @@ WHERE u.id = sp."userId"
 -- Account-scoped/private tables: an inactive authenticated account may neither
 -- read nor mutate its private/commercial state through PostgREST. service_role
 -- remains outside this authenticated-role policy and canonical server handlers
--- therefore retain controlled recovery/admin access.
+-- therefore retain controlled recovery/admin access. Wrapping the stable helper
+-- in SELECT lets PostgreSQL cache it as an initPlan per statement instead of
+-- evaluating it once per row.
 DO $$
 DECLARE
   v_table text;
@@ -187,7 +189,7 @@ BEGIN
       EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', v_table);
       EXECUTE format('DROP POLICY IF EXISTS active_account_access ON public.%I', v_table);
       EXECUTE format(
-        'CREATE POLICY active_account_access ON public.%I AS RESTRICTIVE FOR ALL TO authenticated USING (public.is_active_user()) WITH CHECK (public.is_active_user())',
+        'CREATE POLICY active_account_access ON public.%I AS RESTRICTIVE FOR ALL TO authenticated USING ((SELECT public.is_active_user())) WITH CHECK ((SELECT public.is_active_user()))',
         v_table
       );
     END IF;
@@ -236,15 +238,15 @@ BEGIN
       EXECUTE format('DROP POLICY IF EXISTS active_account_delete ON public.%I', v_table);
 
       EXECUTE format(
-        'CREATE POLICY active_account_insert ON public.%I AS RESTRICTIVE FOR INSERT TO authenticated WITH CHECK (public.is_active_user())',
+        'CREATE POLICY active_account_insert ON public.%I AS RESTRICTIVE FOR INSERT TO authenticated WITH CHECK ((SELECT public.is_active_user()))',
         v_table
       );
       EXECUTE format(
-        'CREATE POLICY active_account_update ON public.%I AS RESTRICTIVE FOR UPDATE TO authenticated USING (public.is_active_user()) WITH CHECK (public.is_active_user())',
+        'CREATE POLICY active_account_update ON public.%I AS RESTRICTIVE FOR UPDATE TO authenticated USING ((SELECT public.is_active_user())) WITH CHECK ((SELECT public.is_active_user()))',
         v_table
       );
       EXECUTE format(
-        'CREATE POLICY active_account_delete ON public.%I AS RESTRICTIVE FOR DELETE TO authenticated USING (public.is_active_user())',
+        'CREATE POLICY active_account_delete ON public.%I AS RESTRICTIVE FOR DELETE TO authenticated USING ((SELECT public.is_active_user()))',
         v_table
       );
     END IF;

--- a/supabase/608_enforce_active_account_authorization.sql
+++ b/supabase/608_enforce_active_account_authorization.sql
@@ -192,6 +192,7 @@ DECLARE
 BEGIN
   FOREACH v_table IN ARRAY ARRAY[
     'users',
+    'user_display_names_data',
     'buyer_profiles',
     'seller_profiles',
     'carts',

--- a/supabase/608_enforce_active_account_authorization.sql
+++ b/supabase/608_enforce_active_account_authorization.sql
@@ -61,11 +61,14 @@ AS $$
   );
 $$;
 
--- id / role / isActive are account-control columns. They must only be changed
--- through a trusted server boundary running as service_role. Historical users
--- RLS permits an authenticated owner to UPDATE their own row and permits active
--- admins to UPDATE other rows; without this trigger either caller could mutate
--- isActive directly and bypass the Auth-ban / push-cleanup contract.
+-- id / isActive are account-suspension control columns. They must only be
+-- changed through a trusted server boundary running as service_role. Historical
+-- users RLS permits an authenticated owner to UPDATE their own row and permits
+-- active admins to UPDATE other rows; without this trigger either caller could
+-- mutate isActive directly and bypass the Auth-ban / push-cleanup contract.
+-- Role changes remain governed by the dedicated users_update role-escalation
+-- policy introduced by migration 410 so existing Admin Users role management is
+-- not broken by this account-suspension migration.
 --
 -- current_user is the effective PostgreSQL API role (authenticated/service_role),
 -- not application JWT metadata. Direct SQL maintenance normally runs as postgres
@@ -79,10 +82,9 @@ BEGIN
   IF current_user = 'authenticated'
      AND (
        NEW.id IS DISTINCT FROM OLD.id
-       OR NEW.role IS DISTINCT FROM OLD.role
        OR NEW."isActive" IS DISTINCT FROM OLD."isActive"
      ) THEN
-    RAISE EXCEPTION 'Account control columns are server-managed.'
+    RAISE EXCEPTION 'Account suspension control columns are server-managed.'
       USING ERRCODE = '42501';
   END IF;
 
@@ -92,7 +94,7 @@ $$;
 
 DROP TRIGGER IF EXISTS enforce_user_account_control_boundary ON public.users;
 CREATE TRIGGER enforce_user_account_control_boundary
-BEFORE UPDATE OF id, role, "isActive" ON public.users
+BEFORE UPDATE OF id, "isActive" ON public.users
 FOR EACH ROW
 EXECUTE FUNCTION public.enforce_user_account_control_boundary();
 

--- a/supabase/608_enforce_active_account_authorization.sql
+++ b/supabase/608_enforce_active_account_authorization.sql
@@ -61,6 +61,42 @@ AS $$
   );
 $$;
 
+-- Keep the denormalised seller lifecycle state fail-closed with the canonical
+-- account state. The user row and this seller-status update execute in the same
+-- database transaction, so a server-side suspension cannot leave an inactive
+-- seller looking commercially active because a later application write failed.
+CREATE OR REPLACE FUNCTION public.sync_seller_suspension_from_user_activity()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NEW.role = 'seller' AND NEW."isActive" IS NOT TRUE THEN
+    UPDATE public.seller_profiles
+    SET "sellerStatus" = 'suspended'
+    WHERE "userId" = NEW.id
+      AND "sellerStatus" IS DISTINCT FROM 'suspended';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS sync_seller_suspension_from_user_activity ON public.users;
+CREATE TRIGGER sync_seller_suspension_from_user_activity
+AFTER INSERT OR UPDATE OF role, "isActive" ON public.users
+FOR EACH ROW
+EXECUTE FUNCTION public.sync_seller_suspension_from_user_activity();
+
+-- Reconcile any inactive seller rows that pre-date the trigger.
+UPDATE public.seller_profiles sp
+SET "sellerStatus" = 'suspended'
+FROM public.users u
+WHERE u.id = sp."userId"
+  AND u.role = 'seller'
+  AND u."isActive" IS NOT TRUE
+  AND sp."sellerStatus" IS DISTINCT FROM 'suspended';
+
 -- Account-scoped/private tables: an inactive authenticated account may neither
 -- read nor mutate its private/commercial state through PostgREST. service_role
 -- remains outside this authenticated-role policy and canonical server handlers

--- a/supabase/608_enforce_active_account_authorization.sql
+++ b/supabase/608_enforce_active_account_authorization.sql
@@ -182,6 +182,10 @@ WHERE u.id = sp."userId"
 -- therefore retain controlled recovery/admin access. Wrapping the stable helper
 -- in SELECT lets PostgreSQL cache it as an initPlan per statement instead of
 -- evaluating it once per row.
+--
+-- Support recovery remains available through the validated server-side public
+-- support-ticket boundary; stale authenticated sessions do not retain direct
+-- PostgREST access to private support tickets or their message history.
 DO $$
 DECLARE
   v_table text;
@@ -201,6 +205,8 @@ BEGIN
     'notifications',
     'csp_reports',
     'error_reports',
+    'support_tickets',
+    'support_ticket_messages',
     'orders',
     'order_items',
     'order_messages',

--- a/supabase/608_enforce_active_account_authorization.sql
+++ b/supabase/608_enforce_active_account_authorization.sql
@@ -67,16 +67,16 @@ $$;
 -- admins to UPDATE other rows; without this trigger either caller could mutate
 -- isActive directly and bypass the Auth-ban / push-cleanup contract.
 --
--- auth.role() is the PostgREST JWT database role (authenticated/service_role),
--- not application app_metadata. SQL migrations/direct database maintenance have
--- no authenticated JWT role and service_role remains intentionally permitted.
+-- current_user is the effective PostgreSQL API role (authenticated/service_role),
+-- not application JWT metadata. Direct SQL maintenance normally runs as postgres
+-- and the service_role used by canonical server handlers remains permitted.
 CREATE OR REPLACE FUNCTION public.enforce_user_account_control_boundary()
 RETURNS trigger
 LANGUAGE plpgsql
 SET search_path = ''
 AS $$
 BEGIN
-  IF auth.role() = 'authenticated'
+  IF current_user = 'authenticated'
      AND (
        NEW.id IS DISTINCT FROM OLD.id
        OR NEW.role IS DISTINCT FROM OLD.role

--- a/supabase/608_enforce_active_account_authorization.sql
+++ b/supabase/608_enforce_active_account_authorization.sql
@@ -61,6 +61,48 @@ AS $$
   );
 $$;
 
+-- Fresh rebuilds must preserve the live-safe signup rule. Supabase user_metadata
+-- is caller-controlled during sign-up, so it may select the ordinary marketplace
+-- roles buyer/seller but can never mint an admin account. Admin is accepted only
+-- from raw_app_meta_data, which is server-controlled.
+--
+-- Historical migration 455 contains an older definition that also accepted
+-- raw_user_meta_data.role='admin'. Replacing it here reconciles the repository
+-- with the effective live contract and prevents a fresh rebuild from restoring
+-- that privilege-escalation path.
+CREATE OR REPLACE FUNCTION public.handle_new_auth_user()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  INSERT INTO public.users (id, email, role, "isEmailVerified")
+  VALUES (
+    NEW.id,
+    NEW.email,
+    CASE
+      WHEN (NEW.raw_app_meta_data->>'role') IN ('admin', 'seller', 'buyer')
+        THEN (NEW.raw_app_meta_data->>'role')
+      WHEN (NEW.raw_user_meta_data->>'role') IN ('seller', 'buyer')
+        THEN (NEW.raw_user_meta_data->>'role')
+      ELSE 'buyer'
+    END,
+    (NEW.email_confirmed_at IS NOT NULL)
+  )
+  ON CONFLICT DO NOTHING;
+
+  RETURN NEW;
+EXCEPTION WHEN OTHERS THEN
+  RAISE WARNING 'handle_new_auth_user: non-fatal error for auth user % (email: %): %',
+    NEW.id, NEW.email, SQLERRM;
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.handle_new_auth_user() IS
+  'Creates public.users on Auth signup; user_metadata may choose buyer/seller but never admin.';
+
 -- id / isActive are account-suspension control columns. They must only be
 -- changed through a trusted server boundary running as service_role. Historical
 -- users RLS permits an authenticated owner to UPDATE their own row and permits

--- a/supabase/608_enforce_active_account_authorization.sql
+++ b/supabase/608_enforce_active_account_authorization.sql
@@ -61,6 +61,163 @@ AS $$
   );
 $$;
 
+-- SECURITY DEFINER helpers used directly and/or from RLS must not become a
+-- stale-session side channel around the restrictive policies installed below.
+-- Read-eligibility helpers therefore return false for inactive accounts even
+-- though their underlying historical tables remain accessible to the function
+-- owner. Public seller checkout readiness remains anonymous-readable, but it
+-- independently joins the live users row so suspended sellers cannot remain
+-- commercially discoverable because of stale denormalised profile state.
+CREATE OR REPLACE FUNCTION public.can_open_dispute(
+  p_order_id uuid,
+  p_seller_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT (SELECT public.is_active_user())
+    AND EXISTS (
+      SELECT 1
+      FROM public.orders o
+      WHERE o.id = p_order_id
+        AND o."buyerId" = (SELECT auth.uid())
+        AND o."sellerId" = p_seller_id
+        AND o.status IN ('paid', 'packed', 'shipped', 'delivered', 'completed')
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.can_open_return(
+  p_order_id uuid,
+  p_seller_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT (SELECT public.is_active_user())
+    AND EXISTS (
+      SELECT 1
+      FROM public.orders o
+      WHERE o.id = p_order_id
+        AND o."buyerId" = (SELECT auth.uid())
+        AND o."sellerId" = p_seller_id
+        AND o.status = 'completed'
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_valid_review_purchase(
+  p_order_id uuid,
+  p_product_id uuid
+)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT (SELECT public.is_active_user())
+    AND EXISTS (
+      SELECT 1
+      FROM public.orders o
+      WHERE o.id = p_order_id
+        AND o."buyerId" = (SELECT auth.uid())
+        AND o.status IN ('delivered', 'completed')
+        AND (
+          o."productId" = p_product_id
+          OR EXISTS (
+            SELECT 1
+            FROM public.order_items oi
+            WHERE oi."orderId" = o.id
+              AND oi."productId" = p_product_id
+          )
+        )
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.owns_product(p_product_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT (SELECT public.is_active_user())
+    AND EXISTS (
+      SELECT 1
+      FROM public.products p
+      WHERE p.id = p_product_id
+        AND p."sellerId" = (SELECT auth.uid())
+    );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_seller_checkout_ready(p_seller_id uuid)
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.seller_profiles sp
+    JOIN public.users u ON u.id = sp."userId"
+    WHERE sp."userId" = p_seller_id
+      AND u.role = 'seller'
+      AND u."isActive" = TRUE
+      AND sp."sellerStatus" = 'active'
+      AND sp."stripeConnectStatus" = 'active'
+      AND COALESCE(sp."isPaused", false) = false
+  );
+$$;
+
+-- Product-view analytics are an intentional public browse side effect. A
+-- suspended authenticated session may still browse public content, but it must
+-- not keep writing account-scoped recently_viewed history. Treat such a session
+-- like an anonymous visitor for the account-scoped branch of this function.
+CREATE OR REPLACE FUNCTION public.track_product_view(
+  p_product_id uuid,
+  p_user_id uuid DEFAULT NULL,
+  p_session_id text DEFAULT NULL
+)
+RETURNS void
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_user_id uuid := CASE
+    WHEN (SELECT public.is_active_user()) THEN (SELECT auth.uid())
+    ELSE NULL
+  END;
+BEGIN
+  UPDATE public.products
+  SET views = COALESCE(views, 0) + 1,
+      "lastViewedAt" = NOW()
+  WHERE id = p_product_id;
+
+  IF v_user_id IS NOT NULL THEN
+    INSERT INTO public.recently_viewed ("userId", "productId", "viewedAt")
+    VALUES (v_user_id, p_product_id, NOW())
+    ON CONFLICT ("userId", "productId") DO UPDATE SET "viewedAt" = NOW();
+  ELSIF p_session_id IS NOT NULL AND length(p_session_id) BETWEEN 1 AND 200 THEN
+    INSERT INTO public.recently_viewed ("sessionId", "productId", "viewedAt")
+    VALUES (p_session_id, p_product_id, NOW())
+    ON CONFLICT ("sessionId", "productId") DO UPDATE SET "viewedAt" = NOW();
+  END IF;
+
+  INSERT INTO public.product_analytics ("productId", date, views, "uniqueVisitors")
+  VALUES (p_product_id, CURRENT_DATE, 1, 1)
+  ON CONFLICT ("productId", date) DO UPDATE SET
+    views = public.product_analytics.views + 1,
+    "uniqueVisitors" = public.product_analytics."uniqueVisitors" + 1;
+END;
+$$;
+
 -- Fresh rebuilds must preserve the live-safe signup rule. Supabase user_metadata
 -- is caller-controlled during sign-up, so it may select the ordinary marketplace
 -- roles buyer/seller but can never mint an admin account. Admin is accepted only

--- a/supabase/608_enforce_active_account_authorization.sql
+++ b/supabase/608_enforce_active_account_authorization.sql
@@ -1,0 +1,168 @@
+-- 608_enforce_active_account_authorization.sql
+--
+-- Checkpoint A account-suspension invariant:
+--   * public.users.isActive is the database source of truth for whether an
+--     authenticated account may access account-scoped/private marketplace data;
+--   * stale JWT role claims must never bypass an inactive database account;
+--   * public browse/read surfaces remain available, but marketplace writes from
+--     an inactive authenticated account fail closed under RLS.
+--
+-- Supabase Auth suspension is handled by the canonical server boundary. This
+-- migration is the immediate database backstop for already-issued JWTs.
+
+CREATE OR REPLACE FUNCTION public.is_active_user()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.users u
+    WHERE u.id = auth.uid()
+      AND u."isActive" = TRUE
+  );
+$$;
+
+COMMENT ON FUNCTION public.is_active_user() IS
+  'Authorization guard: true only when the authenticated public.users row is active.';
+
+-- Never trust a stale app_metadata role claim ahead of the live database row.
+CREATE OR REPLACE FUNCTION public.is_admin()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.users u
+    WHERE u.id = auth.uid()
+      AND u.role = 'admin'
+      AND u."isActive" = TRUE
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_seller()
+RETURNS boolean
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.users u
+    WHERE u.id = auth.uid()
+      AND u.role = 'seller'
+      AND u."isActive" = TRUE
+  );
+$$;
+
+-- Account-scoped/private tables: an inactive authenticated account may neither
+-- read nor mutate its private/commercial state through PostgREST. service_role
+-- remains outside this authenticated-role policy and canonical server handlers
+-- therefore retain controlled recovery/admin access.
+DO $$
+DECLARE
+  v_table text;
+BEGIN
+  FOREACH v_table IN ARRAY ARRAY[
+    'users',
+    'buyer_profiles',
+    'seller_profiles',
+    'carts',
+    'cart_items',
+    'wishlists',
+    'saved_searches',
+    'recently_viewed',
+    'conversations',
+    'messages',
+    'notification_settings',
+    'notifications',
+    'csp_reports',
+    'error_reports',
+    'orders',
+    'order_items',
+    'order_messages',
+    'order_events',
+    'shipments',
+    'shipment_events',
+    'returns',
+    'disputes',
+    'dispute_messages',
+    'payout_requests',
+    'payouts',
+    'seller_balance',
+    'seller_balance_adjustments',
+    'seller_verifications',
+    'reported_listings',
+    'push_tokens',
+    'payment_sessions',
+    'offers',
+    'product_offers',
+    'coupon_usage',
+    'rfq_requests',
+    'rfq_responses',
+    'service_requests',
+    'service_quotes'
+  ]
+  LOOP
+    IF to_regclass(format('public.%I', v_table)) IS NOT NULL THEN
+      EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', v_table);
+      EXECUTE format('DROP POLICY IF EXISTS active_account_access ON public.%I', v_table);
+      EXECUTE format(
+        'CREATE POLICY active_account_access ON public.%I AS RESTRICTIVE FOR ALL TO authenticated USING (public.is_active_user()) WITH CHECK (public.is_active_user())',
+        v_table
+      );
+    END IF;
+  END LOOP;
+END
+$$;
+
+-- Public marketplace content remains readable while signed in, even for an
+-- account that has been suspended. Only authenticated writes are restricted.
+-- This preserves browse/support recovery while preventing a stale JWT from
+-- changing listings, services, reviews, questions, promotions or coupons.
+DO $$
+DECLARE
+  v_table text;
+BEGIN
+  FOREACH v_table IN ARRAY ARRAY[
+    'seller_stores',
+    'products',
+    'product_shipping',
+    'product_questions',
+    'reviews',
+    'promoted_listings',
+    'coupons',
+    'services',
+    'service_attributes',
+    'service_media'
+  ]
+  LOOP
+    IF to_regclass(format('public.%I', v_table)) IS NOT NULL THEN
+      EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', v_table);
+
+      EXECUTE format('DROP POLICY IF EXISTS active_account_insert ON public.%I', v_table);
+      EXECUTE format('DROP POLICY IF EXISTS active_account_update ON public.%I', v_table);
+      EXECUTE format('DROP POLICY IF EXISTS active_account_delete ON public.%I', v_table);
+
+      EXECUTE format(
+        'CREATE POLICY active_account_insert ON public.%I AS RESTRICTIVE FOR INSERT TO authenticated WITH CHECK (public.is_active_user())',
+        v_table
+      );
+      EXECUTE format(
+        'CREATE POLICY active_account_update ON public.%I AS RESTRICTIVE FOR UPDATE TO authenticated USING (public.is_active_user()) WITH CHECK (public.is_active_user())',
+        v_table
+      );
+      EXECUTE format(
+        'CREATE POLICY active_account_delete ON public.%I AS RESTRICTIVE FOR DELETE TO authenticated USING (public.is_active_user())',
+        v_table
+      );
+    END IF;
+  END LOOP;
+END
+$$;


### PR DESCRIPTION
## Checkpoint A P0/P1 — active-account authorization boundary (migration 608)

This PR is the **migration 608 / active-account boundary** immediately after the now production-applied/verified migration 607.

## Root cause
Suspending or deactivating an account could previously change only profile/public state while leaving stale Supabase Auth authority, direct PostgREST paths, SECURITY DEFINER helpers or user-authenticated service-role handlers usable.

## Canonical repair
- shared live-account authorization guard for user-authenticated service-role functions;
- live `public.users.isActive` + live DB role required; stale JWT role metadata is not an authorization source;
- canonical server-side admin suspend/reactivate with Auth ban/unban, `users.isActive`, seller lifecycle sync, push cleanup and audit;
- fail-closed compensation for partial suspend/reactivate/audit failures;
- standard admin tooling cannot self-suspend or manage admin targets through the ordinary boundary;
- legacy seller/buyer/admin account-status surfaces route through the same canonical server boundary without visual redesign;
- reversible Buyer/Seller self-deactivation is server-controlled, including seller pause/listing hide and push cleanup;
- checkout and PaymentIntent boundaries re-check live buyer/seller eligibility before payment/commercial mutation;
- seller auto-activation rejects inactive/non-seller accounts and reminders skip inactive sellers;
- direct authenticated mutation of `users.id` / `users.isActive` is blocked;
- direct authenticated DELETE of `public.users` is blocked;
- `is_admin()` / `is_seller()` are live-DB + active-aware and no longer trust stale JWT app_metadata;
- `handle_new_auth_user()` is reconciled to the live-safe contract so caller-controlled user_metadata can never mint admin;
- restrictive active-account RLS is installed across private/account-scoped marketplace state, while public browse reads remain available;
- `can_open_dispute`, `can_open_return`, `is_valid_review_purchase` and `owns_product` are active-account-aware so SECURITY DEFINER execution cannot bypass suspension;
- `is_seller_checkout_ready` joins the live active seller user row, preventing stale seller profile state from keeping an inactive seller commercially discoverable;
- public `track_product_view` still records public browse analytics, but an inactive authenticated session no longer writes account-scoped `recently_viewed` history;
- RLS helper calls use init-plan-safe `SELECT` wrappers where this migration creates the policy.

## Scope guard
- **No Supplier Commerce runtime implementation.**
- **No migration 609/610.**
- **No Workspace / Super Admin visual redesign.** Touched pages contain functional wiring only.
- PR #516 remains the controlling Supplier Commerce contract.

## 607 prerequisite — PASS
PR #519 / migration 607 is now:
- production applied and verified;
- rollback-safe contract tested for create/retry/dispatch/deliver/POD/idempotency;
- inactive actor rejection tested;
- merged to `main` at `85caf1eed5c3c4cc4532eaebf8cf2bd7fa5f60f6`.

## Current Branch Guard
- base: `main` at `85caf1eed5c3c4cc4532eaebf8cf2bd7fa5f60f6`;
- audited HEAD: `4c1175c9aabb247daff20012c197e5e345e86b45`;
- PR is mergeable;
- 47 changed files;
- exactly one migration: `supabase/608_enforce_active_account_authorization.sql`;
- no 609/610 and no Supplier Commerce runtime contamination.

## Validation / production pre-state
Focused repository tests exist for active-account auth, admin suspend/reactivate compensation and audit compensation, seller activation, checkout/PaymentIntent eligibility and self-deactivation cleanup. GitHub still exposes no current-head workflow run, so CI PASS is not fabricated.

Read-only production preflight on 19 Aug 2026:
- migration 608 absent;
- `public.is_active_user()` absent;
- inactive users = 0;
- inactive seller lifecycle mismatches = 0;
- users total = 5;
- seller profiles total = 4.

Supabase security-advisor review was performed before cutover. SECURITY DEFINER stale-session paths relevant to this boundary are covered by the live active-role helpers or explicitly hardened in 608. Existing advisor findings unrelated to this account-suspension cutover remain backlog and are not silently bundled into this PR.

## Controlled cutover
**Do not apply migration 608 before the merged runtime is deployed.**

Required order:
1. merge this runtime to main;
2. verify Netlify production has the new account-status/deactivation runtime;
3. apply migration 608;
4. run live rollback-safe active/inactive RLS + trigger + helper verification;
5. only then record 608 PASS.

Checkpoint A as a whole remains NOT PASS until every gate is evidenced.

Sequence remains:
**CHECKPOINT A → ATOMIC PASS → BASELINE FREEZE → GATE B → GATE B PASS → Supplier Commerce phases.**