### PR TITLE
Route shipment server writes through canonical DB contract

### DIFF
--- a/netlify/functions/__tests__/shipment-boundary.test.ts
+++ b/netlify/functions/__tests__/shipment-boundary.test.ts
@@ -1,0 +1,627 @@
+import { readFileSync } from 'node:fs';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HandlerEvent } from '@netlify/functions';
+
+function makeEvent(
+  httpMethod: string,
+  path: string,
+  body: unknown,
+  authorization = 'Bearer valid-token',
+): HandlerEvent {
+  return {
+    httpMethod,
+    body: body === undefined ? null : JSON.stringify(body),
+    headers: { authorization },
+    multiValueHeaders: {},
+    isBase64Encoded: false,
+    path,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    rawQuery: '',
+    rawUrl: `http://localhost${path}`,
+  };
+}
+
+describe('canonical shipment write boundary', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+    process.env.URL = 'https://test.example';
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  function installSharedMocks() {
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+    vi.doMock('../_shared/orderTransitionGuards', () => ({
+      enforcePaymentBackedTransition: vi.fn().mockResolvedValue({
+        ok: true,
+        statusCode: 200,
+        hasValidPaymentEvidence: true,
+        paymentEvidenceSource: 'order.stripePaymentIntentId',
+        requiresPaymentEvidence: true,
+        allowedNonStripeFlow: null,
+      }),
+    }));
+  }
+
+  it('rejects fulfilment-time attempts to rewrite paid shipping terms', async () => {
+    const rpc = vi.fn();
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      from: vi.fn((table: string) => {
+        if (table !== 'users') throw new Error(`Unexpected table before rejection: ${table}`);
+        return {
+          select: vi.fn().mockReturnThis(),
+          eq: vi.fn().mockReturnThis(),
+          single: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+        };
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    installSharedMocks();
+
+    const { handler } = await import('../create-shipment');
+    const res = await handler(
+      makeEvent('POST', '/.netlify/functions/create-shipment', {
+        order_id: 'order-1',
+        shipping_cost: 999,
+      }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).error).toContain('fixed at checkout');
+    expect(rpc).not.toHaveBeenCalled();
+  });
+
+  it('routes shipment create/update through the atomic server RPC', async () => {
+    const rpc = vi.fn().mockResolvedValue({
+      data: {
+        shipment: { id: 'shipment-1', order_id: 'order-1' },
+        created: true,
+        changed: true,
+      },
+      error: null,
+    });
+
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'orders') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'order-1',
+                orderNumber: 'LM-1',
+                status: 'paid',
+                productId: 'product-1',
+                sellerId: 'seller-1',
+                buyerId: 'buyer-1',
+                stripePaymentIntentId: 'pi_1',
+                rfqId: null,
+                rfqResponseId: null,
+                escrowStatus: 'held',
+              },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'products') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { id: 'product-1', listingContext: 'product' },
+              error: null,
+            }),
+          };
+        }
+        throw new Error(`Direct shipment table mutation is not allowed in this handler: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    installSharedMocks();
+
+    const { handler } = await import('../create-shipment');
+    const res = await handler(
+      makeEvent('POST', '/.netlify/functions/create-shipment', {
+        order_id: 'order-1',
+        courier_name: 'Carrier',
+        tracking_number: 'TRACK-1',
+      }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(201);
+    expect(JSON.parse(res.body).changed).toBe(true);
+    expect(rpc).toHaveBeenCalledWith('server_upsert_shipment', {
+      p_order_id: 'order-1',
+      p_actor_id: 'seller-1',
+      p_courier_name: 'Carrier',
+      p_set_courier_name: true,
+      p_tracking_number: 'TRACK-1',
+      p_set_tracking_number: true,
+      p_dispatched_at: null,
+      p_set_dispatched_at: false,
+    });
+  });
+
+  it('routes shipment status + audit + order mapping through one atomic RPC', async () => {
+    const notificationInsert = vi.fn().mockResolvedValue({ error: null });
+    const rpc = vi.fn().mockResolvedValue({
+      data: { shipment: { id: 'shipment-1', status: 'Processing' }, changed: true },
+      error: null,
+    });
+
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'shipments') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'shipment-1',
+                order_id: 'order-1',
+                seller_id: 'seller-1',
+                buyer_id: 'buyer-1',
+                orders: {
+                  id: 'order-1',
+                  orderNumber: 'LM-1',
+                  status: 'paid',
+                  productId: 'product-1',
+                  stripePaymentIntentId: 'pi_1',
+                  rfqId: null,
+                  rfqResponseId: null,
+                  buyerId: 'buyer-1',
+                },
+              },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'notifications') {
+          return { insert: notificationInsert };
+        }
+        throw new Error(`Unexpected direct table access after transition: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    installSharedMocks();
+
+    const { handler } = await import('../update-shipment-status');
+    const res = await handler(
+      makeEvent(
+        'PUT',
+        '/.netlify/functions/shipments/shipment-1/status',
+        { status: 'Processing', message: 'Packing complete' },
+      ),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).changed).toBe(true);
+    expect(rpc).toHaveBeenCalledWith('server_transition_shipment', {
+      p_shipment_id: 'shipment-1',
+      p_actor_id: 'seller-1',
+      p_status: 'Processing',
+      p_message: 'Packing complete',
+    });
+    expect(notificationInsert).toHaveBeenCalledTimes(1);
+  });
+
+  it('suppresses duplicate user-facing side effects on an idempotent status retry', async () => {
+    const notificationInsert = vi.fn();
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const rpc = vi.fn().mockResolvedValue({
+      data: { shipment: { id: 'shipment-1', status: 'Delivered' }, changed: false },
+      error: null,
+    });
+
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'shipments') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'shipment-1',
+                order_id: 'order-1',
+                seller_id: 'seller-1',
+                buyer_id: 'buyer-1',
+                orders: {
+                  id: 'order-1',
+                  orderNumber: 'LM-1',
+                  status: 'delivered',
+                  productId: 'product-1',
+                  stripePaymentIntentId: 'pi_1',
+                  rfqId: null,
+                  rfqResponseId: null,
+                  buyerId: 'buyer-1',
+                },
+              },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'products') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { id: 'product-1', listingContext: 'product' },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'notifications') {
+          return { insert: notificationInsert };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    installSharedMocks();
+
+    const { handler } = await import('../update-shipment-status');
+    const res = await handler(
+      makeEvent(
+        'PUT',
+        '/.netlify/functions/shipments/shipment-1/status',
+        { status: 'Delivered' },
+      ),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).changed).toBe(false);
+    expect(notificationInsert).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('requires shipped payment evidence for Out for Delivery', async () => {
+    const paymentGuard = vi.fn().mockResolvedValue({
+      ok: true,
+      statusCode: 200,
+      hasValidPaymentEvidence: true,
+      paymentEvidenceSource: 'order.stripePaymentIntentId',
+      requiresPaymentEvidence: true,
+      allowedNonStripeFlow: null,
+    });
+    const rpc = vi.fn().mockResolvedValue({
+      data: { shipment: { id: 'shipment-1', status: 'Out for Delivery' }, changed: true },
+      error: null,
+    });
+
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'shipments') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            single: vi.fn().mockResolvedValue({
+              data: {
+                id: 'shipment-1',
+                order_id: 'order-1',
+                seller_id: 'seller-1',
+                buyer_id: 'buyer-1',
+                orders: {
+                  id: 'order-1',
+                  orderNumber: 'LM-1',
+                  status: 'paid',
+                  productId: 'product-1',
+                  stripePaymentIntentId: 'pi_1',
+                  rfqId: null,
+                  rfqResponseId: null,
+                  buyerId: 'buyer-1',
+                },
+              },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'products') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: { id: 'product-1', listingContext: 'product' },
+              error: null,
+            }),
+          };
+        }
+        if (table === 'notifications') {
+          return { insert: vi.fn().mockResolvedValue({ error: null }) };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+    vi.doMock('../_shared/orderTransitionGuards', () => ({
+      enforcePaymentBackedTransition: paymentGuard,
+    }));
+
+    const { handler } = await import('../update-shipment-status');
+    const res = await handler(
+      makeEvent(
+        'PUT',
+        '/.netlify/functions/shipments/shipment-1/status',
+        { status: 'Out for Delivery' },
+      ),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(paymentGuard).toHaveBeenCalledWith(expect.objectContaining({ nextStatus: 'shipped' }));
+  });
+
+  it('does not mint a new POD upload URL after canonical proof is attached', async () => {
+    const createSignedUploadUrl = vi.fn();
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc: vi.fn(),
+      storage: {
+        from: vi.fn(() => ({ createSignedUploadUrl })),
+      },
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'shipments') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                id: 'shipment-1',
+                seller_id: 'seller-1',
+                buyer_id: 'buyer-1',
+                status: 'Delivered',
+                proof_of_delivery_url: 'shipment-1/shipment-1-1.jpg',
+              },
+              error: null,
+            }),
+          };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+
+    const { handler } = await import('../upload-proof-of-delivery');
+    const res = await handler(
+      makeEvent(
+        'POST',
+        '/.netlify/functions/shipments/shipment-1/proof',
+        { contentType: 'image/jpeg', fileSize: 100 },
+      ),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(409);
+    expect(createSignedUploadUrl).not.toHaveBeenCalled();
+  });
+
+  it('treats confirmation of the exact canonical POD path as an idempotent success', async () => {
+    const filePath = 'shipment-1/shipment-1-123.jpg';
+    const rpc = vi.fn();
+    const remove = vi.fn();
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      storage: { from: vi.fn(() => ({ remove })) },
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'shipments') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                id: 'shipment-1',
+                seller_id: 'seller-1',
+                buyer_id: 'buyer-1',
+                status: 'Delivered',
+                proof_of_delivery_url: filePath,
+              },
+              error: null,
+            }),
+          };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+
+    const { handler } = await import('../upload-proof-of-delivery');
+    const res = await handler(
+      makeEvent('PUT', '/.netlify/functions/shipments/shipment-1/proof', { filePath }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body).attached).toBe(false);
+    expect(rpc).not.toHaveBeenCalled();
+    expect(remove).not.toHaveBeenCalled();
+  });
+
+  it('removes an uploaded POD object when the atomic DB attachment is rejected', async () => {
+    const remove = vi.fn().mockResolvedValue({ error: null });
+    const filePath = 'shipment-1/shipment-1-123.jpg';
+    const rpc = vi.fn().mockResolvedValue({
+      data: null,
+      error: { code: 'P0001', message: 'proof is already attached' },
+    });
+    const storageApi = {
+      list: vi.fn().mockResolvedValue({
+        data: [{ name: 'shipment-1-123.jpg', metadata: { size: 100, mimetype: 'image/jpeg' } }],
+        error: null,
+      }),
+      download: vi.fn(),
+      remove,
+    };
+    const supabase = {
+      auth: {
+        getUser: vi.fn().mockResolvedValue({ data: { user: { id: 'seller-1' } }, error: null }),
+      },
+      rpc,
+      storage: { from: vi.fn(() => storageApi) },
+      from: vi.fn((table: string) => {
+        if (table === 'users') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({ data: { id: 'seller-1', role: 'seller' }, error: null }),
+          };
+        }
+        if (table === 'shipments') {
+          return {
+            select: vi.fn().mockReturnThis(),
+            eq: vi.fn().mockReturnThis(),
+            maybeSingle: vi.fn().mockResolvedValue({
+              data: {
+                id: 'shipment-1',
+                seller_id: 'seller-1',
+                buyer_id: 'buyer-1',
+                status: 'Delivered',
+                proof_of_delivery_url: null,
+              },
+              error: null,
+            }),
+          };
+        }
+        throw new Error(`Unexpected table: ${table}`);
+      }),
+    };
+
+    vi.doMock('@supabase/supabase-js', () => ({ createClient: vi.fn(() => supabase) }));
+    vi.doMock('../_shared/rateLimiter', () => ({
+      checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+    }));
+
+    const { handler } = await import('../upload-proof-of-delivery');
+    const res = await handler(
+      makeEvent('PUT', '/.netlify/functions/shipments/shipment-1/proof', { filePath }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(409);
+    expect(rpc).toHaveBeenCalledWith('server_attach_shipment_proof', {
+      p_shipment_id: 'shipment-1',
+      p_actor_id: 'seller-1',
+      p_file_path: filePath,
+    });
+    expect(remove).toHaveBeenCalledWith([filePath]);
+  });
+
+  it('keeps the DB migration service-role-only, atomic, idempotent and one-shipment-per-order', () => {
+    const sql = readFileSync(
+      new URL('../../../supabase/607_lock_shipment_writes_to_server.sql', import.meta.url),
+      'utf8',
+    );
+
+    expect(sql).toContain('CREATE UNIQUE INDEX IF NOT EXISTS shipments_one_per_order');
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.server_upsert_shipment');
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.server_transition_shipment');
+    expect(sql).toContain('CREATE OR REPLACE FUNCTION public.server_attach_shipment_proof');
+    expect(sql).toContain("ARRAY['Dispatched', 'In Transit', 'Out for Delivery']");
+    expect(sql).toContain("'changed', false");
+    expect(sql).toContain("'attached', false");
+    expect(sql).toContain('GRANT EXECUTE ON FUNCTION public.server_upsert_shipment');
+    expect(sql).toContain('TO service_role;');
+    expect(sql).toContain('FROM PUBLIC, anon, authenticated;');
+    expect(sql).toContain('proof of delivery is already attached and cannot be overwritten');
+    expect(sql).toContain('REVOKE INSERT, UPDATE, DELETE, TRUNCATE, REFERENCES, TRIGGER');
+  });
+});

--- a/netlify/functions/__tests__/shipment-inactive-actor.test.ts
+++ b/netlify/functions/__tests__/shipment-inactive-actor.test.ts
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { HandlerEvent } from '@netlify/functions';
+
+const ACTOR_ID = '11111111-1111-4111-8111-111111111111';
+
+function makeEvent(method: string, path: string, body: unknown = {}): HandlerEvent {
+  return {
+    httpMethod: method,
+    body: JSON.stringify(body),
+    headers: { authorization: 'Bearer valid-but-suspended-token' },
+    multiValueHeaders: {},
+    isBase64Encoded: false,
+    path,
+    queryStringParameters: null,
+    multiValueQueryStringParameters: null,
+    rawQuery: '',
+    rawUrl: `http://localhost${path}`,
+  };
+}
+
+function installInactiveActorMock() {
+  const rpc = vi.fn();
+  const storageFrom = vi.fn();
+  const from = vi.fn((table: string) => {
+    if (table !== 'users') {
+      throw new Error(`Inactive actor reached protected service-role table: ${table}`);
+    }
+    return {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      maybeSingle: vi.fn().mockResolvedValue({
+        data: { id: ACTOR_ID, role: 'seller', isActive: false },
+        error: null,
+      }),
+    };
+  });
+
+  const client = {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: { id: ACTOR_ID } },
+        error: null,
+      }),
+    },
+    from,
+    rpc,
+    storage: { from: storageFrom },
+  };
+
+  vi.doMock('@supabase/supabase-js', () => ({
+    createClient: vi.fn(() => client),
+  }));
+  vi.doMock('../_shared/rateLimiter', () => ({
+    checkRateLimit: vi.fn().mockResolvedValue({ exceeded: false }),
+  }));
+  vi.doMock('../_shared/orderTransitionGuards', () => ({
+    enforcePaymentBackedTransition: vi.fn().mockResolvedValue({ ok: true }),
+  }));
+
+  return { rpc, storageFrom, from };
+}
+
+describe('shipment boundaries reject inactive actors before service-role mutation', () => {
+  const originalEnv = { ...process.env };
+
+  beforeEach(() => {
+    process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-test-key';
+    process.env.URL = 'https://test.example';
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    vi.restoreAllMocks();
+  });
+
+  it('blocks create-shipment before the canonical mutation RPC', async () => {
+    const mocks = installInactiveActorMock();
+    const { handler } = await import('../create-shipment');
+
+    const res = await handler(
+      makeEvent('POST', '/.netlify/functions/create-shipment', { order_id: 'order-1' }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toContain('suspended');
+    expect(mocks.rpc).not.toHaveBeenCalled();
+    expect(mocks.from).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks update-shipment-status before the canonical transition RPC', async () => {
+    const mocks = installInactiveActorMock();
+    const { handler } = await import('../update-shipment-status');
+
+    const res = await handler(
+      makeEvent('PUT', '/.netlify/functions/shipments/shipment-1/status', { status: 'Delivered' }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toContain('suspended');
+    expect(mocks.rpc).not.toHaveBeenCalled();
+    expect(mocks.from).toHaveBeenCalledTimes(1);
+  });
+
+  it('blocks proof-of-delivery before shipment access or private Storage access', async () => {
+    const mocks = installInactiveActorMock();
+    const { handler } = await import('../upload-proof-of-delivery');
+
+    const res = await handler(
+      makeEvent('POST', '/.netlify/functions/shipments/shipment-1/proof', {
+        contentType: 'image/jpeg',
+        fileSize: 1024,
+      }),
+      {} as never,
+    );
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toContain('suspended');
+    expect(mocks.rpc).not.toHaveBeenCalled();
+    expect(mocks.storageFrom).not.toHaveBeenCalled();
+    expect(mocks.from).toHaveBeenCalledTimes(1);
+  });
+});

--- a/netlify/functions/__tests__/shipment-inactive-actor.test.ts
+++ b/netlify/functions/__tests__/shipment-inactive-actor.test.ts
@@ -21,6 +21,10 @@ function makeEvent(method: string, path: string, body: unknown = {}): HandlerEve
 function installInactiveActorMock() {
   const rpc = vi.fn();
   const storageFrom = vi.fn();
+  const inactiveActorResult = {
+    data: { id: ACTOR_ID, role: 'seller', isActive: false },
+    error: null,
+  };
   const from = vi.fn((table: string) => {
     if (table !== 'users') {
       throw new Error(`Inactive actor reached protected service-role table: ${table}`);
@@ -28,10 +32,8 @@ function installInactiveActorMock() {
     return {
       select: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
-      maybeSingle: vi.fn().mockResolvedValue({
-        data: { id: ACTOR_ID, role: 'seller', isActive: false },
-        error: null,
-      }),
+      single: vi.fn().mockResolvedValue(inactiveActorResult),
+      maybeSingle: vi.fn().mockResolvedValue(inactiveActorResult),
     };
   });
 

--- a/netlify/functions/create-shipment.ts
+++ b/netlify/functions/create-shipment.ts
@@ -32,7 +32,13 @@ type ShipmentMutationResult = {
   changed?: boolean;
 };
 
-async function getAuthUser(event: HandlerEvent) {
+type ShipmentActor = {
+  id: string;
+  role: string;
+  isActive: boolean;
+};
+
+async function getAuthUser(event: HandlerEvent): Promise<ShipmentActor | null> {
   const authHeader = event.headers.authorization || event.headers.Authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return null;
@@ -45,12 +51,13 @@ async function getAuthUser(event: HandlerEvent) {
     return null;
   }
 
-  const { data: userData } = await supabase
+  const { data: userData, error: userError } = await supabase
     .from('users')
-    .select('*')
+    .select('id, role, isActive')
     .eq('id', user.id)
-    .single();
+    .maybeSingle<ShipmentActor>();
 
+  if (userError || !userData) return null;
   return userData;
 }
 
@@ -75,6 +82,16 @@ export const handler: Handler = async (event) => {
       return {
         statusCode: 401,
         body: JSON.stringify({ error: 'Unauthorized' }),
+      };
+    }
+
+    // This runtime is deliberately deployed before migration 608. Do not rely
+    // on later RLS/Auth helpers to close the cutover window: a valid/stale JWT
+    // for an inactive account must never reach a service-role mutation or RPC.
+    if (user.isActive !== true) {
+      return {
+        statusCode: 403,
+        body: JSON.stringify({ error: 'Account is suspended' }),
       };
     }
 

--- a/netlify/functions/create-shipment.ts
+++ b/netlify/functions/create-shipment.ts
@@ -20,11 +20,18 @@ interface CreateShipmentRequest {
   courier_name?: string;
   tracking_number?: string;
   dispatched_at?: string | null;
-  shipping_method?: string;
-  shipping_cost?: number;
+  // Legacy fields are accepted only so the endpoint can reject attempts to
+  // mutate paid commercial terms explicitly instead of silently ignoring them.
+  shipping_method?: unknown;
+  shipping_cost?: unknown;
 }
 
-// Helper to get user from Authorization header
+type ShipmentMutationResult = {
+  shipment?: Record<string, unknown>;
+  created?: boolean;
+  changed?: boolean;
+};
+
 async function getAuthUser(event: HandlerEvent) {
   const authHeader = event.headers.authorization || event.headers.Authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
@@ -38,7 +45,6 @@ async function getAuthUser(event: HandlerEvent) {
     return null;
   }
 
-  // Get user role
   const { data: userData } = await supabase
     .from('users')
     .select('*')
@@ -64,7 +70,6 @@ export const handler: Handler = async (event) => {
   }
 
   try {
-    // Authenticate user
     const user = await getAuthUser(event);
     if (!user) {
       return {
@@ -73,7 +78,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Only sellers and admins can create shipments
     if (user.role !== 'seller' && user.role !== 'admin') {
       return {
         statusCode: 403,
@@ -81,7 +85,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Rate-limit: 30 shipment creates/updates per user per 60-minute window.
     const shipRl = await checkRateLimit({
       supabase,
       tableName: 'create_shipment_rate_limits',
@@ -105,7 +108,7 @@ export const handler: Handler = async (event) => {
         body: JSON.stringify({ error: 'Invalid JSON in request body' }),
       };
     }
-    const { order_id, courier_name, tracking_number, dispatched_at, shipping_method, shipping_cost } = body;
+    const { order_id, courier_name, tracking_number, dispatched_at } = body;
 
     if (!order_id) {
       return {
@@ -114,16 +117,31 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    if (shipping_cost !== undefined && (!Number.isFinite(shipping_cost) || shipping_cost < 0)) {
+    if (
+      Object.prototype.hasOwnProperty.call(body, 'dispatched_at') &&
+      dispatched_at !== null &&
+      (typeof dispatched_at !== 'string' || Number.isNaN(Date.parse(dispatched_at)))
+    ) {
       return {
         statusCode: 400,
-        body: JSON.stringify({ error: 'shipping_cost must be a non-negative number' }),
+        body: JSON.stringify({ error: 'dispatched_at must be a valid timestamp or null' }),
       };
     }
 
-    // Verify the order exists and user is the seller (or admin).
-    // Shipment creation is an order-lifecycle operation: terminal/cancelled
-    // orders must never be turned back into fulfilment work.
+    // Shipping method/amount are commercial terms fixed by the verified checkout
+    // and Stripe payment evidence. Fulfilment must never rewrite them.
+    if (
+      Object.prototype.hasOwnProperty.call(body, 'shipping_method') ||
+      Object.prototype.hasOwnProperty.call(body, 'shipping_cost')
+    ) {
+      return {
+        statusCode: 409,
+        body: JSON.stringify({
+          error: 'Shipping method and amount are fixed at checkout and cannot be changed during fulfilment.',
+        }),
+      };
+    }
+
     const { data: order, error: orderError } = await supabase
       .from('orders')
       .select('id, orderNumber, status, productId, sellerId, buyerId, stripePaymentIntentId, rfqId, rfqResponseId, escrowStatus')
@@ -137,7 +155,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Check authorization
     if (user.role !== 'admin' && order.sellerId !== user.id) {
       return {
         statusCode: 403,
@@ -145,7 +162,9 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    if (['cancelled', 'refunded', 'disputed', 'completed'].includes(order.status)) {
+    // Delivered is terminal for shipment-detail mutation. Return/POD flows have
+    // their own canonical boundaries and must not reopen tracking/details history.
+    if (['cancelled', 'refunded', 'disputed', 'delivered', 'completed'].includes(order.status)) {
       return {
         statusCode: 409,
         body: JSON.stringify({ error: `A shipment cannot be created or changed for an order in '${order.status}' status.` }),
@@ -165,9 +184,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // A physical order must have valid completed Stripe evidence before a
-    // shipment can be created at all. This closes the create-shipment bypass
-    // around the guarded status-update endpoint.
     const paymentGuard = await enforcePaymentBackedTransition({
       supabase,
       order,
@@ -183,90 +199,49 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Check if shipment already exists for this order
-    const { data: existingShipment } = await supabase
-      .from('shipments')
-      .select('*')
-      .eq('order_id', order_id)
-      .single();
+    const { data: mutation, error: mutationError } = await supabase.rpc('server_upsert_shipment', {
+      p_order_id: order_id,
+      p_actor_id: user.id,
+      p_courier_name: typeof courier_name === 'string' ? courier_name : null,
+      p_set_courier_name: Object.prototype.hasOwnProperty.call(body, 'courier_name'),
+      p_tracking_number: typeof tracking_number === 'string' ? tracking_number : null,
+      p_set_tracking_number: Object.prototype.hasOwnProperty.call(body, 'tracking_number'),
+      p_dispatched_at: dispatched_at ?? null,
+      p_set_dispatched_at: Object.prototype.hasOwnProperty.call(body, 'dispatched_at'),
+    });
 
-    let shipment;
-    let isNew = false;
-
-    if (existingShipment) {
-      // Update existing shipment
-      const { data, error } = await supabase
-        .from('shipments')
-        .update({
-          courier_name,
-          tracking_number,
-          ...(dispatched_at !== undefined ? { dispatched_at } : {}),
-          updated_at: new Date().toISOString(),
-        })
-        .eq('id', existingShipment.id)
-        .select()
-        .single();
-
-      if (error) {
-        throw error;
+    if (mutationError) {
+      if (mutationError.code === '42501') {
+        return { statusCode: 403, body: JSON.stringify({ error: 'Not authorized' }) };
       }
-      shipment = data;
-    } else {
-      // Create new shipment
-      const { data, error } = await supabase
-        .from('shipments')
-        .insert({
-          order_id,
-          seller_id: order.sellerId,
-          buyer_id: order.buyerId,
-          courier_name,
-          tracking_number,
-          dispatched_at: dispatched_at || null,
-          status: dispatched_at ? 'Dispatched' : 'Pending',
-        })
-        .select()
-        .single();
-
-      if (error) {
-        throw error;
+      if (mutationError.code === 'P0002') {
+        return { statusCode: 404, body: JSON.stringify({ error: 'Order not found' }) };
       }
-      shipment = data;
-      isNew = true;
-
-      // Create initial shipment event
-      await supabase
-        .from('shipment_events')
-        .insert({
-          shipment_id: shipment.id,
-          status: dispatched_at ? 'Dispatched' : 'Pending',
-          message: dispatched_at ? `Shipment dispatched on ${new Date(dispatched_at).toLocaleDateString('en-GB')}` : 'Shipment created',
-          changed_by: user.id,
-        });
+      if (mutationError.code === 'P0001') {
+        return { statusCode: 409, body: JSON.stringify({ error: mutationError.message }) };
+      }
+      throw new Error(`Atomic shipment mutation failed: ${mutationError.message}`);
     }
 
-    // The API payload keeps snake_case for backwards compatibility, but the
-    // canonical orders schema uses camelCase column names.
-    if (shipping_method || shipping_cost !== undefined) {
-      const updateData: { shippingMethod?: string; shippingAmount?: number } = {};
-      if (shipping_method) updateData.shippingMethod = shipping_method;
-      if (shipping_cost !== undefined) updateData.shippingAmount = shipping_cost;
-
-      const { error: orderShippingError } = await supabase
-        .from('orders')
-        .update(updateData)
-        .eq('id', order_id);
-
-      if (orderShippingError) {
-        throw new Error(`Failed to persist order shipping details: ${orderShippingError.message}`);
-      }
+    const result = mutation as ShipmentMutationResult | null;
+    if (!result?.shipment) {
+      throw new Error('Atomic shipment mutation returned no shipment');
     }
+
+    const isNew = result.created === true;
+    const changed = result.changed === true;
 
     return {
       statusCode: isNew ? 201 : 200,
       body: JSON.stringify({ 
         success: true, 
-        shipment,
-        message: isNew ? 'Shipment created' : 'Shipment updated'
+        shipment: result.shipment,
+        changed,
+        message: isNew
+          ? 'Shipment created'
+          : changed
+            ? 'Shipment updated'
+            : 'Shipment already matches the requested details'
       }),
     };
   } catch (error) {

--- a/netlify/functions/create-shipment.ts
+++ b/netlify/functions/create-shipment.ts
@@ -55,7 +55,7 @@ async function getAuthUser(event: HandlerEvent): Promise<ShipmentActor | null> {
     .from('users')
     .select('id, role, isActive')
     .eq('id', user.id)
-    .maybeSingle<ShipmentActor>();
+    .single<ShipmentActor>();
 
   if (userError || !userData) return null;
   return userData;

--- a/netlify/functions/update-shipment-status.ts
+++ b/netlify/functions/update-shipment-status.ts
@@ -20,6 +20,15 @@ interface UpdateStatusRequest {
   message?: string;
 }
 
+type ShipmentTransitionResult = {
+  shipment?: {
+    tracking_number?: string | null;
+    courier_name?: string | null;
+    [key: string]: unknown;
+  };
+  changed?: boolean;
+};
+
 // Helper to get user from Authorization header
 async function getAuthUser(event: HandlerEvent) {
   const authHeader = event.headers.authorization || event.headers.Authorization;
@@ -34,7 +43,6 @@ async function getAuthUser(event: HandlerEvent) {
     return null;
   }
 
-  // Get user role
   const { data: userData } = await supabase
     .from('users')
     .select('*')
@@ -44,8 +52,11 @@ async function getAuthUser(event: HandlerEvent) {
   return userData;
 }
 
-// Helper to send email notifications
-async function sendStatusEmail(order: { buyerId: string; orderNumber: string; id: string }, shipment: { tracking_number?: string | null; courier_name?: string | null }, status: string) {
+async function sendStatusEmail(
+  order: { buyerId: string; orderNumber: string; id: string },
+  shipment: { tracking_number?: string | null; courier_name?: string | null },
+  status: string,
+) {
   const emailTemplates: Record<string, { subject: string; template: string }> = {
     'Dispatched': {
       subject: 'Your order has been dispatched',
@@ -62,12 +73,9 @@ async function sendStatusEmail(order: { buyerId: string; orderNumber: string; id
   };
 
   const emailConfig = emailTemplates[status];
-  if (!emailConfig) {
-    return; // No email for this status
-  }
+  if (!emailConfig) return;
 
   try {
-    // Get buyer info
     const { data: buyer } = await supabase
       .from('users')
       .select('email, firstName, lastName')
@@ -102,7 +110,7 @@ async function sendStatusEmail(order: { buyerId: string; orderNumber: string; id
     });
   } catch (error) {
     console.error('Failed to send email:', error);
-    // Don't fail the whole request if email fails
+    // Post-commit notification failure must not roll back canonical shipment state.
   }
 }
 
@@ -122,7 +130,6 @@ export const handler: Handler = async (event) => {
   }
 
   try {
-    // Authenticate user
     const user = await getAuthUser(event);
     if (!user) {
       return {
@@ -131,7 +138,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Only sellers and admins may update shipment status.
     if (user.role !== 'seller' && user.role !== 'admin') {
       return {
         statusCode: 403,
@@ -139,7 +145,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Rate-limit: 60 status updates per user per 60-minute window.
     const statusRl = await checkRateLimit({
       supabase,
       tableName: 'update_shipment_status_rate_limits',
@@ -154,9 +159,8 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Get shipment ID from path
     const pathParts = event.path.split('/');
-    const shipmentId = pathParts[pathParts.length - 2]; // .../shipments/:id/status
+    const shipmentId = pathParts[pathParts.length - 2];
 
     if (!shipmentId) {
       return {
@@ -183,7 +187,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Validate status
     const validStatuses = ['Pending', 'Processing', 'Dispatched', 'In Transit', 'Out for Delivery', 'Delivered', 'Returned', 'Delivery Failed'];
     if (!validStatuses.includes(status)) {
       return {
@@ -192,7 +195,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Get shipment and verify authorization
     const { data: shipment, error: shipmentError } = await supabase
       .from('shipments')
       .select('*, orders(*)')
@@ -206,7 +208,6 @@ export const handler: Handler = async (event) => {
       };
     }
 
-    // Check authorization (seller or admin)
     if (user.role !== 'admin' && shipment.seller_id !== user.id) {
       return {
         statusCode: 403,
@@ -217,16 +218,16 @@ export const handler: Handler = async (event) => {
     let targetOrderStatus: GuardedOrderStatus | null = null;
     if (status === 'Delivered') {
       targetOrderStatus = 'delivered';
-    } else if (status === 'Dispatched' || status === 'In Transit') {
+    } else if (status === 'Dispatched' || status === 'In Transit' || status === 'Out for Delivery') {
       targetOrderStatus = 'shipped';
     }
 
     if (targetOrderStatus && shipment.orders?.id && shipment.orders?.productId) {
-        const { data: product } = await supabase
-          .from('products')
-          .select('id, listingContext')
-          .eq('id', shipment.orders.productId)
-          .maybeSingle<{ id: string; listingContext: 'product' | 'service' | null }>();
+      const { data: product } = await supabase
+        .from('products')
+        .select('id, listingContext')
+        .eq('id', shipment.orders.productId)
+        .maybeSingle<{ id: string; listingContext: 'product' | 'service' | null }>();
 
       const paymentGuard = await enforcePaymentBackedTransition({
         supabase,
@@ -255,72 +256,62 @@ export const handler: Handler = async (event) => {
       }
     }
 
-    // Update shipment status
-    const { data: updatedShipment, error: updateError } = await supabase
-      .from('shipments')
-      .update({
-        status,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', shipmentId)
-      .select()
-      .single();
+    const { data: transition, error: transitionError } = await supabase.rpc('server_transition_shipment', {
+      p_shipment_id: shipmentId,
+      p_actor_id: user.id,
+      p_status: status,
+      p_message: typeof message === 'string' ? message : null,
+    });
 
-    if (updateError) {
-      throw updateError;
+    if (transitionError) {
+      if (transitionError.code === '42501') {
+        return { statusCode: 403, body: JSON.stringify({ error: 'Not authorized' }) };
+      }
+      if (transitionError.code === 'P0002') {
+        return { statusCode: 404, body: JSON.stringify({ error: 'Shipment or order not found' }) };
+      }
+      if (transitionError.code === '22023') {
+        return { statusCode: 400, body: JSON.stringify({ error: transitionError.message }) };
+      }
+      if (transitionError.code === 'P0001') {
+        return { statusCode: 409, body: JSON.stringify({ error: transitionError.message }) };
+      }
+      throw new Error(`Atomic shipment transition failed: ${transitionError.message}`);
     }
 
-    // Insert shipment event
-    await supabase
-      .from('shipment_events')
-      .insert({
-        shipment_id: shipmentId,
-        status,
-        message: message || `Status updated to ${status}`,
-        changed_by: user.id,
-      });
-
-    // Update order status if applicable
-    if (status === 'Delivered') {
-      await supabase
-        .from('orders')
-        .update({ 
-          status: 'delivered',
-          deliveredAt: new Date().toISOString()
-        })
-        .eq('id', shipment.order_id);
-    } else if (status === 'Dispatched' || status === 'In Transit') {
-      await supabase
-        .from('orders')
-        .update({ status: 'shipped' })
-        .eq('id', shipment.order_id);
+    const result = transition as ShipmentTransitionResult | null;
+    if (!result?.shipment) {
+      throw new Error('Atomic shipment transition returned no shipment');
     }
+    const updatedShipment = result.shipment;
+    const changed = result.changed === true;
 
-    // Create the buyer's in-app notification server-side. The seller cannot
-    // insert a notification for another user under the notifications RLS policy,
-    // so this belongs in the authenticated service-role transition handler.
-    const { error: notificationError } = await supabase
-      .from('notifications')
-      .insert({
-        userId: shipment.buyer_id,
-        type: 'shipment',
-        title: 'Shipment update',
-        message: `Your order ${shipment.orders?.orderNumber ?? shipment.order_id} shipment status is now: ${status}.`,
-        link: '/buyer/orders',
-      });
-    if (notificationError) {
-      console.error('Failed to create shipment notification:', notificationError.message);
+    // Idempotent retries return success but must not duplicate user-facing side
+    // effects. Only a material canonical state change emits notification/email.
+    if (changed) {
+      const { error: notificationError } = await supabase
+        .from('notifications')
+        .insert({
+          userId: shipment.buyer_id,
+          type: 'shipment',
+          title: 'Shipment update',
+          message: `Your order ${shipment.orders?.orderNumber ?? shipment.order_id} shipment status is now: ${status}.`,
+          link: '/buyer/orders',
+        });
+      if (notificationError) {
+        console.error('Failed to create shipment notification:', notificationError.message);
+      }
+
+      await sendStatusEmail(shipment.orders, updatedShipment, status);
     }
-
-    // Send email notification for certain statuses
-    await sendStatusEmail(shipment.orders, updatedShipment, status);
 
     return {
       statusCode: 200,
       body: JSON.stringify({ 
         success: true, 
         shipment: updatedShipment,
-        message: 'Status updated successfully'
+        changed,
+        message: changed ? 'Status updated successfully' : 'Shipment already has the requested status'
       }),
     };
   } catch (error) {

--- a/netlify/functions/update-shipment-status.ts
+++ b/netlify/functions/update-shipment-status.ts
@@ -53,7 +53,7 @@ async function getAuthUser(event: HandlerEvent): Promise<ShipmentActor | null> {
     .from('users')
     .select('id, role, isActive')
     .eq('id', user.id)
-    .maybeSingle<ShipmentActor>();
+    .single<ShipmentActor>();
 
   if (userError || !userData) return null;
   return userData;

--- a/netlify/functions/update-shipment-status.ts
+++ b/netlify/functions/update-shipment-status.ts
@@ -29,8 +29,14 @@ type ShipmentTransitionResult = {
   changed?: boolean;
 };
 
-// Helper to get user from Authorization header
-async function getAuthUser(event: HandlerEvent) {
+type ShipmentActor = {
+  id: string;
+  role: string;
+  isActive: boolean;
+};
+
+// Helper to get user from Authorization header and resolve current platform state.
+async function getAuthUser(event: HandlerEvent): Promise<ShipmentActor | null> {
   const authHeader = event.headers.authorization || event.headers.Authorization;
   if (!authHeader || !authHeader.startsWith('Bearer ')) {
     return null;
@@ -43,12 +49,13 @@ async function getAuthUser(event: HandlerEvent) {
     return null;
   }
 
-  const { data: userData } = await supabase
+  const { data: userData, error: userError } = await supabase
     .from('users')
-    .select('*')
+    .select('id, role, isActive')
     .eq('id', user.id)
-    .single();
+    .maybeSingle<ShipmentActor>();
 
+  if (userError || !userData) return null;
   return userData;
 }
 
@@ -135,6 +142,15 @@ export const handler: Handler = async (event) => {
       return {
         statusCode: 401,
         body: JSON.stringify({ error: 'Unauthorized' }),
+      };
+    }
+
+    // #520 is intentionally the pre-608 runtime. A stale but otherwise valid
+    // token for a suspended actor must stop here before any service-role access.
+    if (user.isActive !== true) {
+      return {
+        statusCode: 403,
+        body: JSON.stringify({ error: 'Account is suspended' }),
       };
     }
 

--- a/netlify/functions/upload-proof-of-delivery.ts
+++ b/netlify/functions/upload-proof-of-delivery.ts
@@ -29,6 +29,11 @@ const EXT_TO_MIME: Record<string, string> = {
   pdf: 'application/pdf',
 };
 
+type AttachProofResult = {
+  shipment?: Record<string, unknown>;
+  attached?: boolean;
+};
+
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -42,6 +47,13 @@ function isSafeProofPath(shipmentId: string, filePath: string): boolean {
 function expectedMime(filePath: string): string | null {
   const ext = filePath.split('.').pop()?.toLowerCase() ?? '';
   return EXT_TO_MIME[ext] ?? null;
+}
+
+async function removeUncommittedProof(filePath: string): Promise<void> {
+  const { error } = await supabase.storage.from(BUCKET_NAME).remove([filePath]);
+  if (error) {
+    console.error('upload-proof-of-delivery: failed to remove uncommitted proof object:', error.message);
+  }
 }
 
 async function getAuthUser(event: HandlerEvent) {
@@ -138,6 +150,20 @@ export const handler: Handler = async (event) => {
   }
 
   if (event.httpMethod === 'POST') {
+    // POD is commercial evidence. Once attached, do not mint another signed
+    // upload URL. PUT confirmation remains retry-safe for the already-canonical
+    // path, but POST cannot create replacement evidence.
+    if (shipment.proof_of_delivery_url) {
+      return { statusCode: 409, body: JSON.stringify({ error: 'Proof of delivery is already attached and cannot be replaced.' }) };
+    }
+
+    // A proof-of-delivery object may only be created for an actual Delivered
+    // shipment. This prevents evidence from existing before the lifecycle event
+    // it is intended to prove.
+    if (shipment.status !== 'Delivered') {
+      return { statusCode: 409, body: JSON.stringify({ error: 'Proof of delivery can only be uploaded after the shipment is Delivered.' }) };
+    }
+
     let requestBody: { contentType?: string; fileSize?: number };
     try {
       requestBody = JSON.parse(event.body || '{}') as { contentType?: string; fileSize?: number };
@@ -182,6 +208,34 @@ export const handler: Handler = async (event) => {
       return { statusCode: 400, body: JSON.stringify({ error: 'Invalid upload path' }) };
     }
 
+    // Confirmation retries for the exact canonical object are safe even if the
+    // shipment later entered a return/recovery state. A different object can
+    // never replace established evidence.
+    if (shipment.proof_of_delivery_url) {
+      if (shipment.proof_of_delivery_url === filePath) {
+        return {
+          statusCode: 200,
+          body: JSON.stringify({
+            success: true,
+            shipment,
+            attached: false,
+            message: 'Proof of delivery is already attached',
+          }),
+        };
+      }
+
+      await removeUncommittedProof(filePath);
+      return { statusCode: 409, body: JSON.stringify({ error: 'Proof of delivery is already attached and cannot be replaced.' }) };
+    }
+
+    if (shipment.status !== 'Delivered') {
+      // A signed URL may have been minted while the shipment was Delivered and
+      // the state may have changed before confirmation. The object is not part of
+      // commercial history until DB attachment succeeds, so remove it.
+      await removeUncommittedProof(filePath);
+      return { statusCode: 409, body: JSON.stringify({ error: 'Proof of delivery can only be attached while the shipment is Delivered.' }) };
+    }
+
     const fileName = filePath.split('/').pop() ?? '';
     const { data: listedObjects, error: listError } = await supabase.storage
       .from(BUCKET_NAME)
@@ -219,31 +273,53 @@ export const handler: Handler = async (event) => {
       !requiredMime ||
       normalizedActualMime !== requiredMime
     ) {
-      await supabase.storage.from(BUCKET_NAME).remove([filePath]).catch(() => undefined);
+      await removeUncommittedProof(filePath);
       return { statusCode: 400, body: JSON.stringify({ error: 'Uploaded proof file failed server validation' }) };
     }
 
-    const { data: updatedShipment, error: updateError } = await supabase
-      .from('shipments')
-      .update({
-        proof_of_delivery_url: filePath,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', shipmentId)
-      .select()
-      .single();
-    if (updateError) throw updateError;
-
-    await supabase.from('shipment_events').insert({
-      shipment_id: shipmentId,
-      status: shipment.status,
-      message: 'Proof of delivery uploaded',
-      changed_by: user.id,
+    // Attach the validated object path and append its audit event in one DB
+    // transaction. If a different concurrent proof won the race, remove this
+    // newly-uploaded unreferenced object as compensation.
+    const { data: attachResult, error: attachError } = await supabase.rpc('server_attach_shipment_proof', {
+      p_shipment_id: shipmentId,
+      p_actor_id: user.id,
+      p_file_path: filePath,
     });
+
+    if (attachError) {
+      await removeUncommittedProof(filePath);
+      if (attachError.code === '42501') {
+        return { statusCode: 403, body: JSON.stringify({ error: 'Not authorized' }) };
+      }
+      if (attachError.code === 'P0002') {
+        return { statusCode: 404, body: JSON.stringify({ error: 'Shipment not found' }) };
+      }
+      if (attachError.code === '22023') {
+        return { statusCode: 400, body: JSON.stringify({ error: attachError.message }) };
+      }
+      if (attachError.code === 'P0001') {
+        return { statusCode: 409, body: JSON.stringify({ error: attachError.message }) };
+      }
+      throw new Error(`Atomic proof attachment failed: ${attachError.message}`);
+    }
+
+    const result = attachResult as AttachProofResult | null;
+    if (!result?.shipment) {
+      // DB commit succeeded but the contract response is invalid. Do NOT delete
+      // the object now because it may already be the canonical referenced proof.
+      throw new Error('Atomic proof attachment returned no shipment');
+    }
 
     return {
       statusCode: 200,
-      body: JSON.stringify({ success: true, shipment: updatedShipment, message: 'Proof of delivery uploaded successfully' }),
+      body: JSON.stringify({
+        success: true,
+        shipment: result.shipment,
+        attached: result.attached === true,
+        message: result.attached === true
+          ? 'Proof of delivery uploaded successfully'
+          : 'Proof of delivery is already attached',
+      }),
     };
   }
 

--- a/netlify/functions/upload-proof-of-delivery.ts
+++ b/netlify/functions/upload-proof-of-delivery.ts
@@ -34,6 +34,12 @@ type AttachProofResult = {
   attached?: boolean;
 };
 
+type ShipmentActor = {
+  id: string;
+  role: string;
+  isActive: boolean;
+};
+
 function escapeRegex(value: string): string {
   return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }
@@ -56,18 +62,20 @@ async function removeUncommittedProof(filePath: string): Promise<void> {
   }
 }
 
-async function getAuthUser(event: HandlerEvent) {
+async function getAuthUser(event: HandlerEvent): Promise<ShipmentActor | null> {
   const authHeader = event.headers.authorization || event.headers.Authorization;
   if (!authHeader?.startsWith('Bearer ')) return null;
 
   const { data: { user }, error } = await supabase.auth.getUser(authHeader.substring(7));
   if (error || !user) return null;
 
-  const { data: userData } = await supabase
+  const { data: userData, error: userError } = await supabase
     .from('users')
-    .select('id, role')
+    .select('id, role, isActive')
     .eq('id', user.id)
-    .maybeSingle<{ id: string; role: string }>();
+    .maybeSingle<ShipmentActor>();
+
+  if (userError || !userData) return null;
   return userData;
 }
 
@@ -80,6 +88,14 @@ export const handler: Handler = async (event) => {
   if (!user) {
     return { statusCode: 401, body: JSON.stringify({ error: 'Unauthorized' }) };
   }
+
+  // This boundary uses service_role for private Storage and shipment evidence.
+  // It therefore must enforce the live account state itself during the pre-608
+  // cutover; a stale valid JWT for a suspended account is never sufficient.
+  if (user.isActive !== true) {
+    return { statusCode: 403, body: JSON.stringify({ error: 'Account is suspended' }) };
+  }
+
   if (user.role !== 'seller' && user.role !== 'admin' && user.role !== 'buyer') {
     return { statusCode: 403, body: JSON.stringify({ error: 'Forbidden' }) };
   }


### PR DESCRIPTION
## Checkpoint A P1 — shipment RPC-only pre-cutover runtime

This PR is the **pre-cutover fail-closed runtime** and now targets current `main`, which already contains the production-applied/verified 606 invariant.

## Controlled cutover contract
This PR must deploy **before** migration 607.

The shipment handlers use only the canonical service-role RPCs (`server_upsert_shipment`, `server_transition_shipment`, `server_attach_shipment_proof`) and contain no fallback to direct shipment/order/event mutation. While 607 is absent, mutation attempts therefore fail closed because the RPCs do not yet exist.

## Active-account cutover correction
Guardian found that 608 is intentionally later than this runtime. The three shipment/POD boundaries now independently resolve `users.id, role, isActive` and reject `isActive != true` before rate limiting, shipment/order access, private Storage access, or canonical mutation RPC execution. This prevents a valid/stale JWT for a suspended account from exploiting the pre-608 interval.

Covered boundaries:
- `netlify/functions/create-shipment.ts`;
- `netlify/functions/update-shipment-status.ts`;
- `netlify/functions/upload-proof-of-delivery.ts`.

A focused `shipment-inactive-actor.test.ts` asserts the inactive actor receives 403 and never reaches shipment mutation RPC/private Storage. Existing `shipment-boundary.test.ts` remains the broader shipment contract suite.

## Canonical behavior preserved
- fulfilment-time shipping method/cost rewrites rejected;
- shipment/order/event writes only through canonical RPCs;
- retry/idempotency behavior preserved;
- duplicate notification side effects suppressed on no-op retry;
- POD private/immutable and first attachment only after Delivered;
- no checkout amount, Stripe, Supplier Commerce, UI or product schema changes.

## Current branch state
- base: `main` at `6f6049ce2c89fa78afcee7ea9ca27f2498b8dd61` when retargeted;
- current head includes the original 4-file shipment slice plus the new inactive-actor test;
- production runtime is still unchanged by this PR;
- GitHub Actions run for the corrected head again terminated with failed jobs before any steps were exposed; therefore CI is infrastructure-blocked and is **not** reported as code PASS/FAIL.

## Mandatory execution sequence
606 PASS (done) -> **deploy this runtime and verify shipment writes fail closed while 607 is absent** -> apply/verify 607 -> verify this already-deployed runtime succeeds RPC-only -> only then shipment cutover PASS.

Status: **DRAFT / CODE CORRECTION PRESENT / DEPLOY + CUTOVER EVIDENCE PENDING / DO NOT APPLY 607 YET.**

Checkpoint A remains NOT PASS.