### PR TITLE
Harden push token ownership invariant migration

### DIFF
--- a/supabase/606_enforce_single_active_push_token_owner.sql
+++ b/supabase/606_enforce_single_active_push_token_owner.sql
@@ -11,10 +11,13 @@
 -- Existing duplicate active ownership is reconciled deterministically before
 -- the unique index is created. The most recently updated row wins; createdAt
 -- and id provide stable tie-breakers. Historical rows are retained inactive.
--- Hold a short write-conflicting lock while reconciling and installing the
--- invariant so no registration can slip between those two operations.
-
-LOCK TABLE public.push_tokens IN SHARE ROW EXCLUSIVE MODE;
+--
+-- Do not depend on the migration runner wrapping multiple statements in one
+-- transaction. The regular CREATE UNIQUE INDEX below is the fail-closed gate:
+-- while the index is installed PostgreSQL blocks conflicting table writes, and
+-- any duplicate active ownership that appears after reconciliation makes index
+-- creation fail rather than silently accepting an invalid state. A failed
+-- migration must be investigated/retried; it is never a PASS.
 
 WITH ranked_active AS (
   SELECT
@@ -36,6 +39,61 @@ WHERE pt.id = ranked.id
 CREATE UNIQUE INDEX IF NOT EXISTS push_tokens_one_active_owner_per_token
   ON public.push_tokens (token)
   WHERE "isActive" = TRUE;
+
+-- Guard against a stale/wrong object with the same index name and verify the
+-- live data invariant before the migration can be considered successful.
+DO $$
+DECLARE
+  v_is_unique boolean;
+  v_is_valid boolean;
+  v_key_definition text;
+  v_predicate text;
+BEGIN
+  SELECT
+    i.indisunique,
+    i.indisvalid,
+    pg_get_indexdef(i.indexrelid, 1, true),
+    pg_get_expr(i.indpred, i.indrelid)
+  INTO
+    v_is_unique,
+    v_is_valid,
+    v_key_definition,
+    v_predicate
+  FROM pg_index AS i
+  JOIN pg_class AS idx
+    ON idx.oid = i.indexrelid
+  JOIN pg_class AS tbl
+    ON tbl.oid = i.indrelid
+  JOIN pg_namespace AS ns
+    ON ns.oid = tbl.relnamespace
+  WHERE ns.nspname = 'public'
+    AND tbl.relname = 'push_tokens'
+    AND idx.relname = 'push_tokens_one_active_owner_per_token'
+    AND i.indnkeyatts = 1;
+
+  IF NOT FOUND
+     OR NOT COALESCE(v_is_unique, false)
+     OR NOT COALESCE(v_is_valid, false)
+     OR v_key_definition IS DISTINCT FROM 'token'
+     OR v_predicate IS NULL
+     OR position('isActive' IN v_predicate) = 0
+  THEN
+    RAISE EXCEPTION
+      'push token ownership invariant index is missing or has an unexpected definition';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.push_tokens
+    WHERE "isActive" = TRUE
+    GROUP BY token
+    HAVING count(*) > 1
+  ) THEN
+    RAISE EXCEPTION
+      'duplicate active push token ownership remains after invariant installation';
+  END IF;
+END;
+$$;
 
 COMMENT ON INDEX public.push_tokens_one_active_owner_per_token IS
   'Privacy invariant: a physical push token can have at most one active Loadify user owner.';


### PR DESCRIPTION
## Checkpoint A — migration 606 hardening

This PR contains the production-applied push-token ownership invariant.

## Why
The original draft used an explicit table lock across reconciliation and index creation. The final migration does not depend on a cross-statement transaction assumption. It reconciles duplicate active ownership deterministically and uses a regular partial UNIQUE index as the fail-closed concurrency gate.

## Canonical repair
- deterministic winner for existing duplicate active ownership: `updatedAt`, then `createdAt`, then `id`;
- historical rows are retained and superseded ownership is deactivated, never deleted;
- partial UNIQUE index on physical `token` where `isActive = true`;
- installed-index definition and remaining-duplicate verification are part of the migration;
- no UI, Workspace, order, payment, Stripe, seller, Supplier Commerce, or customer-flow changes.

## Preconditions
- merged #511 production runtime precondition: PASS;
- production marker/build/device evidence for #511 was supplied and verified before migration execution.

## Production execution evidence — 19 Aug 2026
Migration applied successfully to project `fwdfpmfvgygvqciecesx`.

Live post-state verified immediately after apply:
- migration head: `20260819194042 / enforce_single_active_push_token_owner`;
- active push-token rows: 2;
- inactive historical rows: 4;
- duplicate active physical tokens: 0;
- installed index: `push_tokens_one_active_owner_per_token` = UNIQUE on `token` WHERE `"isActive" = true`;
- negative invariant test attempted to reactivate the superseded duplicate owner inside a rollback-safe PL/pgSQL exception block; PostgreSQL rejected it with the UNIQUE invariant and the historical row remained inactive.

Current live active ownership resolves to two distinct physical tokens, one for the Loadify account and one for the Angelica account.

## Status
**606 DB/data invariant = PASS / APPLIED / VERIFIED.**

This does not by itself declare the entire Checkpoint A push/privacy functional gate PASS; real-device cross-account notification/session isolation remains a separate evidence gate. Checkpoint A remains NOT PASS.

Next sequence remains: corrected #520 pre-cutover runtime -> controlled #519/607 -> #515/608 -> #523/609 -> #522/610, each with its own evidence and no fake PASS.