### PR TITLE
Enforce immutable order commercial snapshots (migration 610)

### DIFF
--- a/netlify/functions/__tests__/commercial-history-consumers.test.ts
+++ b/netlify/functions/__tests__/commercial-history-consumers.test.ts
@@ -1,0 +1,58 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const readRepo = (relativePath: string) =>
+  readFileSync(new URL(`../../../${relativePath}`, import.meta.url), 'utf8');
+
+const invoice = readRepo('netlify/functions/generate-invoice.ts');
+const tracking = readRepo('netlify/functions/track-shipment.ts');
+const mobileOrders = readRepo('src/pages/MobileOrdersPage.tsx');
+const buyerOrders = readRepo('src/pages/pixel-perfect/buyer/BuyerOrders.tsx');
+const buyerDashboard = readRepo('src/pages/pixel-perfect/buyer/BuyerDashboard.tsx');
+const buyerReviews = readRepo('src/pages/pixel-perfect/buyer/BuyerReviews.tsx');
+const sellerOrders = readRepo('src/pages/pixel-perfect/seller/SellerOrders.tsx');
+const sellerDashboard = readRepo('src/pages/pixel-perfect/seller/SellerDashboard.tsx');
+
+describe('immutable commercial-history consumers', () => {
+  it('invoice uses order/item snapshots and isolates live identity to legacy fallback', () => {
+    expect(invoice).toContain('commercialSnapshotSource');
+    expect(invoice).toContain('buyerNameSnapshot');
+    expect(invoice).toContain('buyerEmailSnapshot');
+    expect(invoice).toContain('sellerBusinessNameSnapshot');
+    expect(invoice).toContain('productTitleSnapshot');
+    expect(invoice).toContain('productSnapshotSource');
+    expect(invoice).toContain('if (!hasCommercialSnapshot)');
+  });
+
+  it('tracking authenticates/displays post-cutover history from immutable snapshots', () => {
+    expect(tracking).toContain('buyerEmailSnapshot');
+    expect(tracking).toContain('sellerBusinessNameSnapshot');
+    expect(tracking).toContain('commercialSnapshotSource');
+    expect(tracking).toContain('productTitleSnapshot');
+    expect(tracking).toContain('productImageSnapshot');
+    expect(tracking).toContain('productSnapshotSource');
+    expect(tracking).toContain('if (!hasCommercialSnapshot)');
+  });
+
+  it('buyer order surfaces prefer immutable product identity', () => {
+    expect(mobileOrders).toContain('productSnapshotSource');
+    expect(mobileOrders).toContain('productTitleSnapshot');
+    expect(mobileOrders).toContain('productImageSnapshot');
+    expect(buyerOrders).toContain('order_items(productTitleSnapshot)');
+    expect(buyerDashboard).toContain('order_items(productTitleSnapshot, productSnapshotSource)');
+  });
+
+  it('seller order surfaces prefer checkout-time buyer identity', () => {
+    for (const source of [sellerOrders, sellerDashboard]) {
+      expect(source).toContain('buyerNameSnapshot');
+      expect(source).toContain('commercialSnapshotSource');
+      expect(source).toContain('legacyBuyer');
+    }
+  });
+
+  it('reviewable purchase identity uses the order-item snapshot when available', () => {
+    expect(buyerReviews).toContain('productTitleSnapshot');
+    expect(buyerReviews).toContain('productSnapshotSource');
+    expect(buyerReviews).toContain('snapshotItem');
+  });
+});

--- a/netlify/functions/__tests__/commercial-snapshot-cutover.test.ts
+++ b/netlify/functions/__tests__/commercial-snapshot-cutover.test.ts
@@ -1,0 +1,77 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const read = (relativePath: string) => readFileSync(new URL(relativePath, import.meta.url), 'utf8');
+
+const webCheckout = read('../create-checkout.ts');
+const mobileCheckout = read('../create-payment-intent.ts');
+const webhook = read('../stripe-webhook.ts');
+const migration = read('../../../supabase/610_snapshot_order_commercial_identity.sql');
+
+describe('commercial snapshot cutover contract', () => {
+  it.each([
+    ['web checkout', webCheckout],
+    ['mobile checkout', mobileCheckout],
+  ])('%s persists the same versioned immutable evidence shape', (_name, source) => {
+    expect(source).toContain('commercialSnapshotVersion: 1');
+    expect(source).toContain('buyerSnapshot');
+    expect(source).toContain('sellerSnapshot');
+    expect(source).toContain('image:');
+    expect(source).toContain('listingContext:');
+    expect(source).toContain(".select('email, firstName, lastName')");
+    expect(source).toContain('businessName');
+    expect(source).toContain('isB2B: isB2BBuyer');
+    expect(source).toContain('reverseCharge: applyReverseCharge');
+    expect(source).toContain('shippingAmountPence');
+    expect(source).toContain('totalPence');
+  });
+
+  it('webhook delegates the complete paid persistence unit to one canonical DB transaction', () => {
+    expect(webhook).toContain("sb.rpc('server_materialize_paid_order_v1'");
+    expect(webhook).toContain('p_payment_session_id: paymentSessionId');
+    expect(webhook).toContain('p_payment_intent_id: paymentIntentId');
+    expect(webhook).toContain('p_commission_rate: commissionRate');
+    expect(webhook).toContain('firstPaidTransition');
+
+    // The webhook must no longer coordinate the transactional persistence unit
+    // through separate HTTP/database requests.
+    expect(webhook).not.toContain(".upsert(orderItems, { onConflict: 'orderId,productId'");
+    expect(webhook).not.toContain("sb.rpc('finalize_paid_order_item'");
+    expect(webhook).not.toContain(".update({ status: 'paid' })");
+  });
+
+  it('the DB RPC owns order + item snapshots + stock finalization + paid transition atomically', () => {
+    expect(migration).toContain('CREATE OR REPLACE FUNCTION public.server_materialize_paid_order_v1');
+    expect(migration).toContain('FROM public.payment_sessions ps');
+    expect(migration).toContain('FOR UPDATE;');
+    expect(migration).toContain('INSERT INTO public.orders');
+    expect(migration).toContain('INSERT INTO public.order_items');
+    expect(migration).toContain('PERFORM public.finalize_paid_order_item');
+    expect(migration).toContain(`SET status = 'paid'`);
+    expect(migration).toContain(`status = 'completed'`);
+    expect(migration).toContain('v_persisted_item_count <> v_item_count');
+    expect(migration).toContain('v_finalized_item_count <> v_item_count');
+    expect(migration).toContain("GRANT EXECUTE ON FUNCTION public.server_materialize_paid_order_v1");
+    expect(migration).toContain('TO service_role;');
+  });
+
+  it('keeps retry behavior idempotent and user-facing side effects first-transition-only', () => {
+    expect(migration).toContain("v_order.status NOT IN ('awaiting_payment', 'paid')");
+    expect(migration).toContain('ON CONFLICT ("orderId", "productId") DO NOTHING');
+    expect(migration).toContain('v_first_paid_transition := false');
+    expect(webhook).toContain('if (result.firstPaidTransition)');
+    expect(webhook).toContain('if (!result.firstPaidTransition) return;');
+  });
+
+  it('keeps the database cutover fail-closed for incomplete or legacy evidence', () => {
+    expect(migration).toContain('payment_session_has_commercial_snapshot_v1');
+    expect(migration).toContain('WHEN others THEN');
+    expect(migration).toContain('RETURN false;');
+    expect(migration).toContain('IS DISTINCT FROM true');
+    expect(migration).toContain('trg_require_payment_session_commercial_snapshot_v1');
+    expect(migration).toContain('trg_require_paid_order_commercial_snapshot');
+    expect(migration).toContain('trg_require_paid_order_item_product_snapshot');
+    expect(migration).toContain(`NEW."commercialSnapshotSource" IS DISTINCT FROM 'checkout_verified'`);
+    expect(migration).toContain(`NEW."productSnapshotSource" IS DISTINCT FROM 'checkout_verified'`);
+  });
+});

--- a/netlify/functions/admin-orders.ts
+++ b/netlify/functions/admin-orders.ts
@@ -1,6 +1,5 @@
-import { Handler } from '@netlify/functions';
-import { createClient } from '@supabase/supabase-js';
-import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { Handler, HandlerEvent } from '@netlify/functions';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import {
   assessAdminReleaseEligibility,
   enforcePaymentBackedTransition,
@@ -10,6 +9,16 @@ import {
 
 const JSON_HEADERS = { 'Content-Type': 'application/json' };
 
+interface AuthOk {
+  ok: true;
+  caller: { id: string; email: string; role: string };
+}
+interface AuthFail {
+  ok: false;
+  status: number;
+}
+type AuthResult = AuthOk | AuthFail;
+
 interface OrderListRow {
   id: string;
   orderNumber: string | null;
@@ -18,10 +27,16 @@ interface OrderListRow {
   createdAt: string | null;
   buyerId: string;
   productId: string;
+  buyerNameSnapshot?: string | null;
+  commercialSnapshotSource?: string | null;
   stripePaymentIntentId?: string | null;
   rfqId?: string | null;
   rfqResponseId?: string | null;
   escrowStatus?: string | null;
+  order_items?: Array<{
+    productTitleSnapshot?: string | null;
+    productSnapshotSource?: string | null;
+  }> | null;
 }
 
 interface ProductMetaRow {
@@ -36,6 +51,41 @@ interface PaymentSessionMetaRow {
   orderId: string;
   status: string;
   stripePaymentIntent: string | null;
+}
+
+async function authenticateAdmin(event: HandlerEvent, admin: SupabaseClient): Promise<AuthResult> {
+  const authHeader = event.headers['authorization'] || event.headers['Authorization'];
+
+  if (!authHeader || !authHeader.startsWith('Bearer ')) {
+    return { ok: false, status: 401 };
+  }
+
+  const token = authHeader.substring(7).trim();
+  const { data, error } = await admin.auth.getUser(token);
+  if (error || !data?.user) {
+    return { ok: false, status: 401 };
+  }
+
+  const authUser = data.user;
+  const authEmail = (authUser.email || '').toLowerCase().trim();
+  if (!authEmail) {
+    return { ok: false, status: 401 };
+  }
+
+  // Service-role access bypasses RLS. Never trust a role embedded in an older
+  // JWT as sufficient authority: resolve the current platform account state and
+  // require an active admin before any read or mutation through this boundary.
+  const { data: dbUser, error: dbError } = await admin
+    .from('users')
+    .select('role, isActive')
+    .eq('id', authUser.id)
+    .maybeSingle<{ role: string | null; isActive: boolean | null }>();
+
+  if (dbError || !dbUser || dbUser.role !== 'admin' || dbUser.isActive !== true) {
+    return { ok: false, status: 403 };
+  }
+
+  return { ok: true, caller: { id: authUser.id, email: authEmail, role: 'admin' } };
 }
 
 function formatDate(iso: string | null | undefined): string {
@@ -76,7 +126,7 @@ export const handler: Handler = async (event) => {
     auth: { autoRefreshToken: false, persistSession: false },
   });
 
-  const auth = await authenticateActiveAccount(event, admin, ['admin']);
+  const auth = await authenticateAdmin(event, admin);
   if (!auth.ok) {
     return {
       statusCode: auth.status,
@@ -89,7 +139,7 @@ export const handler: Handler = async (event) => {
     if (event.httpMethod === 'GET') {
       const { data: rows, error: ordersErr } = await admin
         .from('orders')
-        .select('id, orderNumber, total, status, createdAt, buyerId, productId, stripePaymentIntentId, rfqId, rfqResponseId, escrowStatus')
+        .select('id, orderNumber, total, status, createdAt, buyerId, productId, buyerNameSnapshot, commercialSnapshotSource, stripePaymentIntentId, rfqId, rfqResponseId, escrowStatus, order_items(productTitleSnapshot, productSnapshotSource)')
         .order('createdAt', { ascending: false })
         .limit(100);
 
@@ -97,21 +147,32 @@ export const handler: Handler = async (event) => {
 
       const orderRows = (rows || []) as OrderListRow[];
 
-      const buyerIds = [...new Set(orderRows.map((o: { buyerId: string | null }) => o.buyerId).filter((id): id is string => !!id))];
-      const buyerNames: Record<string, string> = {};
+      // Current buyer names are a display-only fallback for legacy rows. An
+      // authoritative post-cutover snapshot must never be replaced by today's
+      // profile value.
+      const legacyBuyerIds = [...new Set(
+        orderRows
+          .filter((o) => !o.commercialSnapshotSource || !o.buyerNameSnapshot?.trim())
+          .map((o) => o.buyerId)
+          .filter((id): id is string => !!id),
+      )];
+      const legacyBuyerNames: Record<string, string> = {};
 
-      if (buyerIds.length > 0) {
+      if (legacyBuyerIds.length > 0) {
         const { data: buyers } = await admin
           .from('users')
           .select('id, firstName, lastName')
-          .in('id', buyerIds);
+          .in('id', legacyBuyerIds);
         (buyers ?? []).forEach((b: { id: string; firstName?: string | null; lastName?: string | null }) => {
           const name = [b.firstName, b.lastName].filter((n): n is string => !!n).join(' ').trim();
-          buyerNames[b.id] = name || 'Customer';
+          legacyBuyerNames[b.id] = name || 'Customer';
         });
       }
 
-      const productIds = [...new Set(orderRows.map((o: { productId: string | null }) => o.productId).filter((id): id is string => !!id))];
+      // Product metadata remains necessary for the payment/release guard. Its
+      // title is only a legacy display fallback; post-cutover display comes from
+      // the immutable order-item snapshot.
+      const productIds = [...new Set(orderRows.map((o) => o.productId).filter((id): id is string => !!id))];
       const productTitles: Record<string, string> = {};
       const productMeta = new Map<string, ProductMetaRow>();
 
@@ -160,12 +221,17 @@ export const handler: Handler = async (event) => {
           },
           paymentEvidence,
         });
+        const snapshotItem = o.order_items?.find((item) => item.productSnapshotSource != null) ?? null;
 
         return {
           id: o.id,
           orderNumber: o.orderNumber || o.id.slice(0, 8).toUpperCase(),
-          buyer: buyerNames[o.buyerId] ?? (o.buyerId ? o.buyerId.slice(0, 8).toUpperCase() : '—'),
-          product: productTitles[o.productId] ?? '—',
+          buyer: o.commercialSnapshotSource && o.buyerNameSnapshot?.trim()
+            ? o.buyerNameSnapshot.trim()
+            : legacyBuyerNames[o.buyerId] ?? (o.buyerId ? o.buyerId.slice(0, 8).toUpperCase() : '—'),
+          product: snapshotItem
+            ? snapshotItem.productTitleSnapshot || '—'
+            : productTitles[o.productId] ?? '—',
           total: o.total ?? 0,
           status: o.status ?? 'paid',
           date: formatDate(o.createdAt),
@@ -299,7 +365,7 @@ export const handler: Handler = async (event) => {
         ) {
           await admin.from('order_events').insert({
             orderId,
-            actorId: auth.actor.id,
+            actorId: auth.caller.id,
             event: 'admin_unpaid_transition_override',
             metadata: {
               reason: overrideReason,
@@ -397,7 +463,7 @@ export const handler: Handler = async (event) => {
 
         await admin.from('order_events').insert({
           orderId,
-          actorId: auth.actor.id,
+          actorId: auth.caller.id,
           event: 'admin_unpaid_lock_release',
           metadata: {
             reason,

--- a/netlify/functions/create-checkout.ts
+++ b/netlify/functions/create-checkout.ts
@@ -2,7 +2,6 @@ import Stripe from 'stripe';
 import { createClient } from '@supabase/supabase-js';
 import { randomUUID } from 'crypto';
 import type { Handler } from '@netlify/functions';
-import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { isMaintenanceMode } from './_shared/platformFlags';
 import { checkRateLimit } from './_shared/rateLimiter';
 
@@ -36,6 +35,7 @@ interface DBProduct {
   stockQuantity: number;
   listingContext: string;
   listingStatus: string;
+  images: string[];
 }
 
 const STRIPE_CHECKOUT_WINDOW_MINUTES = 30;
@@ -89,30 +89,7 @@ export const handler: Handler = async (event) => {
     };
   }
 
-  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
-    auth: { autoRefreshToken: false, persistSession: false },
-  });
-
-  // Checkout uses service_role for reservations and payment-session materialisation.
-  // A stale but valid access token from a suspended account must stop before any
-  // reservation, rate-limit write, Stripe creation, or payment-session write.
-  const auth = await authenticateActiveAccount(event, supabase);
-  if (!auth.ok) {
-    return {
-      statusCode: auth.status,
-      body: JSON.stringify({
-        error: auth.status === 401
-          ? 'Authentication required. Please sign in to complete your purchase.'
-          : 'This account is not active and cannot place orders.',
-      }),
-    };
-  }
-
-  const verifiedBuyerId = auth.actor.id;
-  if (buyerId && buyerId !== verifiedBuyerId) {
-    return { statusCode: 403, body: JSON.stringify({ error: 'buyerId does not match authenticated user' }) };
-  }
-
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
   const reservationToken = randomUUID();
   let reservedProductIds: string[] = [];
   const releaseReservedProducts = async () => {
@@ -128,6 +105,27 @@ export const handler: Handler = async (event) => {
       });
     reservedProductIds = [];
   };
+
+  let verifiedBuyerId = '';
+  const authHeader = event.headers['authorization'];
+  if (authHeader?.startsWith('Bearer ')) {
+    const token = authHeader.substring(7);
+    const { data: { user: authUser }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !authUser) {
+      return { statusCode: 401, body: JSON.stringify({ error: 'Invalid authentication token' }) };
+    }
+    if (buyerId && buyerId !== authUser.id) {
+      return { statusCode: 403, body: JSON.stringify({ error: 'buyerId does not match authenticated user' }) };
+    }
+    verifiedBuyerId = authUser.id;
+  }
+
+  if (!verifiedBuyerId) {
+    return {
+      statusCode: 401,
+      body: JSON.stringify({ error: 'Authentication required. Please sign in to complete your purchase.' }),
+    };
+  }
 
   const checkoutRl = await checkRateLimit({
     supabase,
@@ -145,8 +143,15 @@ export const handler: Handler = async (event) => {
   }
 
   const maintenance = await isMaintenanceMode(supabase);
-  if (maintenance && auth.actor.role !== 'admin') {
-    return { statusCode: 503, body: JSON.stringify({ error: 'Platform is temporarily under maintenance' }) };
+  if (maintenance) {
+    const { data: callerRow } = await supabase
+      .from('users')
+      .select('role')
+      .eq('id', verifiedBuyerId)
+      .maybeSingle<{ role: string | null }>();
+    if (callerRow?.role !== 'admin') {
+      return { statusCode: 503, body: JSON.stringify({ error: 'Platform is temporarily under maintenance' }) };
+    }
   }
 
   const maybeRpc = (supabase as typeof supabase & { rpc?: (fn: string) => Promise<unknown> }).rpc;
@@ -162,7 +167,7 @@ export const handler: Handler = async (event) => {
   const productIds = submittedProductIds;
   const { data: dbProducts, error: dbError } = await supabase
     .from('products')
-    .select('id, price, title, sellerId, isActive, isApproved, stockQuantity, listingContext, listingStatus')
+    .select('id, price, title, sellerId, isActive, isApproved, stockQuantity, listingContext, listingStatus, images')
     .in('id', productIds);
 
   if (dbError) {
@@ -214,6 +219,8 @@ export const handler: Handler = async (event) => {
       quantity: item.quantity,
       price: dbProduct.price,
       title: dbProduct.title,
+      image: Array.isArray(dbProduct.images) && dbProduct.images.length > 0 ? dbProduct.images[0] : null,
+      listingContext: dbProduct.listingContext === 'service' ? 'service' as const : 'product' as const,
     };
   });
 
@@ -226,44 +233,36 @@ export const handler: Handler = async (event) => {
   }
 
   const checkoutSellerId = uniqueSellerIds[0];
-  const [sellerAccountResult, sellerProfileResult] = await Promise.all([
-    supabase
-      .from('users')
-      .select('role, isActive')
-      .eq('id', checkoutSellerId)
-      .maybeSingle<{ role: string | null; isActive: boolean | null }>(),
-    supabase
-      .from('seller_profiles')
-      .select('stripeAccountId, stripeConnectStatus, sellerStatus, isPaused')
-      .eq('userId', checkoutSellerId)
-      .maybeSingle<{
-        stripeAccountId: string | null;
-        stripeConnectStatus: string | null;
-        sellerStatus: string | null;
-        isPaused: boolean | null;
-      }>(),
-  ]);
+  const { data: sellerProfile, error: sellerProfileError } = await supabase
+    .from('seller_profiles')
+    .select('stripeAccountId, stripeConnectStatus, sellerStatus, isPaused, businessName, fullName')
+    .eq('userId', checkoutSellerId)
+    .maybeSingle<{
+      stripeAccountId: string | null;
+      stripeConnectStatus: string | null;
+      sellerStatus: string | null;
+      isPaused: boolean | null;
+      businessName: string | null;
+      fullName: string | null;
+    }>();
 
-  if (sellerAccountResult.error || sellerProfileResult.error) {
-    console.error(
-      'create-checkout: seller eligibility query failed:',
-      sellerAccountResult.error?.message ?? sellerProfileResult.error?.message,
-    );
+  if (sellerProfileError) {
+    console.error('create-checkout: seller profile query failed:', sellerProfileError.message);
     return { statusCode: 500, body: JSON.stringify({ error: 'Unable to verify seller status. Please try again.' }) };
   }
 
-  const sellerAccount = sellerAccountResult.data;
-  const sellerProfile = sellerProfileResult.data;
   if (
-    !sellerAccount ||
-    sellerAccount.role !== 'seller' ||
-    sellerAccount.isActive !== true ||
     !sellerProfile?.stripeAccountId ||
     sellerProfile.stripeConnectStatus !== 'active' ||
     sellerProfile.sellerStatus !== 'active' ||
     sellerProfile.isPaused === true
   ) {
     return { statusCode: 400, body: JSON.stringify({ error: 'This seller is not currently available to accept payments.' }) };
+  }
+
+  const sellerBusinessName = sellerProfile.businessName?.trim() || sellerProfile.fullName?.trim() || '';
+  if (!sellerBusinessName) {
+    return { statusCode: 409, body: JSON.stringify({ error: 'Seller commercial identity is incomplete. Please try again later.' }) };
   }
 
   let shippingAmount = 0;
@@ -325,14 +324,58 @@ export const handler: Handler = async (event) => {
   }
 
   const VAT_RATE = 0.20;
-  const { data: buyerProfile } = await supabase
+  const { data: buyerProfile, error: buyerProfileError } = await supabase
     .from('buyer_profiles')
-    .select('accountType, isVatVerified')
+    .select('accountType, isVatVerified, companyName, vatNumber')
     .eq('userId', verifiedBuyerId)
-    .maybeSingle<{ accountType: string | null; isVatVerified: boolean | null }>();
+    .maybeSingle<{
+      accountType: string | null;
+      isVatVerified: boolean | null;
+      companyName: string | null;
+      vatNumber: string | null;
+    }>();
+
+  if (buyerProfileError) {
+    console.error('create-checkout: buyer profile query failed:', buyerProfileError.message);
+    return { statusCode: 500, body: JSON.stringify({ error: 'Unable to verify buyer identity. Please try again.' }) };
+  }
+
+  const { data: buyerUser, error: buyerUserError } = await supabase
+    .from('users')
+    .select('email, firstName, lastName')
+    .eq('id', verifiedBuyerId)
+    .maybeSingle<{ email: string; firstName: string | null; lastName: string | null }>();
+
+  if (buyerUserError || !buyerUser) {
+    console.error('create-checkout: buyer user query failed:', buyerUserError?.message ?? 'buyer row missing');
+    return { statusCode: 500, body: JSON.stringify({ error: 'Unable to verify buyer identity. Please try again.' }) };
+  }
+
+  const buyerEmail = buyerUser.email?.trim() || '';
+  if (!buyerEmail) {
+    return { statusCode: 409, body: JSON.stringify({ error: 'Buyer email identity is incomplete. Please update your account details.' }) };
+  }
+  const buyerName = [buyerUser.firstName, buyerUser.lastName]
+    .map((part) => part?.trim() || '')
+    .filter(Boolean)
+    .join(' ')
+    .trim() || buyerEmail;
 
   const isB2BBuyer = Boolean(buyerProfile?.accountType) && buyerProfile?.accountType !== 'individual';
   const applyReverseCharge = isB2BBuyer && Boolean(buyerProfile?.isVatVerified);
+  const buyerSnapshot = {
+    id: verifiedBuyerId,
+    name: buyerName,
+    email: buyerEmail,
+    companyName: buyerProfile?.companyName?.trim() || null,
+    vatNumber: buyerProfile?.vatNumber?.trim() || null,
+    isB2B: isB2BBuyer,
+    reverseCharge: applyReverseCharge,
+  };
+  const sellerSnapshot = {
+    id: checkoutSellerId,
+    businessName: sellerBusinessName,
+  };
 
   const catalogSubtotalPence = enrichedItems.reduce(
     (sum, item) => sum + Math.round(item.price * 100) * item.quantity,
@@ -434,6 +477,9 @@ export const handler: Handler = async (event) => {
         amount: chargeableTotal,
         currency: 'GBP',
         metadata: {
+          commercialSnapshotVersion: 1,
+          buyerSnapshot,
+          sellerSnapshot,
           items: enrichedItems,
           shippingAddress: effectiveShippingAddress,
           billingAddress,

--- a/netlify/functions/create-payment-intent.ts
+++ b/netlify/functions/create-payment-intent.ts
@@ -7,7 +7,6 @@ import Stripe from 'stripe';
 import { createClient } from '@supabase/supabase-js';
 import { randomUUID } from 'crypto';
 import type { Handler } from '@netlify/functions';
-import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 import { isMaintenanceMode } from './_shared/platformFlags';
 import { checkRateLimit } from './_shared/rateLimiter';
 
@@ -39,6 +38,7 @@ interface DBProduct {
   stockQuantity: number;
   listingContext: string;
   listingStatus: string;
+  images: string[];
 }
 
 const DB_RESERVATION_FAILSAFE_MINUTES = 60;
@@ -82,31 +82,26 @@ export const handler: Handler = async (event) => {
     };
   }
 
-  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
-    auth: { autoRefreshToken: false, persistSession: false },
-  });
-
-  // Mobile checkout uses service_role for reservation and payment-session writes.
-  // Resolve live account state before any rate-limit write, reservation, Stripe
-  // PaymentIntent creation, or commercial persistence.
-  const auth = await authenticateActiveAccount(event, supabase);
-  if (!auth.ok) {
-    return {
-      statusCode: auth.status,
-      body: JSON.stringify({
-        error: auth.status === 401
-          ? 'Authentication required. Please sign in to complete your purchase.'
-          : 'This account is not active and cannot place orders.',
-      }),
-    };
-  }
-
-  const verifiedBuyerId = auth.actor.id;
-  if (buyerId && buyerId !== verifiedBuyerId) {
-    return { statusCode: 403, body: JSON.stringify({ error: 'buyerId does not match authenticated user' }) };
-  }
-
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
   const reservationToken = randomUUID();
+
+  let verifiedBuyerId = '';
+  const authHeader = event.headers['authorization'];
+  if (authHeader?.startsWith('Bearer ')) {
+    const token = authHeader.substring(7);
+    const { data: { user: authUser }, error: authError } = await supabase.auth.getUser(token);
+    if (authError || !authUser) {
+      return { statusCode: 401, body: JSON.stringify({ error: 'Invalid authentication token' }) };
+    }
+    if (buyerId && buyerId !== authUser.id) {
+      return { statusCode: 403, body: JSON.stringify({ error: 'buyerId does not match authenticated user' }) };
+    }
+    verifiedBuyerId = authUser.id;
+  }
+
+  if (!verifiedBuyerId) {
+    return { statusCode: 401, body: JSON.stringify({ error: 'Authentication required. Please sign in to complete your purchase.' }) };
+  }
 
   const piRl = await checkRateLimit({
     supabase,
@@ -121,8 +116,15 @@ export const handler: Handler = async (event) => {
   }
 
   const maintenance = await isMaintenanceMode(supabase);
-  if (maintenance && auth.actor.role !== 'admin') {
-    return { statusCode: 503, body: JSON.stringify({ error: 'Platform is temporarily under maintenance' }) };
+  if (maintenance) {
+    const { data: callerRow } = await supabase
+      .from('users')
+      .select('role')
+      .eq('id', verifiedBuyerId)
+      .maybeSingle<{ role: string | null }>();
+    if (callerRow?.role !== 'admin') {
+      return { statusCode: 503, body: JSON.stringify({ error: 'Platform is temporarily under maintenance' }) };
+    }
   }
 
   await supabase.rpc('release_expired_reservations').catch((err: unknown) => {
@@ -135,7 +137,7 @@ export const handler: Handler = async (event) => {
   const productIds = submittedProductIds;
   const { data: dbProducts, error: dbError } = await supabase
     .from('products')
-    .select('id, price, title, sellerId, isActive, isApproved, stockQuantity, listingContext, listingStatus')
+    .select('id, price, title, sellerId, isActive, isApproved, stockQuantity, listingContext, listingStatus, images')
     .in('id', productIds);
 
   if (dbError) {
@@ -232,6 +234,8 @@ export const handler: Handler = async (event) => {
       quantity: item.quantity,
       price: dbProduct.price,
       title: dbProduct.title,
+      image: Array.isArray(dbProduct.images) && dbProduct.images.length > 0 ? dbProduct.images[0] : null,
+      listingContext: dbProduct.listingContext === 'service' ? 'service' as const : 'product' as const,
     };
   });
 
@@ -241,38 +245,24 @@ export const handler: Handler = async (event) => {
   }
 
   const checkoutSellerId = uniqueSellerIds[0];
-  const [sellerAccountResult, sellerProfileResult] = await Promise.all([
-    supabase
-      .from('users')
-      .select('role, isActive')
-      .eq('id', checkoutSellerId)
-      .maybeSingle<{ role: string | null; isActive: boolean | null }>(),
-    supabase
-      .from('seller_profiles')
-      .select('stripeAccountId, stripeConnectStatus, sellerStatus, isPaused')
-      .eq('userId', checkoutSellerId)
-      .maybeSingle<{
-        stripeAccountId: string | null;
-        stripeConnectStatus: string | null;
-        sellerStatus: string | null;
-        isPaused: boolean | null;
-      }>(),
-  ]);
+  const { data: sellerProfile, error: sellerProfileError } = await supabase
+    .from('seller_profiles')
+    .select('stripeAccountId, stripeConnectStatus, sellerStatus, isPaused, businessName, fullName')
+    .eq('userId', checkoutSellerId)
+    .maybeSingle<{
+      stripeAccountId: string | null;
+      stripeConnectStatus: string | null;
+      sellerStatus: string | null;
+      isPaused: boolean | null;
+      businessName: string | null;
+      fullName: string | null;
+    }>();
 
-  if (sellerAccountResult.error || sellerProfileResult.error) {
-    console.error(
-      'create-payment-intent: seller eligibility query failed:',
-      sellerAccountResult.error?.message ?? sellerProfileResult.error?.message,
-    );
+  if (sellerProfileError) {
+    console.error('create-payment-intent: seller profile query failed:', sellerProfileError.message);
     return { statusCode: 500, body: JSON.stringify({ error: 'Unable to verify seller status. Please try again.' }) };
   }
-
-  const sellerAccount = sellerAccountResult.data;
-  const sellerProfile = sellerProfileResult.data;
   if (
-    !sellerAccount ||
-    sellerAccount.role !== 'seller' ||
-    sellerAccount.isActive !== true ||
     !sellerProfile?.stripeAccountId ||
     sellerProfile.stripeConnectStatus !== 'active' ||
     sellerProfile.sellerStatus !== 'active' ||
@@ -281,15 +271,64 @@ export const handler: Handler = async (event) => {
     return { statusCode: 400, body: JSON.stringify({ error: 'This seller is not currently available to accept payments.' }) };
   }
 
+  const sellerBusinessName = sellerProfile.businessName?.trim() || sellerProfile.fullName?.trim() || '';
+  if (!sellerBusinessName) {
+    return { statusCode: 409, body: JSON.stringify({ error: 'Seller commercial identity is incomplete. Please try again later.' }) };
+  }
+
   const VAT_RATE = 0.20;
-  const { data: buyerProfile } = await supabase
+  const { data: buyerProfile, error: buyerProfileError } = await supabase
     .from('buyer_profiles')
-    .select('accountType, isVatVerified')
+    .select('accountType, isVatVerified, companyName, vatNumber')
     .eq('userId', verifiedBuyerId)
-    .maybeSingle<{ accountType: string | null; isVatVerified: boolean | null }>();
+    .maybeSingle<{
+      accountType: string | null;
+      isVatVerified: boolean | null;
+      companyName: string | null;
+      vatNumber: string | null;
+    }>();
+
+  if (buyerProfileError) {
+    console.error('create-payment-intent: buyer profile query failed:', buyerProfileError.message);
+    return { statusCode: 500, body: JSON.stringify({ error: 'Unable to verify buyer identity. Please try again.' }) };
+  }
+
+  const { data: buyerUser, error: buyerUserError } = await supabase
+    .from('users')
+    .select('email, firstName, lastName')
+    .eq('id', verifiedBuyerId)
+    .maybeSingle<{ email: string; firstName: string | null; lastName: string | null }>();
+
+  if (buyerUserError || !buyerUser) {
+    console.error('create-payment-intent: buyer user query failed:', buyerUserError?.message ?? 'buyer row missing');
+    return { statusCode: 500, body: JSON.stringify({ error: 'Unable to verify buyer identity. Please try again.' }) };
+  }
+
+  const buyerEmail = buyerUser.email?.trim() || '';
+  if (!buyerEmail) {
+    return { statusCode: 409, body: JSON.stringify({ error: 'Buyer email identity is incomplete. Please update your account details.' }) };
+  }
+  const buyerName = [buyerUser.firstName, buyerUser.lastName]
+    .map((part) => part?.trim() || '')
+    .filter(Boolean)
+    .join(' ')
+    .trim() || buyerEmail;
 
   const isB2BBuyer = Boolean(buyerProfile?.accountType) && buyerProfile?.accountType !== 'individual';
   const applyReverseCharge = isB2BBuyer && Boolean(buyerProfile?.isVatVerified);
+  const buyerSnapshot = {
+    id: verifiedBuyerId,
+    name: buyerName,
+    email: buyerEmail,
+    companyName: buyerProfile?.companyName?.trim() || null,
+    vatNumber: buyerProfile?.vatNumber?.trim() || null,
+    isB2B: isB2BBuyer,
+    reverseCharge: applyReverseCharge,
+  };
+  const sellerSnapshot = {
+    id: checkoutSellerId,
+    businessName: sellerBusinessName,
+  };
 
   const catalogSubtotalPence = enrichedItems.reduce(
     (sum, item) => sum + Math.round(item.price * 100) * item.quantity,
@@ -364,6 +403,9 @@ export const handler: Handler = async (event) => {
         amount: chargeableTotal,
         currency: 'GBP',
         metadata: {
+          commercialSnapshotVersion: 1,
+          buyerSnapshot,
+          sellerSnapshot,
           items: enrichedItems,
           shippingAddress: effectiveShippingAddress,
           billingAddress,

--- a/netlify/functions/generate-invoice.ts
+++ b/netlify/functions/generate-invoice.ts
@@ -2,23 +2,25 @@
  * generate-invoice
  *
  * Generates a printable HTML invoice for a given order and streams it
- * back to the buyer's browser. The buyer uses their browser's built-in
- * Print → Save as PDF to create a PDF copy.
+ * back to the buyer's browser.
  *
  * Security:
- *   – Requires a valid JWT and a live active platform account.
+ *   – Requires a valid JWT.
  *   – The authenticated user must be the order's buyer OR an admin.
- *   – Uses the service-role client to query order data but enforces live
- *     authorization before accessing commercial history.
+ *   – Service-role data access is protected by the ownership check below.
+ *
+ * Commercial-history rule:
+ *   – Post-cutover orders with commercialSnapshotSource MUST render checkout-time
+ *     buyer/seller/product identity from immutable snapshots.
+ *   – Only legacy rows with no authoritative snapshot may use today's profile /
+ *     product values as a display-only fallback. No fallback is ever persisted.
  */
 
 import { createClient } from '@supabase/supabase-js';
 import type { Handler } from '@netlify/functions';
-import { authenticateActiveAccount } from './_shared/activeAccountAuth';
 
 const supabaseUrl = process.env.VITE_SUPABASE_URL!;
 const supabaseServiceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY!;
-
 const ALLOWED_ORIGIN = process.env.VITE_APP_URL || 'https://loadifymarket.co.uk';
 
 const corsHeaders = {
@@ -31,37 +33,41 @@ export const handler: Handler = async (event) => {
   if (event.httpMethod === 'OPTIONS') {
     return { statusCode: 204, headers: corsHeaders, body: '' };
   }
-
   if (event.httpMethod !== 'POST') {
-    return {
-      statusCode: 405,
-      headers: corsHeaders,
-      body: JSON.stringify({ error: 'Method not allowed' }),
-    };
+    return { statusCode: 405, headers: corsHeaders, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+  if (!supabaseUrl || !supabaseServiceRoleKey) {
+    return { statusCode: 500, headers: corsHeaders, body: JSON.stringify({ error: 'Server configuration error' }) };
   }
 
-  if (!supabaseUrl || !supabaseServiceRoleKey) {
+  const authHeader = event.headers['authorization'] || event.headers['Authorization'];
+  const token = authHeader?.replace(/^Bearer\s+/i, '').trim();
+  if (!token) {
+    return { statusCode: 401, headers: corsHeaders, body: JSON.stringify({ error: 'Unauthorized' }) };
+  }
+
+  const anonKey = process.env.VITE_SUPABASE_ANON_KEY;
+  if (!anonKey) {
     return {
       statusCode: 500,
       headers: corsHeaders,
-      body: JSON.stringify({ error: 'Server configuration error' }),
+      body: JSON.stringify({ error: 'Server configuration error: VITE_SUPABASE_ANON_KEY not set' }),
     };
   }
 
-  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey, {
-    auth: { autoRefreshToken: false, persistSession: false },
-  });
-
-  const auth = await authenticateActiveAccount(event, supabase);
-  if (!auth.ok) {
-    return {
-      statusCode: auth.status,
-      headers: corsHeaders,
-      body: JSON.stringify({ error: auth.status === 401 ? 'Unauthorized' : 'Account is suspended' }),
-    };
+  const anonClient = createClient(supabaseUrl, anonKey);
+  const { data: { user }, error: authError } = await anonClient.auth.getUser(token);
+  if (authError || !user) {
+    return { statusCode: 401, headers: corsHeaders, body: JSON.stringify({ error: 'Invalid or expired token' }) };
   }
 
-  const isAdmin = auth.actor.role === 'admin';
+  const supabase = createClient(supabaseUrl, supabaseServiceRoleKey);
+  const { data: callerRow } = await supabase
+    .from('users')
+    .select('role, firstName, lastName')
+    .eq('id', user.id)
+    .single<{ role: string; firstName?: string; lastName?: string }>();
+  const isAdmin = callerRow?.role === 'admin';
 
   let body: { orderId?: string };
   try {
@@ -89,6 +95,14 @@ export const handler: Handler = async (event) => {
       shippingAddress,
       buyerId,
       sellerId,
+      buyerNameSnapshot,
+      buyerEmailSnapshot,
+      buyerCompanyNameSnapshot,
+      buyerVatNumberSnapshot,
+      sellerBusinessNameSnapshot,
+      isB2BSnapshot,
+      reverseChargeSnapshot,
+      commercialSnapshotSource,
       products ( title, images )
     `)
     .eq('id', orderId)
@@ -104,6 +118,14 @@ export const handler: Handler = async (event) => {
       shippingAddress: Record<string, string>;
       buyerId: string | null;
       sellerId: string;
+      buyerNameSnapshot: string | null;
+      buyerEmailSnapshot: string | null;
+      buyerCompanyNameSnapshot: string | null;
+      buyerVatNumberSnapshot: string | null;
+      sellerBusinessNameSnapshot: string | null;
+      isB2BSnapshot: boolean | null;
+      reverseChargeSnapshot: boolean | null;
+      commercialSnapshotSource: string | null;
       products: { title?: string; images?: string[] } | null;
     }>();
 
@@ -111,68 +133,103 @@ export const handler: Handler = async (event) => {
     return { statusCode: 404, headers: corsHeaders, body: JSON.stringify({ error: 'Order not found' }) };
   }
 
-  if (!isAdmin && order.buyerId !== auth.actor.id) {
+  if (!isAdmin && order.buyerId !== user.id) {
     return { statusCode: 403, headers: corsHeaders, body: JSON.stringify({ error: 'Forbidden' }) };
   }
 
-  const { data: items } = await supabase
+  const { data: items, error: itemError } = await supabase
     .from('order_items')
-    .select('quantity, pricePerUnit, subtotal, products ( title )')
+    .select('quantity, pricePerUnit, subtotal, productTitleSnapshot, productSnapshotSource, products ( title )')
     .eq('orderId', orderId);
+  if (itemError) {
+    return { statusCode: 500, headers: corsHeaders, body: JSON.stringify({ error: 'Unable to load invoice items' }) };
+  }
 
-  const buyerRow = order.buyerId
-    ? (await supabase
-        .from('users')
-        .select('firstName, lastName, email')
-        .eq('id', order.buyerId)
-        .single<{ firstName?: string; lastName?: string; email?: string }>()
-      ).data
-    : null;
+  const hasCommercialSnapshot = Boolean(order.commercialSnapshotSource);
 
-  const buyerProfileRow = order.buyerId
-    ? (await supabase
-        .from('buyer_profiles')
-        .select('accountType, companyName, vatNumber, isVatVerified')
-        .eq('userId', order.buyerId)
-        .maybeSingle<{
-          accountType?: string | null;
-          companyName?: string | null;
-          vatNumber?: string | null;
-          isVatVerified?: boolean | null;
-        }>()
-      ).data
-    : null;
+  let buyerRow: { firstName?: string; lastName?: string; email?: string } | null = null;
+  let buyerProfileRow: {
+    accountType?: string | null;
+    companyName?: string | null;
+    vatNumber?: string | null;
+    isVatVerified?: boolean | null;
+  } | null = null;
+  let sellerRow: { businessName?: string } | null = null;
 
-  const isB2B =
-    Boolean(buyerProfileRow?.accountType) &&
-    buyerProfileRow?.accountType !== 'individual';
-  const isReverseCharge = isB2B && Boolean(buyerProfileRow?.isVatVerified);
+  // Never consult mutable identity for a post-cutover order. Current-state
+  // lookups are strictly a legacy display fallback for rows where the snapshot
+  // source itself is absent.
+  if (!hasCommercialSnapshot) {
+    buyerRow = order.buyerId
+      ? (await supabase
+          .from('users')
+          .select('firstName, lastName, email')
+          .eq('id', order.buyerId)
+          .single<{ firstName?: string; lastName?: string; email?: string }>()
+        ).data
+      : null;
 
-  const { data: sellerRow } = await supabase
-    .from('seller_profiles')
-    .select('businessName')
-    .eq('userId', order.sellerId)
-    .single<{ businessName?: string }>();
+    buyerProfileRow = order.buyerId
+      ? (await supabase
+          .from('buyer_profiles')
+          .select('accountType, companyName, vatNumber, isVatVerified')
+          .eq('userId', order.buyerId)
+          .maybeSingle<{
+            accountType?: string | null;
+            companyName?: string | null;
+            vatNumber?: string | null;
+            isVatVerified?: boolean | null;
+          }>()
+        ).data
+      : null;
+
+    sellerRow = (await supabase
+      .from('seller_profiles')
+      .select('businessName')
+      .eq('userId', order.sellerId)
+      .single<{ businessName?: string }>()).data;
+  }
+
+  const legacyBuyerName = [buyerRow?.firstName, buyerRow?.lastName].filter(Boolean).join(' ') || 'Customer';
+  const buyerName = hasCommercialSnapshot
+    ? order.buyerNameSnapshot || 'Customer'
+    : legacyBuyerName;
+  const buyerEmail = hasCommercialSnapshot
+    ? order.buyerEmailSnapshot || ''
+    : buyerRow?.email || '';
+  const sellerName = hasCommercialSnapshot
+    ? order.sellerBusinessNameSnapshot || 'Seller'
+    : sellerRow?.businessName || 'Seller';
+  const isB2B = hasCommercialSnapshot
+    ? order.isB2BSnapshot === true
+    : Boolean(buyerProfileRow?.accountType) && buyerProfileRow?.accountType !== 'individual';
+  const isReverseCharge = hasCommercialSnapshot
+    ? order.reverseChargeSnapshot === true
+    : isB2B && Boolean(buyerProfileRow?.isVatVerified);
+  const buyerCompanyName = hasCommercialSnapshot
+    ? order.buyerCompanyNameSnapshot
+    : buyerProfileRow?.companyName ?? null;
+  const buyerVatNumber = hasCommercialSnapshot
+    ? order.buyerVatNumberSnapshot
+    : buyerProfileRow?.vatNumber ?? null;
 
   const addr = order.shippingAddress ?? {};
-  const buyerName = [buyerRow?.firstName, buyerRow?.lastName].filter(Boolean).join(' ') || 'Customer';
-  const sellerName = sellerRow?.businessName || 'Seller';
   const orderDate = order.createdAt
     ? new Date(order.createdAt).toLocaleDateString('en-GB', { day: 'numeric', month: 'long', year: 'numeric' })
     : '—';
   const orderNum = order.orderNumber || order.id.slice(0, 8).toUpperCase();
 
-  const billToName = isB2B && buyerProfileRow?.companyName
-    ? buyerProfileRow.companyName
-    : buyerName;
-  const billToContact = isB2B && buyerProfileRow?.companyName ? buyerName : null;
-
+  const billToName = isB2B && buyerCompanyName ? buyerCompanyName : buyerName;
+  const billToContact = isB2B && buyerCompanyName ? buyerName : null;
   const formatGBP = (v: number) => `£${(v ?? 0).toFixed(2)}`;
 
   const itemRows = (items ?? [])
     .map((item) => {
       const productObj = Array.isArray(item.products) ? item.products[0] : item.products;
-      const title = (productObj as { title?: string } | null)?.title ?? 'Product';
+      const liveTitle = (productObj as { title?: string } | null)?.title ?? 'Product';
+      const title = item.productSnapshotSource
+        ? item.productTitleSnapshot || 'Product'
+        : liveTitle;
       return `
         <tr>
           <td style="padding:8px 12px;border-bottom:1px solid #e5e7eb;">${escapeHtml(title)}</td>
@@ -183,14 +240,9 @@ export const handler: Handler = async (event) => {
     })
     .join('');
 
-  const addrLine = [
-    addr.address1,
-    addr.address2,
-    addr.city,
-    addr.county,
-    addr.postcode,
-    addr.country,
-  ].filter(Boolean).join(', ');
+  const addrLine = [addr.address1, addr.address2, addr.city, addr.county, addr.postcode, addr.country]
+    .filter(Boolean)
+    .join(', ');
 
   const vatNumber = process.env.VITE_VAT_NUMBER || '';
   const companyName = process.env.VITE_COMPANY_NAME || 'Loadify Market';
@@ -226,10 +278,7 @@ export const handler: Handler = async (event) => {
     .totals .grand-total td { font-weight: 700; font-size: 15px; border-top: 2px solid #121A2B; padding-top: 10px; }
     .footer { margin-top: 48px; padding-top: 20px; border-top: 1px solid #e5e7eb; font-size: 11px; color: #9ca3af; text-align: center; line-height: 1.8; }
     .status-badge { display: inline-block; padding: 2px 10px; border-radius: 999px; font-size: 11px; font-weight: 600; text-transform: capitalize; background: #dcfce7; color: #166534; }
-    @media print {
-      body { padding: 20px; }
-      @page { margin: 15mm; }
-    }
+    @media print { body { padding: 20px; } @page { margin: 15mm; } }
   </style>
 </head>
 <body>
@@ -257,8 +306,8 @@ export const handler: Handler = async (event) => {
       <p>
         <strong>${escapeHtml(billToName)}</strong><br />
         ${billToContact ? `${escapeHtml(billToContact)}<br />` : ''}
-        ${buyerRow?.email ? `${escapeHtml(buyerRow.email)}<br />` : ''}
-        ${isB2B && buyerProfileRow?.vatNumber ? `VAT: ${escapeHtml(buyerProfileRow.vatNumber)}<br />` : ''}
+        ${buyerEmail ? `${escapeHtml(buyerEmail)}<br />` : ''}
+        ${isB2B && buyerVatNumber ? `VAT: ${escapeHtml(buyerVatNumber)}<br />` : ''}
         ${addrLine ? escapeHtml(addrLine) : ''}
       </p>
       ${isB2B ? `<p style="margin-top:6px;font-size:11px;color:#374151;font-weight:600;text-transform:uppercase;letter-spacing:.05em;">Business Account</p>` : ''}

--- a/netlify/functions/stripe-webhook.ts
+++ b/netlify/functions/stripe-webhook.ts
@@ -20,10 +20,6 @@ export const ZERO_COMMISSION_PROMO_END_UTC = new Date('2026-12-31T23:59:59Z').ge
 export const DEFAULT_COMMISSION_RATE = 0.07;
 const STRIPE_EVENT_LEASE_MS = 5 * 60 * 1000;
 
-function money(value: number): number {
-  return Math.round((value + Number.EPSILON) * 100) / 100;
-}
-
 export function getCommissionRate(configuredRate?: number): number {
   if (Date.now() < ZERO_COMMISSION_PROMO_END_UTC) return 0;
   return typeof configuredRate === 'number' && configuredRate >= 0
@@ -220,9 +216,29 @@ interface CartItem {
   quantity: number;
   price: number;
   title: string;
+  image: string | null;
+  listingContext: 'product' | 'service';
+}
+
+interface CommercialBuyerSnapshot {
+  id: string;
+  name: string;
+  email: string;
+  companyName: string | null;
+  vatNumber: string | null;
+  isB2B: boolean;
+  reverseCharge: boolean;
+}
+
+interface CommercialSellerSnapshot {
+  id: string;
+  businessName: string;
 }
 
 interface OrderData {
+  commercialSnapshotVersion?: number;
+  buyerSnapshot?: CommercialBuyerSnapshot;
+  sellerSnapshot?: CommercialSellerSnapshot;
   items: CartItem[];
   shippingAddress: Record<string, string>;
   billingAddress: Record<string, string>;
@@ -241,24 +257,57 @@ interface OrderData {
   applyReverseCharge?: boolean;
 }
 
-function resolveOrderMoney(orderData: OrderData): { subtotal: number; vat: number; shipping: number; total: number } {
-  const totalPence = Number.isInteger(orderData.totalPence)
-    ? Number(orderData.totalPence)
-    : Math.round(Number(orderData.total) * 100);
-  const shippingPence = Number.isInteger(orderData.shippingAmountPence)
-    ? Number(orderData.shippingAmountPence)
-    : Math.round(Number(orderData.shippingAmount ?? 0) * 100);
-
-  if (!Number.isFinite(totalPence) || !Number.isFinite(shippingPence) || totalPence < 0 || shippingPence < 0 || shippingPence > totalPence) {
-    throw new Error('Payment session contains invalid monetary totals');
+function requireCommercialSnapshotEvidence(orderData: OrderData): {
+  buyer: CommercialBuyerSnapshot;
+  seller: CommercialSellerSnapshot;
+} {
+  if (orderData.commercialSnapshotVersion !== 1) {
+    throw new Error('Payment session is missing commercial snapshot evidence v1');
   }
 
-  const productPaid = (totalPence - shippingPence) / 100;
-  const isReverseCharge = Boolean(orderData.applyReverseCharge);
-  const subtotal = isReverseCharge ? money(productPaid) : money(productPaid / 1.20);
-  const vat = isReverseCharge ? 0 : money(productPaid - subtotal);
+  const buyer = orderData.buyerSnapshot;
+  const seller = orderData.sellerSnapshot;
+  if (
+    !buyer ||
+    !buyer.id?.trim() ||
+    !buyer.name?.trim() ||
+    !buyer.email?.trim() ||
+    typeof buyer.isB2B !== 'boolean' ||
+    typeof buyer.reverseCharge !== 'boolean'
+  ) {
+    throw new Error('Payment session contains incomplete buyer snapshot evidence');
+  }
+  if (buyer.id !== orderData.buyerId) {
+    throw new Error('Payment session buyer snapshot does not match buyerId');
+  }
+  if (buyer.reverseCharge && !buyer.isB2B) {
+    throw new Error('Payment session contains invalid reverse-charge snapshot evidence');
+  }
+  if (Boolean(orderData.isB2B) !== buyer.isB2B || Boolean(orderData.applyReverseCharge) !== buyer.reverseCharge) {
+    throw new Error('Payment session commercial/tax snapshot conflicts with checkout totals metadata');
+  }
+  if (!seller || !seller.id?.trim() || !seller.businessName?.trim()) {
+    throw new Error('Payment session contains incomplete seller snapshot evidence');
+  }
 
-  return { subtotal, vat, shipping: shippingPence / 100, total: totalPence / 100 };
+  for (const item of orderData.items ?? []) {
+    if (
+      !item?.productId?.trim() ||
+      !item.sellerId?.trim() ||
+      !item.title?.trim() ||
+      (item.listingContext !== 'product' && item.listingContext !== 'service') ||
+      !Object.prototype.hasOwnProperty.call(item, 'image') ||
+      (item.image !== null && typeof item.image !== 'string') ||
+      !Number.isInteger(item.quantity) ||
+      item.quantity <= 0 ||
+      !Number.isFinite(item.price) ||
+      item.price <= 0
+    ) {
+      throw new Error('Payment session contains incomplete or invalid product snapshot evidence');
+    }
+  }
+
+  return { buyer, seller };
 }
 
 function productIdsFromMetadata(metadata: Record<string, unknown> | null | undefined): string[] {
@@ -311,11 +360,20 @@ async function claimPendingPaymentSession(
   return Boolean(data);
 }
 
+interface AtomicPaidOrderResult {
+  orderId: string;
+  orderNumber: string;
+  sellerId: string;
+  sellerTotal: number;
+  firstPaidTransition: boolean;
+}
+
 async function fulfilPaidOrder(
   sb: import('@supabase/supabase-js').SupabaseClient,
+  paymentSessionId: string,
   paymentIntentId: string,
   orderData: OrderData,
-): Promise<{ orderId: string; orderNumber: string; sellerId: string; sellerTotal: number }> {
+): Promise<AtomicPaidOrderResult> {
   const items = orderData.items ?? [];
   if (!items.length) throw new Error('Payment session contains no order items');
   if (new Set(items.map((item) => item.productId)).size !== items.length) {
@@ -327,105 +385,49 @@ async function fulfilPaidOrder(
     throw new Error('Payment session violates single-seller checkout invariant');
   }
   const sellerId = sellerIds[0];
-  const VAT_RATE = 0.20;
-  const resolvedMoney = resolveOrderMoney(orderData);
-  const reservationToken = typeof orderData.reservationToken === 'string'
-    ? orderData.reservationToken
-    : null;
+  const { seller: sellerSnapshot } = requireCommercialSnapshotEvidence(orderData);
+  if (sellerSnapshot.id !== sellerId) {
+    throw new Error('Payment session seller snapshot does not match item seller');
+  }
 
   const configuredRate = await fetchConfiguredCommissionRate(sb);
   const commissionRate = getCommissionRate(configuredRate ?? undefined);
-  const sellerCommission = money(resolvedMoney.subtotal * commissionRate);
-  const primaryItem = items[0];
 
-  const { data: existingOrder, error: existingOrderError } = await sb
-    .from('orders')
-    .select('id, orderNumber, sellerId, total')
-    .eq('stripePaymentIntentId', paymentIntentId)
-    .maybeSingle<{ id: string; orderNumber: string; sellerId: string; total: number }>();
+  const { data, error } = await sb.rpc('server_materialize_paid_order_v1', {
+    p_payment_session_id: paymentSessionId,
+    p_payment_intent_id: paymentIntentId,
+    p_commission_rate: commissionRate,
+  });
+  if (error) throw error;
 
-  if (existingOrderError) throw existingOrderError;
-  let order = existingOrder;
-  let orderWasCreated = false;
-
-  if (!order) {
-    const insertResult = await sb
-      .from('orders')
-      .insert({
-        buyerId: orderData.buyerId,
-        sellerId,
-        productId: primaryItem.productId,
-        quantity: items.reduce((sum, item) => sum + item.quantity, 0),
-        subtotal: resolvedMoney.subtotal,
-        vatAmount: resolvedMoney.vat,
-        shippingAmount: resolvedMoney.shipping,
-        total: resolvedMoney.total,
-        commission: sellerCommission,
-        status: 'paid',
-        escrowStatus: 'held',
-        shippingAddress: orderData.shippingAddress ?? {},
-        billingAddress: orderData.billingAddress ?? {},
-        shippingMethod: orderData.shippingMethod || 'Standard',
-        isB2B: Boolean(orderData.isB2B),
-        stripePaymentIntentId: paymentIntentId,
-      })
-      .select('id, orderNumber, sellerId, total')
-      .single();
-
-    if (insertResult.error || !insertResult.data) {
-      if (insertResult.error?.code === '23505') {
-        const retryLookup = await sb
-          .from('orders')
-          .select('id, orderNumber, sellerId, total')
-          .eq('stripePaymentIntentId', paymentIntentId)
-          .single();
-        if (retryLookup.error || !retryLookup.data) throw insertResult.error;
-        order = retryLookup.data;
-      } else {
-        throw insertResult.error ?? new Error('Order insert failed');
-      }
-    } else {
-      order = insertResult.data;
-      orderWasCreated = true;
-    }
+  const result = data as AtomicPaidOrderResult | null;
+  if (
+    !result ||
+    typeof result.orderId !== 'string' ||
+    typeof result.orderNumber !== 'string' ||
+    typeof result.sellerId !== 'string' ||
+    typeof result.sellerTotal !== 'number' ||
+    typeof result.firstPaidTransition !== 'boolean'
+  ) {
+    throw new Error('Atomic paid-order materialization returned an invalid contract');
+  }
+  if (result.sellerId !== sellerId) {
+    throw new Error('Atomic paid-order materialization returned conflicting seller identity');
   }
 
-  const orderItems = items.map((item) => ({
-    orderId: order!.id,
-    productId: item.productId,
-    quantity: item.quantity,
-    pricePerUnit: item.price,
-    vatRate: VAT_RATE,
-    subtotal: money((item.price / (1 + VAT_RATE)) * item.quantity),
-  }));
-
-  const { error: itemError } = await sb
-    .from('order_items')
-    .upsert(orderItems, { onConflict: 'orderId,productId', ignoreDuplicates: true });
-  if (itemError) throw itemError;
-
-  for (const item of items) {
-    const { error: fulfilError } = await sb.rpc('finalize_paid_order_item', {
-      p_order_id: order!.id,
-      p_product_id: item.productId,
-      p_reservation_token: reservationToken,
-    });
-    if (fulfilError) throw fulfilError;
-  }
-
-  if (orderWasCreated) {
+  if (result.firstPaidTransition) {
     await sb.from('notifications').insert({
       userId: sellerId,
       type: 'order',
       title: 'New order received',
-      message: `Order ${order!.orderNumber} has been placed. Total: £${resolvedMoney.total.toFixed(2)}`,
+      message: `Order ${result.orderNumber} has been placed. Total: £${result.sellerTotal.toFixed(2)}`,
       link: '/seller/orders',
     }).catch((err: unknown) => console.warn('Seller notification failed:', err));
 
     sendPushToUser(sb, sellerId, {
       title: 'New order received',
-      body: `Order ${order!.orderNumber} placed. Total: £${resolvedMoney.total.toFixed(2)}`,
-      data: { type: 'new_order', orderId: order!.id },
+      body: `Order ${result.orderNumber} placed. Total: £${result.sellerTotal.toFixed(2)}`,
+      data: { type: 'new_order', orderId: result.orderId },
     }).catch((err: unknown) => console.warn('Seller push failed:', err));
 
     if (orderData.buyerId) {
@@ -440,12 +442,12 @@ async function fulfilPaidOrder(
       sendPushToUser(sb, orderData.buyerId, {
         title: 'Order confirmed ✓',
         body: `Your order has been placed. We'll notify you when it ships.`,
-        data: { type: 'order_confirmed', orderId: order!.id },
+        data: { type: 'order_confirmed', orderId: result.orderId },
       }).catch((err: unknown) => console.warn('Buyer push failed:', err));
     }
   }
 
-  return { orderId: order!.id, orderNumber: order!.orderNumber, sellerId, sellerTotal: resolvedMoney.total };
+  return result;
 }
 
 async function handleCheckoutCompleted(session: Stripe.Checkout.Session): Promise<void> {
@@ -460,9 +462,9 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session): Promis
 
   const { data: pendingSession, error } = await supabase!
     .from('payment_sessions')
-    .select('id, status, metadata')
+    .select('id, status, metadata, createdAt')
     .eq('stripeSessionId', session.id)
-    .maybeSingle<{ id: string; status: string; metadata: OrderData }>();
+    .maybeSingle<{ id: string; status: string; metadata: OrderData; createdAt: string }>();
 
   if (error || !pendingSession) {
     throw new Error(`No payment_sessions row found for Stripe session ${session.id}`);
@@ -483,14 +485,11 @@ async function handleCheckoutCompleted(session: Stripe.Checkout.Session): Promis
     throw new Error(`Unexpected checkout currency for session ${session.id}`);
   }
 
-  const result = await fulfilPaidOrder(supabase!, paymentIntentId, orderData);
+  const result = await fulfilPaidOrder(supabase!, pendingSession.id, paymentIntentId, orderData);
 
-  const { error: updateError } = await supabase!
-    .from('payment_sessions')
-    .update({ orderId: result.orderId, stripePaymentIntent: paymentIntentId, amount: expectedPence / 100, status: 'completed' })
-    .eq('id', pendingSession.id)
-    .eq('status', 'pending');
-  if (updateError) throw updateError;
+  // Email is a post-commit side effect. Never duplicate it on an idempotent
+  // materialization retry that did not perform the first paid transition.
+  if (!result.firstPaidTransition) return;
 
   const { data: sellerUser } = await supabase!
     .from('users')
@@ -554,9 +553,9 @@ async function handleMobilePaymentIntentSucceeded(
 ): Promise<void> {
   const { data: pendingSession, error } = await sb
     .from('payment_sessions')
-    .select('id, status, metadata')
+    .select('id, status, metadata, createdAt')
     .eq('stripePaymentIntent', paymentIntent.id)
-    .maybeSingle<{ id: string; status: string; metadata: OrderData }>();
+    .maybeSingle<{ id: string; status: string; metadata: OrderData; createdAt: string }>();
 
   if (error) throw error;
   if (!pendingSession || pendingSession.status === 'completed') return;
@@ -574,13 +573,7 @@ async function handleMobilePaymentIntentSucceeded(
     throw new Error(`Unexpected PaymentIntent currency for ${paymentIntent.id}`);
   }
 
-  const result = await fulfilPaidOrder(sb, paymentIntent.id, orderData);
-  const { error: updateError } = await sb
-    .from('payment_sessions')
-    .update({ orderId: result.orderId, stripePaymentIntent: paymentIntent.id, amount: expectedPence / 100, status: 'completed' })
-    .eq('id', pendingSession.id)
-    .eq('status', 'pending');
-  if (updateError) throw updateError;
+  await fulfilPaidOrder(sb, pendingSession.id, paymentIntent.id, orderData);
 }
 
 interface PaymentSessionWithOrder {

--- a/netlify/functions/track-shipment.ts
+++ b/netlify/functions/track-shipment.ts
@@ -67,7 +67,11 @@ export const handler: Handler = async (event) => {
         status,
         total,
         createdAt,
+        buyerEmailSnapshot,
+        sellerBusinessNameSnapshot,
+        commercialSnapshotSource,
         products (id, title, images),
+        order_items (productTitleSnapshot, productImageSnapshot, productSnapshotSource),
         users!orders_sellerId_fkey (id, firstName, lastName)
       `);
 
@@ -75,12 +79,26 @@ export const handler: Handler = async (event) => {
     const { data: order, error: orderError } = await query.maybeSingle();
     if (orderError || !order) return genericLookupFailure;
 
-    const { data: buyer } = await supabase
-      .from('users')
-      .select('email')
-      .eq('id', order.buyerId)
-      .maybeSingle<{ email: string }>();
-    if (!buyer || buyer.email.toLowerCase() !== email.toLowerCase()) return genericLookupFailure;
+    const hasCommercialSnapshot = Boolean(order.commercialSnapshotSource);
+    let expectedBuyerEmail = hasCommercialSnapshot
+      ? String(order.buyerEmailSnapshot || '').trim()
+      : '';
+
+    // Current buyer identity is consulted only for a legacy row with no
+    // authoritative order snapshot. Never let a later profile change replace
+    // checkout-time identity for a post-cutover order.
+    if (!hasCommercialSnapshot) {
+      const { data: buyer } = await supabase
+        .from('users')
+        .select('email')
+        .eq('id', order.buyerId)
+        .maybeSingle<{ email: string }>();
+      expectedBuyerEmail = buyer?.email?.trim() || '';
+    }
+
+    if (!expectedBuyerEmail || expectedBuyerEmail.toLowerCase() !== email.toLowerCase()) {
+      return genericLookupFailure;
+    }
 
     const { data: shipment } = await supabase
       .from('shipments')
@@ -100,8 +118,6 @@ export const handler: Handler = async (event) => {
 
       if (shipment.proof_of_delivery_url) {
         const proofPath = String(shipment.proof_of_delivery_url);
-        // Private proof paths are stored as <shipmentId>/<file>. If the value is
-        // not scoped to this shipment, do not expose it.
         if (proofPath.startsWith(`${shipment.id}/`) && !proofPath.includes('..')) {
           const { data: signed } = await supabase.storage
             .from(POD_BUCKET)
@@ -111,19 +127,36 @@ export const handler: Handler = async (event) => {
       }
     }
 
+    const snapshotItem = (order.order_items ?? []).find(
+      (item: { productSnapshotSource?: string | null }) => item.productSnapshotSource != null,
+    ) ?? null;
+    const product = snapshotItem
+      ? {
+          title: snapshotItem.productTitleSnapshot || 'Product',
+          // An authoritative NULL means there was no image at checkout.
+          image: snapshotItem.productImageSnapshot ?? null,
+        }
+      : order.products
+        ? {
+            title: order.products.title,
+            image: order.products.images?.[0] || null,
+          }
+        : null;
+
+    const seller = hasCommercialSnapshot
+      ? { name: String(order.sellerBusinessNameSnapshot || 'Seller') }
+      : order.users
+        ? { name: `${order.users.firstName || ''} ${order.users.lastName || ''}`.trim() || 'Seller' }
+        : null;
+
     const response = {
       order: {
         orderNumber: order.orderNumber,
         createdAt: order.createdAt,
         total: order.total,
         status: order.status,
-        product: order.products ? {
-          title: order.products.title,
-          image: order.products.images?.[0] || null,
-        } : null,
-        seller: order.users ? {
-          name: `${order.users.firstName || ''} ${order.users.lastName || ''}`.trim() || 'Seller',
-        } : null,
+        product,
+        seller,
       },
       shipment: shipment ? {
         id: shipment.id,

--- a/src/pages/MobileOrdersPage.tsx
+++ b/src/pages/MobileOrdersPage.tsx
@@ -4,10 +4,6 @@
  * Standalone full-screen orders list for mobile users (buyers).
  * Accessible from Profile or from a push notification deep-link
  * with ?orderId=… in the URL.
- *
- * Tabs: All Orders | To Pay | To Ship | Shipped | Completed | Cancelled
- *
- * Unauthenticated users are redirected to /login.
  */
 
 import { useEffect, useRef, useState } from "react";
@@ -17,8 +13,6 @@ import { supabase } from "@/lib/supabase";
 import { useAuthStore } from "@/store";
 import { useAuthPromptStore } from "@/store/authPromptStore";
 import MobileBottomNav from "@/components/MobileBottomNav";
-
-// ── Types ─────────────────────────────────────────────────────────────────────
 
 interface OrderRow {
   id: string;
@@ -49,8 +43,6 @@ const TAB_STATUSES: Record<Tab, string[]> = {
   cancelled: ["cancelled", "refunded"],
 };
 
-// ── Helpers ───────────────────────────────────────────────────────────────────
-
 function formatDate(iso: string) {
   return new Date(iso).toLocaleDateString("en-GB", {
     day: "numeric",
@@ -59,11 +51,7 @@ function formatDate(iso: string) {
   });
 }
 
-// Status display config
-const STATUS_CONFIG: Record<
-  string,
-  { label: string; className: string }
-> = {
+const STATUS_CONFIG: Record<string, { label: string; className: string }> = {
   awaiting_payment: { label: "Awaiting payment", className: "bg-primary/15 text-primary" },
   paid:             { label: "Paid",              className: "bg-admin/15 text-admin" },
   packed:           { label: "Packed",            className: "bg-primary/15 text-primary" },
@@ -76,21 +64,13 @@ const STATUS_CONFIG: Record<
 };
 
 function statusCfg(status: string) {
-  return (
-    STATUS_CONFIG[status] ?? {
-      label: status.replace(/_/g, " "),
-      className: "bg-white/[0.08] text-foreground/75",
-    }
-  );
+  return STATUS_CONFIG[status] ?? {
+    label: status.replace(/_/g, " "),
+    className: "bg-white/[0.08] text-foreground/75",
+  };
 }
 
-// ── OrderCard ─────────────────────────────────────────────────────────────────
-
-function OrderCard({
-  order,
-  highlighted,
-  cardRef,
-}: {
+function OrderCard({ order, highlighted, cardRef }: {
   order: OrderRow;
   highlighted: boolean;
   cardRef?: React.RefObject<HTMLDivElement | null>;
@@ -107,7 +87,6 @@ function OrderCard({
       onKeyDown={(e) => { if (e.key === "Enter" || e.key === " ") navigate(`/buyer/orders?orderId=${order.id}`); }}
       className={`flex items-start gap-3 rounded-2xl p-3.5 cursor-pointer border transition-shadow ${highlighted ? 'bg-primary/[0.06] border-primary/35 shadow-[0_0_16px_rgba(212,175,55,0.12)]' : 'bg-card border-white/[0.07]'}`}
     >
-      {/* Product thumbnail */}
       <div className="w-20 h-20 rounded-xl bg-white shrink-0 overflow-hidden flex items-center justify-center">
         {order.productImage ? (
           <img
@@ -120,46 +99,29 @@ function OrderCard({
         )}
       </div>
 
-      {/* Details */}
       <div style={{ flex: 1, minWidth: 0 }}>
-        {/* Order number + status badge */}
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginBottom: "4px" }}>
-          <span className="text-[11px] text-foreground/70 font-mono">
-            #{order.orderNumber}
-          </span>
-          <span
-            className={`text-[11px] font-bold px-2 py-0.5 rounded-[20px] shrink-0 ${cfg.className}`}
-          >
+          <span className="text-[11px] text-foreground/70 font-mono">#{order.orderNumber}</span>
+          <span className={`text-[11px] font-bold px-2 py-0.5 rounded-[20px] shrink-0 ${cfg.className}`}>
             {cfg.label}
           </span>
         </div>
 
-        {/* Product title */}
         <p className="text-sm font-bold text-foreground line-clamp-2" style={{ lineHeight: 1.3, marginBottom: "5px" }}>
           {order.productTitle ?? "Order"}
         </p>
-
-        {/* Qty */}
         <p className="text-xs text-foreground/70" style={{ marginBottom: "3px" }}>Qty: {order.quantity}</p>
-
-        {/* Date + price */}
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
-          <span className="text-xs text-foreground/70">
-            Order placed on {formatDate(order.createdAt)}
-          </span>
+          <span className="text-xs text-foreground/70">Order placed on {formatDate(order.createdAt)}</span>
         </div>
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: "6px" }}>
-          <span className="text-[15px] font-extrabold text-primary">
-            £{order.total.toFixed(2)}
-          </span>
+          <span className="text-[15px] font-extrabold text-primary">£{order.total.toFixed(2)}</span>
           <ChevronRight className="text-foreground/25" style={{ width: "16px", height: "16px", flexShrink: 0 }} />
         </div>
       </div>
     </div>
   );
 }
-
-// ── Page ──────────────────────────────────────────────────────────────────────
 
 export default function MobileOrdersPage() {
   const navigate = useNavigate();
@@ -171,11 +133,7 @@ export default function MobileOrdersPage() {
   const [orders, setOrders] = useState<OrderRow[]>([]);
   const [loading, setLoading] = useState(true);
   const [activeTab, setActiveTab] = useState<Tab>("all");
-
-  // Ref map for scroll-to on deep link
-  const cardRefs = useRef<Map<string, React.RefObject<HTMLDivElement | null>>>(
-    new Map()
-  );
+  const cardRefs = useRef<Map<string, React.RefObject<HTMLDivElement | null>>>(new Map());
 
   useEffect(() => {
     if (!user?.id) {
@@ -196,7 +154,8 @@ export default function MobileOrdersPage() {
           .from("orders")
           .select(
             `id, orderNumber, total, status, createdAt, quantity,
-             products:productId(title, images)`
+             products:productId(title, images),
+             order_items(productTitleSnapshot, productImageSnapshot, productSnapshotSource)`
           )
           .eq("buyerId", user.id)
           .order("createdAt", { ascending: false });
@@ -215,17 +174,31 @@ export default function MobileOrdersPage() {
             createdAt: string;
             quantity: number;
             products: { title: string; images: string[] | null } | null;
+            order_items: Array<{
+              productTitleSnapshot: string | null;
+              productImageSnapshot: string | null;
+              productSnapshotSource: string | null;
+            }> | null;
           }>
-        ).map((o) => ({
-          id: o.id,
-          orderNumber: o.orderNumber,
-          total: o.total,
-          status: o.status,
-          createdAt: o.createdAt,
-          quantity: o.quantity ?? 1,
-          productTitle: o.products?.title ?? null,
-          productImage: (o.products?.images ?? [])[0] ?? null,
-        }));
+        ).map((o) => {
+          const snapshotItem = o.order_items?.find((item) => item.productSnapshotSource != null) ?? null;
+          return {
+            id: o.id,
+            orderNumber: o.orderNumber,
+            total: o.total,
+            status: o.status,
+            createdAt: o.createdAt,
+            quantity: o.quantity ?? 1,
+            productTitle: snapshotItem
+              ? snapshotItem.productTitleSnapshot
+              : o.products?.title ?? null,
+            // A NULL image in an authoritative snapshot means no image existed at
+            // checkout; do not replace that historical fact with a later live image.
+            productImage: snapshotItem
+              ? snapshotItem.productImageSnapshot
+              : (o.products?.images ?? [])[0] ?? null,
+          };
+        });
 
         setOrders(rows);
       } finally {
@@ -236,7 +209,6 @@ export default function MobileOrdersPage() {
     void load();
   }, [user?.id, promptAuth]);
 
-  // Scroll to deep-linked order once data is loaded
   useEffect(() => {
     if (!deepLinkOrderId || loading) return;
     const ref = cardRefs.current.get(deepLinkOrderId);
@@ -245,7 +217,6 @@ export default function MobileOrdersPage() {
     }
   }, [deepLinkOrderId, loading]);
 
-  // Filter orders by active tab
   const visibleOrders = activeTab === "all"
     ? orders
     : orders.filter((o) => TAB_STATUSES[activeTab].includes(o.status));
@@ -253,10 +224,7 @@ export default function MobileOrdersPage() {
   const hasAwaitingPayment = orders.some((o) => o.status === "awaiting_payment");
 
   return (
-    <div
-      className="min-h-screen flex flex-col bg-background"
-    >
-      {/* ── Header ── */}
+    <div className="min-h-screen flex flex-col bg-background">
       <div
         className="shrink-0 px-4 sticky top-0 z-10 bg-background/[0.97]"
         style={{
@@ -267,11 +235,7 @@ export default function MobileOrdersPage() {
           paddingBottom: "0",
         }}
       >
-        <h1 className="text-[22px] font-extrabold text-foreground" style={{ marginBottom: "12px" }}>
-          My Orders
-        </h1>
-
-        {/* Tab bar */}
+        <h1 className="text-[22px] font-extrabold text-foreground" style={{ marginBottom: "12px" }}>My Orders</h1>
         <div
           style={{
             display: "flex",
@@ -298,32 +262,22 @@ export default function MobileOrdersPage() {
         </div>
       </div>
 
-      {/* ── Content ── */}
       <div
         className="flex-1 overflow-y-auto px-4 py-4"
         style={{ paddingBottom: "calc(80px + env(safe-area-inset-bottom, 0px))" }}
       >
         {loading ? (
           [1, 2, 3].map((n) => (
-            <div
-              key={n}
-              className="animate-pulse bg-white/[0.05]"
-              style={{ height: "108px", borderRadius: "16px", marginBottom: "12px" }}
-            />
+            <div key={n} className="animate-pulse bg-white/[0.05]" style={{ height: "108px", borderRadius: "16px", marginBottom: "12px" }} />
           ))
         ) : visibleOrders.length === 0 ? (
           <div className="flex flex-col items-center justify-center py-24 gap-4">
             <div className="w-16 h-16 rounded-full bg-white/5 flex items-center justify-center">
               <Package className="h-8 w-8 text-white/20" />
             </div>
-            <p className="text-white/75 text-sm">
-              {activeTab === "all" ? "No orders yet" : "No orders in this category"}
-            </p>
+            <p className="text-white/75 text-sm">{activeTab === "all" ? "No orders yet" : "No orders in this category"}</p>
             {activeTab === "all" && (
-              <Link
-                to="/catalog"
-                className="px-4 py-2 rounded-xl bg-primary/10 text-primary text-sm font-semibold"
-              >
+              <Link to="/catalog" className="px-4 py-2 rounded-xl bg-primary/10 text-primary text-sm font-semibold">
                 Start browsing
               </Link>
             )}
@@ -346,7 +300,6 @@ export default function MobileOrdersPage() {
           </div>
         )}
 
-        {/* Awaiting payment notice */}
         {!loading && hasAwaitingPayment && (
           <div className="flex items-start gap-2 rounded-xl bg-primary/10 border border-primary/40 p-3 mt-3">
             <AlertCircle className="h-4 w-4 text-primary mt-0.5 shrink-0" />
@@ -356,7 +309,6 @@ export default function MobileOrdersPage() {
           </div>
         )}
 
-        {/* Need help footer */}
         {!loading && (
           <button
             onClick={() => navigate("/buyer/profile")}
@@ -373,9 +325,7 @@ export default function MobileOrdersPage() {
             }}
           >
             <HelpCircle className="text-foreground/60" style={{ width: "20px", height: "20px", flexShrink: 0 }} />
-            <span className="text-sm text-foreground/75" style={{ flex: 1, textAlign: "left" }}>
-              Need help with your order?
-            </span>
+            <span className="text-sm text-foreground/75" style={{ flex: 1, textAlign: "left" }}>Need help with your order?</span>
             <ChevronRight className="text-foreground/25" style={{ width: "16px", height: "16px" }} />
           </button>
         )}

--- a/src/pages/pixel-perfect/buyer/BuyerDashboard.tsx
+++ b/src/pages/pixel-perfect/buyer/BuyerDashboard.tsx
@@ -14,6 +14,12 @@ interface OrderRow {
   status: string;
   createdAt: string;
   products: { title: string } | null;
+  order_items: Array<{ productTitleSnapshot: string | null; productSnapshotSource: string | null }> | null;
+}
+
+function orderProductTitle(order: OrderRow): string | null {
+  const snapshotItem = order.order_items?.find((item) => item.productSnapshotSource != null) ?? null;
+  return snapshotItem ? snapshotItem.productTitleSnapshot : order.products?.title ?? null;
 }
 
 interface WishlistProduct {
@@ -51,7 +57,7 @@ const BuyerDashboard = () => {
         const [ordersRes, wishlistRes] = await Promise.all([
           supabase
             .from("orders")
-            .select("id, orderNumber, total, status, createdAt, products(title)")
+            .select("id, orderNumber, total, status, createdAt, products(title), order_items(productTitleSnapshot, productSnapshotSource)")
             .eq("buyerId", user.id)
             .order("createdAt", { ascending: false }),
           supabase
@@ -64,8 +70,6 @@ const BuyerDashboard = () => {
         const allOrders = (ordersRes.data as unknown as OrderRow[]) || [];
         setRecentOrders(allOrders.slice(0, 5));
         setTotalOrders(allOrders.length);
-        // Only count orders that have actually been paid/fulfilled — exclude
-        // cancelled and refunded orders so the "Total Spent" stat is accurate.
         const completedStatuses = ["paid", "packed", "shipped", "delivered", "completed"];
         setTotalSpent(
           allOrders
@@ -73,8 +77,7 @@ const BuyerDashboard = () => {
             .reduce((sum, o) => sum + (o.total || 0), 0)
         );
 
-        const productIds: string[] =
-          wishlistRes.data?.productIds || [];
+        const productIds: string[] = wishlistRes.data?.productIds || [];
         setWishlistCount(productIds.length);
 
         if (productIds.length > 0) {
@@ -111,12 +114,9 @@ const BuyerDashboard = () => {
     <div className="p-4 sm:p-6 space-y-6">
       <div>
         <h1 className="text-2xl font-bold text-foreground">Welcome back, {firstName} 👋</h1>
-        <p className="text-muted-foreground text-sm mt-1">
-          Here's a summary of your account activity.
-        </p>
+        <p className="text-muted-foreground text-sm mt-1">Here's a summary of your account activity.</p>
       </div>
 
-      {/* Stats */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         {stats.map((s) => (
           <Link key={s.label} to={s.to} aria-label={`View ${s.label.toLowerCase()}`} className="block hover:scale-[1.02] transition-transform focus:outline-none focus-visible:ring-2 focus-visible:ring-primary rounded-xl">
@@ -139,7 +139,6 @@ const BuyerDashboard = () => {
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
-        {/* Recent Orders */}
         <Card className="lg:col-span-2">
           <CardHeader className="flex flex-row items-center justify-between pb-3">
             <div>
@@ -147,9 +146,7 @@ const BuyerDashboard = () => {
               <CardDescription>Your latest purchases</CardDescription>
             </div>
             <Button variant="outline" size="sm" className="text-xs" asChild>
-              <Link to="/buyer/orders">
-                View All <ArrowUpRight className="h-3 w-3 ml-1" />
-              </Link>
+              <Link to="/buyer/orders">View All <ArrowUpRight className="h-3 w-3 ml-1" /></Link>
             </Button>
           </CardHeader>
           <CardContent className="space-y-3">
@@ -158,33 +155,35 @@ const BuyerDashboard = () => {
             ) : recentOrders.length === 0 ? (
               <p className="text-sm text-muted-foreground py-4 text-center">No orders yet.</p>
             ) : (
-              recentOrders.map((o) => (
-                <div key={o.id} className="flex items-center justify-between rounded-lg border border-border p-3 hover:bg-muted/30 transition-colors">
-                  <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 rounded-lg bg-muted flex items-center justify-center">
-                      <Package className="h-5 w-5 text-muted-foreground" />
+              recentOrders.map((o) => {
+                const historicalTitle = orderProductTitle(o);
+                return (
+                  <div key={o.id} className="flex items-center justify-between rounded-lg border border-border p-3 hover:bg-muted/30 transition-colors">
+                    <div className="flex items-center gap-3">
+                      <div className="w-10 h-10 rounded-lg bg-muted flex items-center justify-center">
+                        <Package className="h-5 w-5 text-muted-foreground" />
+                      </div>
+                      <div>
+                        <p className="text-sm font-medium text-foreground">{o.orderNumber || o.id.slice(0, 8).toUpperCase()}</p>
+                        <p className="text-xs text-muted-foreground">
+                          {new Date(o.createdAt).toLocaleDateString("en-GB")}
+                          {historicalTitle ? ` · ${historicalTitle}` : ""}
+                        </p>
+                      </div>
                     </div>
-                    <div>
-                      <p className="text-sm font-medium text-foreground">{o.orderNumber || o.id.slice(0, 8).toUpperCase()}</p>
-                      <p className="text-xs text-muted-foreground">
-                        {new Date(o.createdAt).toLocaleDateString("en-GB")}
-                        {o.products?.title ? ` · ${o.products.title}` : ""}
-                      </p>
+                    <div className="flex items-center gap-3">
+                      <span className="text-sm font-semibold text-foreground">
+                        £{(o.total ?? 0).toLocaleString("en-GB", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
+                      </span>
+                      <Badge variant="outline" className={statusColor[o.status] ?? ""}>{o.status}</Badge>
                     </div>
                   </div>
-                  <div className="flex items-center gap-3">
-                    <span className="text-sm font-semibold text-foreground">
-                      £{(o.total ?? 0).toLocaleString("en-GB", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-                    </span>
-                    <Badge variant="outline" className={statusColor[o.status] ?? ""}>{o.status}</Badge>
-                  </div>
-                </div>
-              ))
+                );
+              })
             )}
           </CardContent>
         </Card>
 
-        {/* Wishlist Preview */}
         <Card>
           <CardHeader className="flex flex-row items-center justify-between pb-3">
             <div>
@@ -192,9 +191,7 @@ const BuyerDashboard = () => {
               <CardDescription>Saved for later</CardDescription>
             </div>
             <Button variant="outline" size="sm" className="text-xs" asChild>
-              <Link to="/buyer/wishlist">
-                View All <ArrowUpRight className="h-3 w-3 ml-1" />
-              </Link>
+              <Link to="/buyer/wishlist">View All <ArrowUpRight className="h-3 w-3 ml-1" /></Link>
             </Button>
           </CardHeader>
           <CardContent className="space-y-3">

--- a/src/pages/pixel-perfect/buyer/BuyerOrders.tsx
+++ b/src/pages/pixel-perfect/buyer/BuyerOrders.tsx
@@ -30,6 +30,12 @@ interface OrderRow {
   createdAt: string;
   sellerId: string | null;
   products: { title: string } | null;
+  order_items: Array<{ productTitleSnapshot: string | null }> | null;
+}
+
+function orderProductTitle(order: OrderRow): string {
+  const snapshot = order.order_items?.find((item) => item.productTitleSnapshot?.trim())?.productTitleSnapshot?.trim();
+  return snapshot || order.products?.title || "—";
 }
 
 const statusColor: Record<string, string> = {
@@ -68,20 +74,17 @@ const BuyerOrders = () => {
   const [loading, setLoading] = useState(true);
   const [search, setSearch] = useState("");
 
-  // Return request dialog state
   const [returnOrder, setReturnOrder] = useState<OrderRow | null>(null);
   const [returnReason, setReturnReason] = useState("");
   const [returnDescription, setReturnDescription] = useState("");
   const [returnLoading, setReturnLoading] = useState(false);
 
-  // Dispute dialog state
   const [disputeOrder, setDisputeOrder] = useState<OrderRow | null>(null);
   const [disputeSubject, setDisputeSubject] = useState("");
   const [disputeReason, setDisputeReason] = useState("");
   const [disputeDescription, setDisputeDescription] = useState("");
   const [disputeLoading, setDisputeLoading] = useState(false);
 
-  // Confirm delivery dialog state
   const [confirmDeliveryOrder, setConfirmDeliveryOrder] = useState<OrderRow | null>(null);
   const [confirmDeliveryLoading, setConfirmDeliveryLoading] = useState(false);
 
@@ -89,10 +92,6 @@ const BuyerOrders = () => {
     if (!confirmDeliveryOrder || !user) return;
     setConfirmDeliveryLoading(true);
     try {
-      // Route escrow release through the server-side function so it can enforce
-      // pre-conditions (order must belong to this buyer, status must be
-      // shipped/delivered, no double-release) and handle seller notification
-      // safely server-side rather than writing escrow fields from the browser.
       const res = await authorizedFetch("/.netlify/functions/confirm-delivery", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -105,7 +104,6 @@ const BuyerOrders = () => {
           const errBody = await res.json() as { error?: string };
           serverMessage = errBody.error;
         } catch {
-          // Response body was not valid JSON — use status text instead
           serverMessage = res.statusText || undefined;
         }
         throw new Error(serverMessage ?? `Server error ${res.status}`);
@@ -135,14 +133,11 @@ const BuyerOrders = () => {
         const data = await res.json().catch(() => ({}));
         throw new Error((data as { error?: string }).error || 'Failed to generate invoice');
       }
-      // The function returns an HTML page — open it in a new tab so the user
-      // can print or save as PDF using their browser's built-in print dialog.
       const html = await res.text();
       const blob = new Blob([html], { type: 'text/html' });
       const url = URL.createObjectURL(blob);
       const win = window.open(url, '_blank', 'noopener,noreferrer');
       if (!win) {
-        // Popup was blocked — inform the user and fall back to direct download
         toast({
           title: 'Pop-up blocked',
           description:
@@ -155,7 +150,6 @@ const BuyerOrders = () => {
         a.download = `invoice-${orderNumber || orderId.slice(0, 8)}.html`;
         a.click();
       }
-      // Revoke after a short delay to allow the new tab to fully load
       setTimeout(() => URL.revokeObjectURL(url), 10_000);
     } catch (err) {
       toast({ title: 'Invoice generation failed', description: (err as Error).message, variant: 'destructive' });
@@ -169,7 +163,7 @@ const BuyerOrders = () => {
       try {
         const { data, error } = await supabase
           .from("orders")
-          .select("id, orderNumber, total, status, createdAt, sellerId, products(title)")
+          .select("id, orderNumber, total, status, createdAt, sellerId, products(title), order_items(productTitleSnapshot)")
           .eq("buyerId", user.id)
           .order("createdAt", { ascending: false });
         if (error) throw error;
@@ -187,7 +181,7 @@ const BuyerOrders = () => {
   const filtered = orders.filter(
     (o) =>
       (o.orderNumber || o.id).toLowerCase().includes(search.toLowerCase()) ||
-      (o.products?.title ?? "").toLowerCase().includes(search.toLowerCase())
+      orderProductTitle(o).toLowerCase().includes(search.toLowerCase())
   );
 
   const byStatus = (status: string) => filtered.filter((o) => o.status === status);
@@ -200,7 +194,6 @@ const BuyerOrders = () => {
     }
     setReturnLoading(true);
     try {
-      // Prevent duplicate open returns for the same order
       const { data: existing } = await supabase
         .from("returns")
         .select("id")
@@ -296,7 +289,7 @@ const BuyerOrders = () => {
                 {o.orderNumber || o.id.slice(0, 8).toUpperCase()}
               </TableCell>
               <TableCell className="hidden sm:table-cell text-xs text-muted-foreground max-w-[200px] truncate">
-                {o.products?.title ?? "—"}
+                {orderProductTitle(o)}
               </TableCell>
               <TableCell className="text-xs text-muted-foreground">
                 {new Date(o.createdAt).toLocaleDateString("en-GB")}
@@ -409,7 +402,6 @@ const BuyerOrders = () => {
         <TabsContent value="completed"><Card><CardContent className="pt-4"><div className="overflow-x-auto">{renderTable(byStatus("completed"))}</div></CardContent></Card></TabsContent>
       </Tabs>
 
-      {/* Return Request Dialog */}
       <Dialog open={!!returnOrder} onOpenChange={(open) => { if (!open) setReturnOrder(null); }}>
         <DialogContent>
           <DialogHeader>
@@ -457,7 +449,6 @@ const BuyerOrders = () => {
         </DialogContent>
       </Dialog>
 
-      {/* Dispute Dialog */}
       <Dialog open={!!disputeOrder} onOpenChange={(open) => { if (!open) setDisputeOrder(null); }}>
         <DialogContent>
           <DialogHeader>
@@ -515,7 +506,6 @@ const BuyerOrders = () => {
         </DialogContent>
       </Dialog>
 
-      {/* Confirm Delivery Dialog */}
       <Dialog open={!!confirmDeliveryOrder} onOpenChange={(open) => { if (!open) setConfirmDeliveryOrder(null); }}>
         <DialogContent>
           <DialogHeader>

--- a/src/pages/pixel-perfect/buyer/BuyerReviews.tsx
+++ b/src/pages/pixel-perfect/buyer/BuyerReviews.tsx
@@ -71,7 +71,6 @@ const BuyerReviews = () => {
   const [search, setSearch] = useState("");
   const [selected, setSelected] = useState<ReviewRow | null>(null);
 
-  // Write-review dialog state
   const [writeOpen, setWriteOpen] = useState(false);
   const [reviewableOrders, setReviewableOrders] = useState<ReviewableOrder[]>([]);
   const [newReview, setNewReview] = useState({ orderId: "", productId: "", productTitle: "", rating: 5, title: "", comment: "" });
@@ -98,13 +97,15 @@ const BuyerReviews = () => {
     fetchReviews();
   }, [user]);
 
-  // Load reviewable (delivered, not-yet-reviewed) orders
+  // Load reviewable (delivered, not-yet-reviewed) purchases. For post-cutover
+  // orders the checkout-time product snapshot is authoritative. Current product
+  // title is only a display fallback for legacy rows with no snapshot source.
   useEffect(() => {
     if (!user) return;
     const fetchReviewableOrders = async () => {
       const { data: orders } = await supabase
         .from("orders")
-        .select("id, productId, products(title)")
+        .select("id, productId, products(title), order_items(productId, productTitleSnapshot, productSnapshotSource)")
         .eq("buyerId", user.id)
         .eq("status", "delivered");
       if (!orders?.length) return;
@@ -117,7 +118,21 @@ const BuyerReviews = () => {
         .filter((o) => !reviewedOrderIds.has(o.id))
         .map((o) => {
           const prod = Array.isArray(o.products) ? o.products[0] : o.products;
-          return { orderId: o.id, productId: o.productId, productTitle: (prod as { title?: string })?.title ?? "Unknown Product" };
+          const snapshotItems = (o.order_items ?? []) as Array<{
+            productId: string;
+            productTitleSnapshot: string | null;
+            productSnapshotSource: string | null;
+          }>;
+          const snapshotItem = snapshotItems.find(
+            (item) => item.productId === o.productId && item.productSnapshotSource != null,
+          ) ?? null;
+          return {
+            orderId: o.id,
+            productId: o.productId,
+            productTitle: snapshotItem
+              ? snapshotItem.productTitleSnapshot || "Unknown Product"
+              : (prod as { title?: string } | null)?.title ?? "Unknown Product",
+          };
         });
       setReviewableOrders(reviewable);
     };
@@ -155,14 +170,12 @@ const BuyerReviews = () => {
       toast({ title: "Review submitted", description: "Thank you for your feedback!" });
       setWriteOpen(false);
       setNewReview({ orderId: "", productId: "", productTitle: "", rating: 5, title: "", comment: "" });
-      // Refresh reviews list
       const { data } = await supabase
         .from("reviews")
         .select("id, productId, rating, title, comment, sellerResponse, status, createdAt, products(title)")
         .eq("userId", user.id)
         .order("createdAt", { ascending: false });
       setReviews((data as unknown as ReviewRow[]) || []);
-      // Remove the reviewed order from reviewable list
       setReviewableOrders((prev) => prev.filter((o) => o.orderId !== newReview.orderId));
     } catch (err) {
       toast({ title: "Failed to submit review", description: err instanceof Error ? err.message : "Please try again.", variant: "destructive" });
@@ -249,7 +262,6 @@ const BuyerReviews = () => {
         )}
       </div>
 
-      {/* Stats */}
       <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
         <Card>
           <CardContent className="p-5">
@@ -294,7 +306,6 @@ const BuyerReviews = () => {
         </Card>
       </div>
 
-      {/* Distribution */}
       {!loading && reviews.length > 0 && (
         <Card>
           <CardHeader className="pb-3">
@@ -317,13 +328,11 @@ const BuyerReviews = () => {
         </Card>
       )}
 
-      {/* Search */}
       <div className="relative max-w-sm">
         <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
         <Input placeholder="Search reviews..." value={search} onChange={(e) => setSearch(e.target.value)} className="pl-9" />
       </div>
 
-      {/* Tabs */}
       <Tabs defaultValue="all">
         <TabsList>
           <TabsTrigger value="all">All <Badge variant="secondary" className="ml-2 text-xs">{filtered.length}</Badge></TabsTrigger>
@@ -335,7 +344,6 @@ const BuyerReviews = () => {
         <TabsContent value="pending"><Card><CardContent className="pt-4"><div className="overflow-x-auto">{renderTable(byStatus("pending"))}</div></CardContent></Card></TabsContent>
       </Tabs>
 
-      {/* Review Detail Dialog */}
       <Dialog open={!!selected} onOpenChange={() => setSelected(null)}>
         {selected && (
           <DialogContent className="max-w-lg">
@@ -374,7 +382,6 @@ const BuyerReviews = () => {
         )}
       </Dialog>
 
-      {/* Write a Review Dialog */}
       <Dialog open={writeOpen} onOpenChange={(open) => { if (!open) { setWriteOpen(false); setNewReview({ orderId: "", productId: "", productTitle: "", rating: 5, title: "", comment: "" }); } }}>
         <DialogContent className="max-w-lg">
           <DialogHeader>

--- a/src/pages/pixel-perfect/seller/SellerDashboard.tsx
+++ b/src/pages/pixel-perfect/seller/SellerDashboard.tsx
@@ -84,7 +84,7 @@ const SellerDashboard = () => {
             .eq("sellerId", user.id),
           supabase
             .from("orders")
-            .select(`id, orderNumber, total, status, createdAt, buyerId`)
+            .select(`id, orderNumber, total, status, createdAt, buyerId, buyerNameSnapshot, commercialSnapshotSource`)
             .eq("sellerId", user.id)
             .order("createdAt", { ascending: false }),
           supabase
@@ -106,13 +106,17 @@ const SellerDashboard = () => {
 
         const products = productsRes.data ?? [];
         const orders = (allOrdersRes.data ?? []) as Array<{
-          id: string; orderNumber: string; total: number; status: string; createdAt: string; buyerId: string;
+          id: string;
+          orderNumber: string;
+          total: number;
+          status: string;
+          createdAt: string;
+          buyerId: string;
+          buyerNameSnapshot: string | null;
+          commercialSnapshotSource: string | null;
         }>;
 
-        // Stats
         const activeOrders = orders.filter((o) => ["paid", "packed", "shipped"].includes(o.status)).length;
-        // Only count revenue from orders that have actually been paid — exclude
-        // awaiting_payment, cancelled and refunded so the KPI reflects real income.
         const PAID_STATUSES = ["paid", "packed", "shipped", "delivered", "completed"];
         const totalRevenue = orders
           .filter((o) => PAID_STATUSES.includes(o.status))
@@ -138,33 +142,41 @@ const SellerDashboard = () => {
           todayMessages: todayMessagesRes.count ?? null,
         });
 
-        // Resolve buyer names for recent orders
-        const buyerNames: Record<string, string> = {};
-        const recentBuyerIds = [...new Set(orders.slice(0, 5).map((o) => o.buyerId).filter(Boolean))];
-        if (recentBuyerIds.length > 0) {
+        // Snapshot identity is authoritative for post-cutover commercial history.
+        // Query current users only for recent legacy rows with no authoritative
+        // snapshot, and never persist this fallback into historical records.
+        const recentFive = orders.slice(0, 5);
+        const legacyBuyerIds = [...new Set(
+          recentFive
+            .filter((o) => !o.commercialSnapshotSource || !o.buyerNameSnapshot?.trim())
+            .map((o) => o.buyerId)
+            .filter(Boolean),
+        )];
+        const legacyBuyerNames: Record<string, string> = {};
+        if (legacyBuyerIds.length > 0) {
           const { data: buyers } = await supabase
             .from("users")
             .select("id, firstName, lastName")
-            .in("id", recentBuyerIds);
+            .in("id", legacyBuyerIds);
           (buyers ?? []).forEach((b: BuyerData) => {
             const name = [b.firstName, b.lastName].filter(Boolean).join(" ").trim();
-            buyerNames[b.id] = name || "Customer";
+            legacyBuyerNames[b.id] = name || "Customer";
           });
         }
 
-        // Recent orders (show last 5 only)
         setRecentOrders(
-          orders.slice(0, 5).map((o) => ({
+          recentFive.map((o) => ({
             id: o.id,
             orderNumber: o.orderNumber,
-            buyerName: buyerNames[o.buyerId] ?? "Customer",
+            buyerName: o.commercialSnapshotSource && o.buyerNameSnapshot?.trim()
+              ? o.buyerNameSnapshot.trim()
+              : legacyBuyerNames[o.buyerId] ?? "Customer",
             total: o.total,
             status: o.status,
             createdAt: o.createdAt,
           }))
         );
 
-        // Top products by views
         const sorted = [...products]
           .sort((a, b) => (b.views ?? 0) - (a.views ?? 0))
           .slice(0, 4);
@@ -252,24 +264,17 @@ const SellerDashboard = () => {
 
   return (
     <div className="px-3 pt-3 pb-4 sm:p-6 space-y-3 sm:space-y-6 max-w-[1200px]">
-      {/* Onboarding compact row — shown only to sellers who haven't completed setup */}
       <OnboardingChecklist />
 
-      {/* Quick Actions — top priority, horizontal row */}
       <div className="grid grid-cols-2 gap-2 sm:gap-3">
         <Button size="sm" className="bg-primary hover:bg-primary-hover text-black h-10 text-sm font-extrabold shadow-[0_0_18px_rgba(212,175,55,0.35)] ring-1 ring-primary/40" asChild>
-          <Link to="/seller/products/new">
-            <Package className="mr-1.5 h-4 w-4" /> Add Product
-          </Link>
+          <Link to="/seller/products/new"><Package className="mr-1.5 h-4 w-4" /> Add Product</Link>
         </Button>
         <Button size="sm" variant="outline" className="h-10 text-sm font-semibold border-primary/40 hover:border-primary" asChild>
-          <Link to="/seller/shipments">
-            <Truck className="mr-1.5 h-4 w-4 text-primary" /> Log Shipment
-          </Link>
+          <Link to="/seller/shipments"><Truck className="mr-1.5 h-4 w-4 text-primary" /> Log Shipment</Link>
         </Button>
       </div>
 
-      {/* Stats Grid — compact 2×2 */}
       {loading ? (
         <div className="grid grid-cols-2 gap-2">
           {[1, 2, 3, 4].map((i) => (
@@ -297,7 +302,6 @@ const SellerDashboard = () => {
         </div>
       )}
 
-      {/* Balance row — compact */}
       {balance && (
         <div className="grid grid-cols-2 gap-2">
           <div className="bg-card rounded-lg border border-border p-3 space-y-1.5">
@@ -305,17 +309,8 @@ const SellerDashboard = () => {
             <p className="font-bold text-base text-foreground leading-tight">
               £{balance.availableAmount.toLocaleString("en-GB", { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
             </p>
-            <Button
-              size="sm"
-              className="h-7 text-xs w-full px-2"
-              onClick={handleRequestPayout}
-              disabled={payoutLoading || balance.availableAmount <= 0}
-            >
-              {payoutLoading ? (
-                <><Loader2 className="mr-1 h-3 w-3 animate-spin" /> Requesting…</>
-              ) : (
-                <><Send className="mr-1 h-3 w-3" /> Payout</>
-              )}
+            <Button size="sm" className="h-7 text-xs w-full px-2" onClick={handleRequestPayout} disabled={payoutLoading || balance.availableAmount <= 0}>
+              {payoutLoading ? <><Loader2 className="mr-1 h-3 w-3 animate-spin" /> Requesting…</> : <><Send className="mr-1 h-3 w-3" /> Payout</>}
             </Button>
           </div>
           <div className="bg-card rounded-lg border border-border p-3 space-y-1">
@@ -328,7 +323,6 @@ const SellerDashboard = () => {
         </div>
       )}
 
-      {/* Today mini block */}
       <div className="bg-card rounded-lg border border-border p-3">
         <h2 className="text-sm font-semibold text-foreground mb-2">Today</h2>
         {loading || !stats ? (
@@ -343,7 +337,6 @@ const SellerDashboard = () => {
         )}
       </div>
 
-      {/* Recent Orders — mobile card list */}
       <div className="bg-card rounded-lg border border-border">
         <div className="flex items-center justify-between px-3 py-2.5 border-b border-border">
           <h2 className="text-sm font-semibold text-foreground">Recent Orders</h2>
@@ -363,9 +356,7 @@ const SellerDashboard = () => {
                 <div className="flex-1 min-w-0">
                   <div className="flex items-center gap-1.5">
                     <span className="text-[13px] font-semibold text-foreground">{order.orderNumber}</span>
-                    <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full border capitalize shrink-0 ${statusColors[order.status] ?? "bg-muted text-muted-foreground"}`}>
-                      {order.status}
-                    </span>
+                    <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full border capitalize shrink-0 ${statusColors[order.status] ?? "bg-muted text-muted-foreground"}`}>{order.status}</span>
                   </div>
                   <p className="text-[11px] text-muted-foreground mt-0.5">{order.buyerName}</p>
                 </div>
@@ -379,7 +370,6 @@ const SellerDashboard = () => {
         </div>
       </div>
 
-      {/* Top Products — compact list */}
       <div className="bg-card rounded-lg border border-border">
         <div className="flex items-center justify-between px-3 py-2.5 border-b border-border">
           <h2 className="text-sm font-semibold text-foreground">Top Products</h2>
@@ -396,9 +386,7 @@ const SellerDashboard = () => {
           ) : (
             topProducts.map((prod, i) => (
               <div key={prod.id} className="flex items-center gap-3 px-3 py-2.5">
-                <span className="w-5 h-5 rounded-full bg-muted flex items-center justify-center text-[11px] font-bold text-muted-foreground shrink-0">
-                  {i + 1}
-                </span>
+                <span className="w-5 h-5 rounded-full bg-muted flex items-center justify-center text-[11px] font-bold text-muted-foreground shrink-0">{i + 1}</span>
                 <div className="flex-1 min-w-0">
                   <p className="text-[13px] font-medium text-foreground truncate">{prod.title}</p>
                   <div className="flex items-center gap-2.5 text-[11px] text-muted-foreground mt-0.5">
@@ -412,15 +400,12 @@ const SellerDashboard = () => {
         </div>
       </div>
 
-      {/* Quick Stats — compact grid */}
       <div className="bg-card rounded-lg border border-border p-3">
         <h2 className="text-sm font-semibold text-foreground mb-2.5">Quick Stats</h2>
         <div className="grid grid-cols-2 gap-x-4 gap-y-2">
           <div className="flex items-center justify-between">
             <span className="flex items-center gap-1.5 text-[12px] text-muted-foreground"><Star className="h-3.5 w-3.5 text-accent" /> Rating</span>
-            <span className="text-[12px] font-semibold text-foreground">
-              {loading ? "—" : stats?.sellerRating ? `${stats.sellerRating.toFixed(1)}` : "—"}
-            </span>
+            <span className="text-[12px] font-semibold text-foreground">{loading ? "—" : stats?.sellerRating ? `${stats.sellerRating.toFixed(1)}` : "—"}</span>
           </div>
           <div className="flex items-center justify-between">
             <span className="flex items-center gap-1.5 text-[12px] text-muted-foreground"><Users className="h-3.5 w-3.5 text-primary" /> Customers</span>

--- a/src/pages/pixel-perfect/seller/SellerOrders.tsx
+++ b/src/pages/pixel-perfect/seller/SellerOrders.tsx
@@ -55,7 +55,7 @@ const SellerOrders = () => {
       setLoadError(null);
       const { data, error: fetchError } = await supabase
         .from("orders")
-        .select(`id, orderNumber, total, status, createdAt, buyerId`)
+        .select(`id, orderNumber, total, status, createdAt, buyerId, buyerNameSnapshot, commercialSnapshotSource`)
         .eq("sellerId", user.id)
         .order("createdAt", { ascending: false });
 
@@ -67,20 +67,34 @@ const SellerOrders = () => {
       }
 
       const rows = (data ?? []) as Array<{
-        id: string; orderNumber: string; total: number; status: string; createdAt: string; buyerId: string;
+        id: string;
+        orderNumber: string;
+        total: number;
+        status: string;
+        createdAt: string;
+        buyerId: string;
+        buyerNameSnapshot: string | null;
+        commercialSnapshotSource: string | null;
       }>;
 
-      // Resolve buyer names via secondary query
-      const buyerIds = [...new Set(rows.map((o) => o.buyerId).filter(Boolean))];
-      const buyerNames: Record<string, string> = {};
-      if (buyerIds.length > 0) {
+      // Snapshot identity is authoritative for post-cutover orders. Only rows
+      // without an authoritative snapshot may use today's user profile as a
+      // display-only legacy fallback; that fallback is never persisted.
+      const legacyBuyerIds = [...new Set(
+        rows
+          .filter((o) => !o.commercialSnapshotSource || !o.buyerNameSnapshot?.trim())
+          .map((o) => o.buyerId)
+          .filter(Boolean),
+      )];
+      const legacyBuyerNames: Record<string, string> = {};
+      if (legacyBuyerIds.length > 0) {
         const { data: buyers } = await supabase
           .from("users")
           .select("id, firstName, lastName")
-          .in("id", buyerIds);
+          .in("id", legacyBuyerIds);
         (buyers ?? []).forEach((b: BuyerData) => {
           const name = [b.firstName, b.lastName].filter(Boolean).join(" ").trim();
-          buyerNames[b.id] = name || "Customer";
+          legacyBuyerNames[b.id] = name || "Customer";
         });
       }
 
@@ -89,7 +103,9 @@ const SellerOrders = () => {
           id: o.id,
           orderNumber: o.orderNumber,
           buyerId: o.buyerId,
-          buyerName: buyerNames[o.buyerId] ?? "Customer",
+          buyerName: o.commercialSnapshotSource && o.buyerNameSnapshot?.trim()
+            ? o.buyerNameSnapshot.trim()
+            : legacyBuyerNames[o.buyerId] ?? "Customer",
           total: o.total,
           status: o.status,
           createdAt: o.createdAt,
@@ -116,9 +132,7 @@ const SellerOrders = () => {
       const json = await res.json() as { error?: string };
       if (!res.ok) throw new Error(json.error ?? "Failed to update order status");
 
-      setOrders((prev) =>
-        prev.map((o) => (o.id === orderId ? { ...o, status: newStatus } : o))
-      );
+      setOrders((prev) => prev.map((o) => (o.id === orderId ? { ...o, status: newStatus } : o)));
       toast({ title: "Order updated", description: `Status changed to ${newStatus}.` });
     } catch (err) {
       toast({ title: "Update failed", description: (err as Error).message, variant: "destructive" });
@@ -137,9 +151,7 @@ const SellerOrders = () => {
       const json = await res.json() as { error?: string };
       if (!res.ok) throw new Error(json.error ?? "Failed to mark order as delivered");
 
-      setOrders((prev) =>
-        prev.map((o) => (o.id === orderId ? { ...o, status: "delivered" } : o))
-      );
+      setOrders((prev) => prev.map((o) => (o.id === orderId ? { ...o, status: "delivered" } : o)));
       toast({ title: "Order marked as delivered", description: "The buyer has been notified to confirm delivery." });
     } catch (err) {
       toast({ title: "Update failed", description: (err as Error).message, variant: "destructive" });
@@ -152,12 +164,9 @@ const SellerOrders = () => {
     <div className="p-4 sm:p-6 space-y-6 max-w-[1200px]">
       <div>
         <h1 className="font-display text-2xl font-bold text-foreground">Orders</h1>
-        <p className="text-sm text-muted-foreground mt-1">
-          {loading ? "Loading…" : `${orders.length} orders total`}
-        </p>
+        <p className="text-sm text-muted-foreground mt-1">{loading ? "Loading…" : `${orders.length} orders total`}</p>
       </div>
 
-      {/* Awaiting-payment highlight banner */}
       {!loading && orders.some((o) => o.status === "awaiting_payment") && (
         <div className="flex items-start gap-3 rounded-xl bg-primary/10 border border-primary/40 p-3.5">
           <span className="text-primary text-xl leading-none mt-0.5">⚠</span>
@@ -180,18 +189,11 @@ const SellerOrders = () => {
       <div className="flex gap-3">
         <div className="relative flex-1 max-w-sm">
           <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-          <Input
-            placeholder="Search orders..."
-            className="pl-9 h-10"
-            value={search}
-            onChange={(e) => setSearch(e.target.value)}
-          />
+          <Input placeholder="Search orders..." className="pl-9 h-10" value={search} onChange={(e) => setSearch(e.target.value)} />
         </div>
       </div>
 
       <div className="bg-card rounded-xl border border-border overflow-hidden">
-
-        {/* ── Mobile: card list ─────────────────────────────────── */}
         <div className="sm:hidden divide-y divide-border">
           {loading ? (
             <div className="p-8 text-center text-muted-foreground text-sm">Loading orders…</div>
@@ -218,42 +220,18 @@ const SellerOrders = () => {
                 <div className="flex items-center justify-between pt-1">
                   <span className="text-xs text-muted-foreground">{formatDate(o.createdAt)}</span>
                   <div className="flex items-center gap-1">
-                    <Button
-                      variant="ghost"
-                      size="sm"
-                      className="h-7 text-xs"
-                      onClick={() => navigate(`/tracking/${o.orderNumber || o.id}`)}
-                    >
-                      View
-                    </Button>
+                    <Button variant="ghost" size="sm" className="h-7 text-xs" onClick={() => navigate(`/tracking/${o.orderNumber || o.id}`)}>View</Button>
                     {["paid", "packed", "shipped"].includes(o.status) && (
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
-                          <Button
-                            variant="ghost"
-                            size="sm"
-                            className="h-7 text-xs gap-1"
-                            disabled={actionLoading === o.id}
-                          >
+                          <Button variant="ghost" size="sm" className="h-7 text-xs gap-1" disabled={actionLoading === o.id}>
                             Update <ChevronDown className="h-3 w-3" />
                           </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
-                          {o.status === "paid" && (
-                            <DropdownMenuItem onClick={() => updateOrderStatus(o.id, "packed")}>
-                              Mark as Packed
-                            </DropdownMenuItem>
-                          )}
-                          {(o.status === "paid" || o.status === "packed") && (
-                            <DropdownMenuItem onClick={() => updateOrderStatus(o.id, "shipped")}>
-                              Mark as Shipped
-                            </DropdownMenuItem>
-                          )}
-                          {o.status === "shipped" && (
-                            <DropdownMenuItem onClick={() => markDelivered(o.id)}>
-                              Mark as Delivered
-                            </DropdownMenuItem>
-                          )}
+                          {o.status === "paid" && <DropdownMenuItem onClick={() => updateOrderStatus(o.id, "packed")}>Mark as Packed</DropdownMenuItem>}
+                          {(o.status === "paid" || o.status === "packed") && <DropdownMenuItem onClick={() => updateOrderStatus(o.id, "shipped")}>Mark as Shipped</DropdownMenuItem>}
+                          {o.status === "shipped" && <DropdownMenuItem onClick={() => markDelivered(o.id)}>Mark as Delivered</DropdownMenuItem>}
                         </DropdownMenuContent>
                       </DropdownMenu>
                     )}
@@ -264,7 +242,6 @@ const SellerOrders = () => {
           )}
         </div>
 
-        {/* ── Desktop: table ────────────────────────────────────── */}
         <div className="hidden sm:block overflow-x-auto">
           <table className="w-full">
             <thead>
@@ -279,13 +256,9 @@ const SellerOrders = () => {
             </thead>
             <tbody className="divide-y divide-border">
               {loading ? (
-                <tr>
-                  <td colSpan={6} className="p-8 text-center text-muted-foreground text-sm">Loading orders…</td>
-                </tr>
+                <tr><td colSpan={6} className="p-8 text-center text-muted-foreground text-sm">Loading orders…</td></tr>
               ) : loadError ? (
-                <tr>
-                  <td colSpan={6} className="p-8 text-center text-sm text-red-500">{loadError}</td>
-                </tr>
+                <tr><td colSpan={6} className="p-8 text-center text-sm text-red-500">{loadError}</td></tr>
               ) : filtered.length === 0 ? (
                 <tr>
                   <td colSpan={6} className="p-8 text-center text-muted-foreground text-sm">
@@ -299,50 +272,20 @@ const SellerOrders = () => {
                     <td className="p-4 text-sm font-medium text-foreground">{o.orderNumber}</td>
                     <td className="p-4 text-sm text-foreground">{o.buyerName}</td>
                     <td className="p-4 text-sm font-semibold text-foreground">£{o.total.toLocaleString()}</td>
-                    <td className="p-4">
-                      <span className={`text-xs font-medium px-2.5 py-1 rounded-full capitalize ${statusColors[o.status] ?? "bg-muted text-muted-foreground"}`}>
-                        {o.status}
-                      </span>
-                    </td>
+                    <td className="p-4"><span className={`text-xs font-medium px-2.5 py-1 rounded-full capitalize ${statusColors[o.status] ?? "bg-muted text-muted-foreground"}`}>{o.status}</span></td>
                     <td className="p-4 text-sm text-muted-foreground">{formatDate(o.createdAt)}</td>
                     <td className="p-4 text-right">
                       <div className="flex items-center justify-end gap-1">
-                        <Button
-                          variant="ghost"
-                          size="sm"
-                          className="text-xs"
-                          onClick={() => navigate(`/tracking/${o.orderNumber || o.id}`)}
-                        >
-                          View
-                        </Button>
+                        <Button variant="ghost" size="sm" className="text-xs" onClick={() => navigate(`/tracking/${o.orderNumber || o.id}`)}>View</Button>
                         {["paid", "packed", "shipped"].includes(o.status) && (
                           <DropdownMenu>
                             <DropdownMenuTrigger asChild>
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                className="text-xs gap-1"
-                                disabled={actionLoading === o.id}
-                              >
-                                Update <ChevronDown className="h-3 w-3" />
-                              </Button>
+                              <Button variant="ghost" size="sm" className="text-xs gap-1" disabled={actionLoading === o.id}>Update <ChevronDown className="h-3 w-3" /></Button>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end">
-                              {o.status === "paid" && (
-                                <DropdownMenuItem onClick={() => updateOrderStatus(o.id, "packed")}>
-                                  Mark as Packed
-                                </DropdownMenuItem>
-                              )}
-                              {(o.status === "paid" || o.status === "packed") && (
-                                <DropdownMenuItem onClick={() => updateOrderStatus(o.id, "shipped")}>
-                                  Mark as Shipped
-                                </DropdownMenuItem>
-                              )}
-                              {o.status === "shipped" && (
-                                <DropdownMenuItem onClick={() => markDelivered(o.id)}>
-                                  Mark as Delivered
-                                </DropdownMenuItem>
-                              )}
+                              {o.status === "paid" && <DropdownMenuItem onClick={() => updateOrderStatus(o.id, "packed")}>Mark as Packed</DropdownMenuItem>}
+                              {(o.status === "paid" || o.status === "packed") && <DropdownMenuItem onClick={() => updateOrderStatus(o.id, "shipped")}>Mark as Shipped</DropdownMenuItem>}
+                              {o.status === "shipped" && <DropdownMenuItem onClick={() => markDelivered(o.id)}>Mark as Delivered</DropdownMenuItem>}
                             </DropdownMenuContent>
                           </DropdownMenu>
                         )}
@@ -354,7 +297,6 @@ const SellerOrders = () => {
             </tbody>
           </table>
         </div>
-
       </div>
     </div>
   );

--- a/supabase/610_snapshot_order_commercial_identity.sql
+++ b/supabase/610_snapshot_order_commercial_identity.sql
@@ -1,0 +1,885 @@
+-- 610_snapshot_order_commercial_identity.sql
+--
+-- Checkpoint A commercial-history integrity + fail-closed snapshot cutover.
+--
+-- Legacy rows are never reconstructed from today's mutable product/profile state.
+-- New payment-backed commerce is allowed only when complete verified checkout
+-- evidence is persisted and the resulting order/order-items materialise immutable
+-- snapshots from that evidence.
+
+ALTER TABLE public.orders
+  ADD COLUMN IF NOT EXISTS "buyerNameSnapshot" text,
+  ADD COLUMN IF NOT EXISTS "buyerEmailSnapshot" text,
+  ADD COLUMN IF NOT EXISTS "buyerCompanyNameSnapshot" text,
+  ADD COLUMN IF NOT EXISTS "buyerVatNumberSnapshot" text,
+  ADD COLUMN IF NOT EXISTS "sellerBusinessNameSnapshot" text,
+  ADD COLUMN IF NOT EXISTS "isB2BSnapshot" boolean,
+  ADD COLUMN IF NOT EXISTS "reverseChargeSnapshot" boolean,
+  ADD COLUMN IF NOT EXISTS "commercialSnapshotSource" text,
+  ADD COLUMN IF NOT EXISTS "commercialSnapshotCapturedAt" timestamptz;
+
+ALTER TABLE public.order_items
+  ADD COLUMN IF NOT EXISTS "productTitleSnapshot" text,
+  ADD COLUMN IF NOT EXISTS "productImageSnapshot" text,
+  ADD COLUMN IF NOT EXISTS "listingContextSnapshot" text,
+  ADD COLUMN IF NOT EXISTS "productSnapshotSource" text,
+  ADD COLUMN IF NOT EXISTS "productSnapshotCapturedAt" timestamptz;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'orders_commercial_snapshot_source_check'
+      AND conrelid = 'public.orders'::regclass
+  ) THEN
+    ALTER TABLE public.orders
+      ADD CONSTRAINT orders_commercial_snapshot_source_check
+      CHECK (
+        "commercialSnapshotSource" IS NULL
+        OR "commercialSnapshotSource" IN ('checkout_verified', 'payment_session_backfill')
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'orders_commercial_snapshot_coherence_check'
+      AND conrelid = 'public.orders'::regclass
+  ) THEN
+    ALTER TABLE public.orders
+      ADD CONSTRAINT orders_commercial_snapshot_coherence_check
+      CHECK (
+        (
+          "commercialSnapshotSource" IS NULL
+          AND "commercialSnapshotCapturedAt" IS NULL
+          AND "buyerNameSnapshot" IS NULL
+          AND "buyerEmailSnapshot" IS NULL
+          AND "buyerCompanyNameSnapshot" IS NULL
+          AND "buyerVatNumberSnapshot" IS NULL
+          AND "sellerBusinessNameSnapshot" IS NULL
+          AND "isB2BSnapshot" IS NULL
+          AND "reverseChargeSnapshot" IS NULL
+        )
+        OR (
+          "commercialSnapshotSource" IS NOT NULL
+          AND "commercialSnapshotCapturedAt" IS NOT NULL
+          AND NULLIF(BTRIM("buyerNameSnapshot"), '') IS NOT NULL
+          AND NULLIF(BTRIM("buyerEmailSnapshot"), '') IS NOT NULL
+          AND NULLIF(BTRIM("sellerBusinessNameSnapshot"), '') IS NOT NULL
+          AND "isB2BSnapshot" IS NOT NULL
+          AND "reverseChargeSnapshot" IS NOT NULL
+        )
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'orders_reverse_charge_snapshot_check'
+      AND conrelid = 'public.orders'::regclass
+  ) THEN
+    ALTER TABLE public.orders
+      ADD CONSTRAINT orders_reverse_charge_snapshot_check
+      CHECK (
+        COALESCE("reverseChargeSnapshot", false) = false
+        OR COALESCE("isB2BSnapshot", false) = true
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'order_items_product_snapshot_source_check'
+      AND conrelid = 'public.order_items'::regclass
+  ) THEN
+    ALTER TABLE public.order_items
+      ADD CONSTRAINT order_items_product_snapshot_source_check
+      CHECK (
+        "productSnapshotSource" IS NULL
+        OR "productSnapshotSource" IN ('checkout_verified', 'payment_session_backfill')
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'order_items_listing_context_snapshot_check'
+      AND conrelid = 'public.order_items'::regclass
+  ) THEN
+    ALTER TABLE public.order_items
+      ADD CONSTRAINT order_items_listing_context_snapshot_check
+      CHECK (
+        "listingContextSnapshot" IS NULL
+        OR "listingContextSnapshot" IN ('product', 'service')
+      );
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'order_items_product_snapshot_coherence_check'
+      AND conrelid = 'public.order_items'::regclass
+  ) THEN
+    ALTER TABLE public.order_items
+      ADD CONSTRAINT order_items_product_snapshot_coherence_check
+      CHECK (
+        (
+          "productSnapshotSource" IS NULL
+          AND "productSnapshotCapturedAt" IS NULL
+          AND "productTitleSnapshot" IS NULL
+          AND "productImageSnapshot" IS NULL
+          AND "listingContextSnapshot" IS NULL
+        )
+        OR (
+          "productSnapshotSource" IS NOT NULL
+          AND "productSnapshotCapturedAt" IS NOT NULL
+          AND NULLIF(BTRIM("productTitleSnapshot"), '') IS NOT NULL
+          AND "listingContextSnapshot" IS NOT NULL
+          AND "listingContextSnapshot" IN ('product', 'service')
+        )
+      );
+  END IF;
+END;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Immutable snapshot protection.
+-- Initial capture is server-only. Once captured, lifecycle/admin writes may not
+-- rewrite the historical evidence.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION private.protect_order_commercial_snapshot()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW."commercialSnapshotSource" IS NOT NULL
+       AND COALESCE(auth.jwt() ->> 'role', '') IN ('anon', 'authenticated')
+    THEN
+      RAISE EXCEPTION 'order commercial snapshot may only be captured by the canonical server boundary';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF OLD."commercialSnapshotSource" IS NULL
+     AND NEW."commercialSnapshotSource" IS NOT NULL
+     AND COALESCE(auth.jwt() ->> 'role', '') IN ('anon', 'authenticated')
+  THEN
+    RAISE EXCEPTION 'order commercial snapshot may only be captured by the canonical server boundary';
+  END IF;
+
+  IF OLD."commercialSnapshotSource" IS NOT NULL THEN
+    IF NEW."buyerNameSnapshot" IS DISTINCT FROM OLD."buyerNameSnapshot"
+       OR NEW."buyerEmailSnapshot" IS DISTINCT FROM OLD."buyerEmailSnapshot"
+       OR NEW."buyerCompanyNameSnapshot" IS DISTINCT FROM OLD."buyerCompanyNameSnapshot"
+       OR NEW."buyerVatNumberSnapshot" IS DISTINCT FROM OLD."buyerVatNumberSnapshot"
+       OR NEW."sellerBusinessNameSnapshot" IS DISTINCT FROM OLD."sellerBusinessNameSnapshot"
+       OR NEW."isB2BSnapshot" IS DISTINCT FROM OLD."isB2BSnapshot"
+       OR NEW."reverseChargeSnapshot" IS DISTINCT FROM OLD."reverseChargeSnapshot"
+       OR NEW."commercialSnapshotSource" IS DISTINCT FROM OLD."commercialSnapshotSource"
+       OR NEW."commercialSnapshotCapturedAt" IS DISTINCT FROM OLD."commercialSnapshotCapturedAt"
+    THEN
+      RAISE EXCEPTION 'order commercial snapshot is immutable once captured';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.protect_order_commercial_snapshot()
+  FROM PUBLIC, anon, authenticated, service_role;
+
+DROP TRIGGER IF EXISTS trg_protect_order_commercial_snapshot ON public.orders;
+CREATE TRIGGER trg_protect_order_commercial_snapshot
+BEFORE INSERT OR UPDATE ON public.orders
+FOR EACH ROW
+EXECUTE FUNCTION private.protect_order_commercial_snapshot();
+
+CREATE OR REPLACE FUNCTION private.protect_order_item_product_snapshot()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW."productSnapshotSource" IS NOT NULL
+       AND COALESCE(auth.jwt() ->> 'role', '') IN ('anon', 'authenticated')
+    THEN
+      RAISE EXCEPTION 'order item product snapshot may only be captured by the canonical server boundary';
+    END IF;
+    RETURN NEW;
+  END IF;
+
+  IF OLD."productSnapshotSource" IS NULL
+     AND NEW."productSnapshotSource" IS NOT NULL
+     AND COALESCE(auth.jwt() ->> 'role', '') IN ('anon', 'authenticated')
+  THEN
+    RAISE EXCEPTION 'order item product snapshot may only be captured by the canonical server boundary';
+  END IF;
+
+  IF OLD."productSnapshotSource" IS NOT NULL THEN
+    IF NEW."productTitleSnapshot" IS DISTINCT FROM OLD."productTitleSnapshot"
+       OR NEW."productImageSnapshot" IS DISTINCT FROM OLD."productImageSnapshot"
+       OR NEW."listingContextSnapshot" IS DISTINCT FROM OLD."listingContextSnapshot"
+       OR NEW."productSnapshotSource" IS DISTINCT FROM OLD."productSnapshotSource"
+       OR NEW."productSnapshotCapturedAt" IS DISTINCT FROM OLD."productSnapshotCapturedAt"
+    THEN
+      RAISE EXCEPTION 'order item product snapshot is immutable once captured';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.protect_order_item_product_snapshot()
+  FROM PUBLIC, anon, authenticated, service_role;
+
+DROP TRIGGER IF EXISTS trg_protect_order_item_product_snapshot ON public.order_items;
+CREATE TRIGGER trg_protect_order_item_product_snapshot
+BEFORE INSERT OR UPDATE ON public.order_items
+FOR EACH ROW
+EXECUTE FUNCTION private.protect_order_item_product_snapshot();
+
+-- ---------------------------------------------------------------------------
+-- Snapshot cutover evidence gate.
+--
+-- Both legacy checkout producers create Stripe state before inserting the local
+-- payment_sessions row. They already expire/cancel that Stripe state if this
+-- insert fails. Therefore installing this trigger before the upgraded producers
+-- creates a genuine fail-closed checkout freeze: old producers cannot create a
+-- new post-cutover payment session.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION private.payment_session_has_commercial_snapshot_v1(p_metadata jsonb)
+RETURNS boolean
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path TO ''
+AS $$
+DECLARE
+  v_buyer jsonb;
+  v_seller jsonb;
+  v_item jsonb;
+  v_buyer_id text;
+  v_seller_id text;
+  v_is_b2b boolean;
+  v_reverse_charge boolean;
+BEGIN
+  IF p_metadata IS NULL OR jsonb_typeof(p_metadata) IS DISTINCT FROM 'object' THEN
+    RETURN false;
+  END IF;
+
+  IF p_metadata ->> 'commercialSnapshotVersion' IS DISTINCT FROM '1' THEN
+    RETURN false;
+  END IF;
+
+  v_buyer := p_metadata -> 'buyerSnapshot';
+  v_seller := p_metadata -> 'sellerSnapshot';
+
+  IF jsonb_typeof(v_buyer) IS DISTINCT FROM 'object'
+     OR NULLIF(BTRIM(v_buyer ->> 'id'), '') IS NULL
+     OR NULLIF(BTRIM(v_buyer ->> 'name'), '') IS NULL
+     OR NULLIF(BTRIM(v_buyer ->> 'email'), '') IS NULL
+     OR jsonb_typeof(v_buyer -> 'isB2B') IS DISTINCT FROM 'boolean'
+     OR jsonb_typeof(v_buyer -> 'reverseCharge') IS DISTINCT FROM 'boolean'
+  THEN
+    RETURN false;
+  END IF;
+
+  v_buyer_id := v_buyer ->> 'id';
+  v_is_b2b := (v_buyer ->> 'isB2B')::boolean;
+  v_reverse_charge := (v_buyer ->> 'reverseCharge')::boolean;
+
+  IF v_buyer_id IS DISTINCT FROM p_metadata ->> 'buyerId'
+     OR (v_reverse_charge AND NOT v_is_b2b)
+     OR jsonb_typeof(p_metadata -> 'isB2B') IS DISTINCT FROM 'boolean'
+     OR jsonb_typeof(p_metadata -> 'applyReverseCharge') IS DISTINCT FROM 'boolean'
+     OR (p_metadata ->> 'isB2B')::boolean IS DISTINCT FROM v_is_b2b
+     OR (p_metadata ->> 'applyReverseCharge')::boolean IS DISTINCT FROM v_reverse_charge
+  THEN
+    RETURN false;
+  END IF;
+
+  IF jsonb_typeof(v_seller) IS DISTINCT FROM 'object'
+     OR NULLIF(BTRIM(v_seller ->> 'id'), '') IS NULL
+     OR NULLIF(BTRIM(v_seller ->> 'businessName'), '') IS NULL
+  THEN
+    RETURN false;
+  END IF;
+  v_seller_id := v_seller ->> 'id';
+
+  IF jsonb_typeof(p_metadata -> 'items') IS DISTINCT FROM 'array'
+     OR jsonb_array_length(p_metadata -> 'items') = 0
+  THEN
+    RETURN false;
+  END IF;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(p_metadata -> 'items')
+  LOOP
+    IF jsonb_typeof(v_item) IS DISTINCT FROM 'object'
+       OR NULLIF(BTRIM(v_item ->> 'productId'), '') IS NULL
+       OR NULLIF(BTRIM(v_item ->> 'sellerId'), '') IS NULL
+       OR NULLIF(BTRIM(v_item ->> 'title'), '') IS NULL
+       OR (v_item ->> 'sellerId') IS DISTINCT FROM v_seller_id
+       OR COALESCE(v_item ->> 'listingContext', '') NOT IN ('product', 'service')
+       OR NOT (v_item ? 'image')
+       OR jsonb_typeof(v_item -> 'image') NOT IN ('string', 'null')
+       OR jsonb_typeof(v_item -> 'quantity') IS DISTINCT FROM 'number'
+       OR jsonb_typeof(v_item -> 'price') IS DISTINCT FROM 'number'
+    THEN
+      RETURN false;
+    END IF;
+  END LOOP;
+
+  RETURN true;
+EXCEPTION
+  WHEN others THEN
+    RETURN false;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.payment_session_has_commercial_snapshot_v1(jsonb)
+  FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION private.enforce_payment_session_commercial_snapshot_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+BEGIN
+  IF private.payment_session_has_commercial_snapshot_v1(NEW.metadata) IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'payment session rejected: complete commercial snapshot evidence v1 is required after cutover';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.enforce_payment_session_commercial_snapshot_v1()
+  FROM PUBLIC, anon, authenticated, service_role;
+
+DROP TRIGGER IF EXISTS trg_require_payment_session_commercial_snapshot_v1
+  ON public.payment_sessions;
+CREATE TRIGGER trg_require_payment_session_commercial_snapshot_v1
+BEFORE INSERT ON public.payment_sessions
+FOR EACH ROW
+EXECUTE FUNCTION private.enforce_payment_session_commercial_snapshot_v1();
+
+-- ---------------------------------------------------------------------------
+-- Paid-order materialisation gate.
+-- Existing legacy rows are untouched because these are INSERT-only requirements.
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION private.require_paid_order_commercial_snapshot()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+BEGIN
+  IF NEW."stripePaymentIntentId" IS NOT NULL THEN
+    IF NEW."commercialSnapshotSource" IS DISTINCT FROM 'checkout_verified'
+       OR NEW."commercialSnapshotCapturedAt" IS NULL
+       OR NULLIF(BTRIM(NEW."buyerNameSnapshot"), '') IS NULL
+       OR NULLIF(BTRIM(NEW."buyerEmailSnapshot"), '') IS NULL
+       OR NULLIF(BTRIM(NEW."sellerBusinessNameSnapshot"), '') IS NULL
+       OR NEW."isB2BSnapshot" IS NULL
+       OR NEW."reverseChargeSnapshot" IS NULL
+       OR (NEW."reverseChargeSnapshot" AND NOT NEW."isB2BSnapshot")
+    THEN
+      RAISE EXCEPTION 'paid order rejected: immutable commercial snapshot is required after cutover';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.require_paid_order_commercial_snapshot()
+  FROM PUBLIC, anon, authenticated, service_role;
+
+DROP TRIGGER IF EXISTS trg_require_paid_order_commercial_snapshot ON public.orders;
+CREATE TRIGGER trg_require_paid_order_commercial_snapshot
+BEFORE INSERT ON public.orders
+FOR EACH ROW
+EXECUTE FUNCTION private.require_paid_order_commercial_snapshot();
+
+CREATE OR REPLACE FUNCTION private.require_paid_order_item_product_snapshot()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_payment_intent text;
+BEGIN
+  SELECT o."stripePaymentIntentId"
+    INTO v_payment_intent
+    FROM public.orders o
+   WHERE o.id = NEW."orderId";
+
+  IF v_payment_intent IS NOT NULL THEN
+    IF NEW."productSnapshotSource" IS DISTINCT FROM 'checkout_verified'
+       OR NEW."productSnapshotCapturedAt" IS NULL
+       OR NULLIF(BTRIM(NEW."productTitleSnapshot"), '') IS NULL
+       OR NEW."listingContextSnapshot" IS NULL
+       OR NEW."listingContextSnapshot" NOT IN ('product', 'service')
+    THEN
+      RAISE EXCEPTION 'paid order item rejected: immutable product snapshot is required after cutover';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.require_paid_order_item_product_snapshot()
+  FROM PUBLIC, anon, authenticated, service_role;
+
+DROP TRIGGER IF EXISTS trg_require_paid_order_item_product_snapshot
+  ON public.order_items;
+CREATE TRIGGER trg_require_paid_order_item_product_snapshot
+BEFORE INSERT ON public.order_items
+FOR EACH ROW
+EXECUTE FUNCTION private.require_paid_order_item_product_snapshot();
+
+-- ---------------------------------------------------------------------------
+-- Atomic paid-order materialisation.
+--
+-- One service-role RPC owns the entire post-payment persistence unit. The order
+-- may exist as awaiting_payment *inside this transaction*, but no external reader
+-- can observe it because order + item snapshots + stock finalisation + paid state
+-- + payment-session completion commit together. Any error rolls the whole unit
+-- back, including product stock/reservation mutations made by
+-- finalize_paid_order_item().
+-- ---------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.server_materialize_paid_order_v1(
+  p_payment_session_id uuid,
+  p_payment_intent_id text,
+  p_commission_rate numeric
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_session public.payment_sessions%ROWTYPE;
+  v_metadata jsonb;
+  v_buyer jsonb;
+  v_seller jsonb;
+  v_item jsonb;
+  v_order public.orders%ROWTYPE;
+  v_order_id uuid;
+  v_buyer_id uuid;
+  v_seller_id uuid;
+  v_primary_product_id uuid;
+  v_reservation_token uuid;
+  v_item_product_id uuid;
+  v_item_seller_id uuid;
+  v_item_quantity integer;
+  v_item_price numeric;
+  v_item_image text;
+  v_item_context text;
+  v_item_count integer;
+  v_distinct_product_count integer;
+  v_total_quantity integer;
+  v_persisted_item_count integer;
+  v_finalized_item_count integer;
+  v_total_pence bigint;
+  v_shipping_pence bigint;
+  v_product_paid numeric;
+  v_subtotal numeric;
+  v_vat numeric;
+  v_shipping numeric;
+  v_total numeric;
+  v_commission numeric;
+  v_reverse_charge boolean;
+  v_is_b2b boolean;
+  v_first_paid_transition boolean := false;
+  v_existing_item public.order_items%ROWTYPE;
+BEGIN
+  IF p_payment_session_id IS NULL OR NULLIF(BTRIM(p_payment_intent_id), '') IS NULL THEN
+    RAISE EXCEPTION 'server_materialize_paid_order_v1: payment session and PaymentIntent are required'
+      USING ERRCODE = '22023';
+  END IF;
+  IF p_commission_rate IS NULL OR p_commission_rate < 0 OR p_commission_rate > 1 THEN
+    RAISE EXCEPTION 'server_materialize_paid_order_v1: invalid commission rate'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT ps.*
+    INTO v_session
+    FROM public.payment_sessions ps
+   WHERE ps.id = p_payment_session_id
+   FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'server_materialize_paid_order_v1: payment session not found'
+      USING ERRCODE = 'P0002';
+  END IF;
+
+  IF v_session.status NOT IN ('pending', 'completed') THEN
+    RAISE EXCEPTION 'server_materialize_paid_order_v1: payment session status % is not processable', v_session.status
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  v_metadata := v_session.metadata;
+  IF private.payment_session_has_commercial_snapshot_v1(v_metadata) IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'server_materialize_paid_order_v1: complete commercial snapshot evidence v1 is required'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF lower(COALESCE(v_session.currency, '')) <> 'gbp' THEN
+    RAISE EXCEPTION 'server_materialize_paid_order_v1: payment session currency must be GBP'
+      USING ERRCODE = '22023';
+  END IF;
+
+  v_buyer := v_metadata -> 'buyerSnapshot';
+  v_seller := v_metadata -> 'sellerSnapshot';
+  v_buyer_id := (v_buyer ->> 'id')::uuid;
+  v_seller_id := (v_seller ->> 'id')::uuid;
+  v_is_b2b := (v_buyer ->> 'isB2B')::boolean;
+  v_reverse_charge := (v_buyer ->> 'reverseCharge')::boolean;
+
+  IF v_session."userId" IS DISTINCT FROM v_buyer_id THEN
+    RAISE EXCEPTION 'server_materialize_paid_order_v1: payment session user does not match buyer evidence'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF v_session."stripePaymentIntent" IS NOT NULL
+     AND v_session."stripePaymentIntent" IS DISTINCT FROM p_payment_intent_id
+  THEN
+    RAISE EXCEPTION 'server_materialize_paid_order_v1: PaymentIntent conflicts with persisted session evidence'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF jsonb_typeof(v_metadata -> 'totalPence') IS DISTINCT FROM 'number'
+     OR jsonb_typeof(v_metadata -> 'shippingAmountPence') IS DISTINCT FROM 'number'
+  THEN
+    RAISE EXCEPTION 'server_materialize_paid_order_v1: integer pence totals are required'
+      USING ERRCODE = '22023';
+  END IF;
+
+  v_total_pence := (v_metadata ->> 'totalPence')::bigint;
+  v_shipping_pence := (v_metadata ->> 'shippingAmountPence')::bigint;
+  IF v_total_pence < 0 OR v_shipping_pence < 0 OR v_shipping_pence > v_total_pence THEN
+    RAISE EXCEPTION 'server_materialize_paid_order_v1: invalid monetary totals'
+      USING ERRCODE = '22023';
+  END IF;
+  IF round(v_session.amount * 100)::bigint IS DISTINCT FROM v_total_pence THEN
+    RAISE EXCEPTION 'server_materialize_paid_order_v1: payment session amount conflicts with metadata total'
+      USING ERRCODE = '22023';
+  END IF;
+
+  v_product_paid := (v_total_pence - v_shipping_pence)::numeric / 100;
+  v_subtotal := CASE
+    WHEN v_reverse_charge THEN round(v_product_paid, 2)
+    ELSE round(v_product_paid / 1.20, 2)
+  END;
+  v_vat := CASE
+    WHEN v_reverse_charge THEN 0
+    ELSE round(v_product_paid - v_subtotal, 2)
+  END;
+  v_shipping := v_shipping_pence::numeric / 100;
+  v_total := v_total_pence::numeric / 100;
+  v_commission := round(v_subtotal * p_commission_rate, 2);
+
+  SELECT
+    count(*)::integer,
+    count(DISTINCT value ->> 'productId')::integer,
+    COALESCE(sum((value ->> 'quantity')::numeric), 0)::integer
+  INTO v_item_count, v_distinct_product_count, v_total_quantity
+  FROM jsonb_array_elements(v_metadata -> 'items');
+
+  IF v_item_count <= 0 OR v_distinct_product_count <> v_item_count THEN
+    RAISE EXCEPTION 'server_materialize_paid_order_v1: duplicate or missing product lines'
+      USING ERRCODE = '22023';
+  END IF;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(v_metadata -> 'items')
+  LOOP
+    IF (v_item ->> 'quantity')::numeric <= 0
+       OR (v_item ->> 'quantity')::numeric <> trunc((v_item ->> 'quantity')::numeric)
+       OR (v_item ->> 'price')::numeric <= 0
+    THEN
+      RAISE EXCEPTION 'server_materialize_paid_order_v1: invalid item quantity/price'
+        USING ERRCODE = '22023';
+    END IF;
+    IF (v_item ->> 'sellerId')::uuid IS DISTINCT FROM v_seller_id THEN
+      RAISE EXCEPTION 'server_materialize_paid_order_v1: multi-seller or conflicting seller evidence'
+        USING ERRCODE = '22023';
+    END IF;
+  END LOOP;
+
+  v_primary_product_id := ((v_metadata -> 'items' -> 0) ->> 'productId')::uuid;
+  v_reservation_token := NULLIF(v_metadata ->> 'reservationToken', '')::uuid;
+
+  SELECT o.*
+    INTO v_order
+    FROM public.orders o
+   WHERE o."stripePaymentIntentId" = p_payment_intent_id
+   FOR UPDATE;
+
+  IF FOUND THEN
+    IF v_order."buyerId" IS DISTINCT FROM v_buyer_id
+       OR v_order."sellerId" IS DISTINCT FROM v_seller_id
+       OR v_order.total IS DISTINCT FROM v_total
+       OR v_order."commercialSnapshotSource" IS DISTINCT FROM 'checkout_verified'
+    THEN
+      RAISE EXCEPTION 'server_materialize_paid_order_v1: existing order conflicts with payment evidence'
+        USING ERRCODE = 'P0001';
+    END IF;
+    IF v_order.status NOT IN ('awaiting_payment', 'paid') THEN
+      RAISE EXCEPTION 'server_materialize_paid_order_v1: existing order status % is not processable', v_order.status
+        USING ERRCODE = 'P0001';
+    END IF;
+  ELSE
+    INSERT INTO public.orders (
+      "buyerId",
+      "sellerId",
+      "productId",
+      quantity,
+      subtotal,
+      "vatAmount",
+      "shippingAmount",
+      total,
+      commission,
+      status,
+      "escrowStatus",
+      "shippingAddress",
+      "billingAddress",
+      "shippingMethod",
+      "isB2B",
+      "stripePaymentIntentId",
+      "buyerNameSnapshot",
+      "buyerEmailSnapshot",
+      "buyerCompanyNameSnapshot",
+      "buyerVatNumberSnapshot",
+      "sellerBusinessNameSnapshot",
+      "isB2BSnapshot",
+      "reverseChargeSnapshot",
+      "commercialSnapshotSource",
+      "commercialSnapshotCapturedAt"
+    ) VALUES (
+      v_buyer_id,
+      v_seller_id,
+      v_primary_product_id,
+      v_total_quantity,
+      v_subtotal,
+      v_vat,
+      v_shipping,
+      v_total,
+      v_commission,
+      'awaiting_payment',
+      'held',
+      CASE WHEN jsonb_typeof(v_metadata -> 'shippingAddress') = 'object' THEN v_metadata -> 'shippingAddress' ELSE '{}'::jsonb END,
+      CASE WHEN jsonb_typeof(v_metadata -> 'billingAddress') = 'object' THEN v_metadata -> 'billingAddress' ELSE '{}'::jsonb END,
+      COALESCE(NULLIF(BTRIM(v_metadata ->> 'shippingMethod'), ''), 'Standard'),
+      v_is_b2b,
+      p_payment_intent_id,
+      v_buyer ->> 'name',
+      v_buyer ->> 'email',
+      NULLIF(BTRIM(v_buyer ->> 'companyName'), ''),
+      NULLIF(BTRIM(v_buyer ->> 'vatNumber'), ''),
+      v_seller ->> 'businessName',
+      v_is_b2b,
+      v_reverse_charge,
+      'checkout_verified',
+      v_session."createdAt"
+    )
+    RETURNING * INTO v_order;
+  END IF;
+
+  v_order_id := v_order.id;
+
+  FOR v_item IN SELECT value FROM jsonb_array_elements(v_metadata -> 'items')
+  LOOP
+    v_item_product_id := (v_item ->> 'productId')::uuid;
+    v_item_seller_id := (v_item ->> 'sellerId')::uuid;
+    v_item_quantity := (v_item ->> 'quantity')::integer;
+    v_item_price := (v_item ->> 'price')::numeric;
+    v_item_context := v_item ->> 'listingContext';
+    v_item_image := CASE
+      WHEN jsonb_typeof(v_item -> 'image') = 'null' THEN NULL
+      ELSE v_item ->> 'image'
+    END;
+
+    IF v_item_seller_id IS DISTINCT FROM v_seller_id THEN
+      RAISE EXCEPTION 'server_materialize_paid_order_v1: item seller mismatch'
+        USING ERRCODE = '22023';
+    END IF;
+
+    INSERT INTO public.order_items (
+      "orderId",
+      "productId",
+      quantity,
+      "pricePerUnit",
+      "vatRate",
+      subtotal,
+      "productTitleSnapshot",
+      "productImageSnapshot",
+      "listingContextSnapshot",
+      "productSnapshotSource",
+      "productSnapshotCapturedAt"
+    ) VALUES (
+      v_order_id,
+      v_item_product_id,
+      v_item_quantity,
+      v_item_price,
+      0.20,
+      round((v_item_price / 1.20) * v_item_quantity, 2),
+      v_item ->> 'title',
+      v_item_image,
+      v_item_context,
+      'checkout_verified',
+      v_session."createdAt"
+    )
+    ON CONFLICT ("orderId", "productId") DO NOTHING;
+
+    SELECT oi.*
+      INTO v_existing_item
+      FROM public.order_items oi
+     WHERE oi."orderId" = v_order_id
+       AND oi."productId" = v_item_product_id
+     FOR UPDATE;
+
+    IF NOT FOUND
+       OR v_existing_item.quantity IS DISTINCT FROM v_item_quantity
+       OR v_existing_item."pricePerUnit" IS DISTINCT FROM v_item_price
+       OR v_existing_item."productTitleSnapshot" IS DISTINCT FROM (v_item ->> 'title')
+       OR v_existing_item."productImageSnapshot" IS DISTINCT FROM v_item_image
+       OR v_existing_item."listingContextSnapshot" IS DISTINCT FROM v_item_context
+       OR v_existing_item."productSnapshotSource" IS DISTINCT FROM 'checkout_verified'
+    THEN
+      RAISE EXCEPTION 'server_materialize_paid_order_v1: persisted order item conflicts with payment evidence'
+        USING ERRCODE = 'P0001';
+    END IF;
+
+    PERFORM public.finalize_paid_order_item(
+      v_order_id,
+      v_item_product_id,
+      v_reservation_token
+    );
+  END LOOP;
+
+  SELECT
+    count(*)::integer,
+    count(*) FILTER (WHERE "stockFinalizedAt" IS NOT NULL)::integer
+  INTO v_persisted_item_count, v_finalized_item_count
+  FROM public.order_items
+  WHERE "orderId" = v_order_id;
+
+  IF v_persisted_item_count <> v_item_count OR v_finalized_item_count <> v_item_count THEN
+    RAISE EXCEPTION 'server_materialize_paid_order_v1: complete finalized item set was not materialized'
+      USING ERRCODE = 'P0001';
+  END IF;
+
+  IF v_order.status = 'awaiting_payment' THEN
+    UPDATE public.orders
+       SET status = 'paid',
+           "updatedAt" = now()
+     WHERE id = v_order_id
+       AND status = 'awaiting_payment'
+    RETURNING * INTO v_order;
+    IF NOT FOUND THEN
+      RAISE EXCEPTION 'server_materialize_paid_order_v1: paid transition lost its expected state'
+        USING ERRCODE = '40001';
+    END IF;
+    v_first_paid_transition := true;
+  ELSE
+    v_first_paid_transition := false;
+  END IF;
+
+  UPDATE public.payment_sessions
+     SET "orderId" = v_order_id,
+         "stripePaymentIntent" = p_payment_intent_id,
+         amount = v_total,
+         status = 'completed',
+         "updatedAt" = now()
+   WHERE id = p_payment_session_id;
+
+  RETURN jsonb_build_object(
+    'orderId', v_order.id,
+    'orderNumber', v_order."orderNumber",
+    'sellerId', v_seller_id,
+    'sellerTotal', v_total,
+    'firstPaidTransition', v_first_paid_transition
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.server_materialize_paid_order_v1(uuid, text, numeric)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_materialize_paid_order_v1(uuid, text, numeric)
+  TO service_role;
+
+COMMENT ON FUNCTION public.server_materialize_paid_order_v1(uuid, text, numeric) IS
+  'Service-role-only atomic post-payment materialization: locks verified payment evidence and commits order snapshot, complete item snapshots, stock finalization, paid transition and payment-session completion together; retry is idempotent.';
+
+-- RLS remains authoritative for row access. Remove non-row capabilities that are
+-- not protected by RLS and are unnecessary for browser/mobile roles.
+REVOKE TRUNCATE, REFERENCES, TRIGGER
+  ON TABLE public.orders, public.order_items
+  FROM PUBLIC, anon, authenticated;
+
+COMMENT ON COLUMN public.orders."buyerNameSnapshot" IS
+  'Immutable checkout-time buyer display-name snapshot; NULL on legacy rows without authoritative evidence.';
+COMMENT ON COLUMN public.orders."buyerEmailSnapshot" IS
+  'Immutable checkout-time buyer email snapshot; NULL on legacy rows without authoritative evidence.';
+COMMENT ON COLUMN public.orders."buyerCompanyNameSnapshot" IS
+  'Immutable checkout-time buyer company snapshot when applicable.';
+COMMENT ON COLUMN public.orders."buyerVatNumberSnapshot" IS
+  'Immutable checkout-time buyer VAT snapshot when applicable.';
+COMMENT ON COLUMN public.orders."sellerBusinessNameSnapshot" IS
+  'Immutable checkout-time seller business identity snapshot.';
+COMMENT ON COLUMN public.orders."isB2BSnapshot" IS
+  'Immutable checkout-time B2B classification.';
+COMMENT ON COLUMN public.orders."reverseChargeSnapshot" IS
+  'Immutable checkout-time reverse-charge decision.';
+COMMENT ON COLUMN public.orders."commercialSnapshotSource" IS
+  'Evidence source for immutable order commercial identity. Legacy unknowns stay NULL.';
+COMMENT ON COLUMN public.orders."commercialSnapshotCapturedAt" IS
+  'Timestamp of authoritative commercial snapshot capture.';
+COMMENT ON COLUMN public.order_items."productTitleSnapshot" IS
+  'Immutable verified checkout-time product title.';
+COMMENT ON COLUMN public.order_items."productImageSnapshot" IS
+  'Immutable verified checkout-time primary product image/path; may be NULL when no image existed.';
+COMMENT ON COLUMN public.order_items."listingContextSnapshot" IS
+  'Immutable checkout-time product/service context.';
+COMMENT ON COLUMN public.order_items."productSnapshotSource" IS
+  'Evidence source for immutable product identity/context. Legacy unknowns stay NULL.';
+COMMENT ON COLUMN public.order_items."productSnapshotCapturedAt" IS
+  'Timestamp of authoritative product snapshot capture.';
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'public.payment_sessions'::regclass
+      AND tgname = 'trg_require_payment_session_commercial_snapshot_v1'
+      AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'payment session commercial snapshot cutover trigger is missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'public.orders'::regclass
+      AND tgname = 'trg_require_paid_order_commercial_snapshot'
+      AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'paid order commercial snapshot cutover trigger is missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_trigger
+    WHERE tgrelid = 'public.order_items'::regclass
+      AND tgname = 'trg_require_paid_order_item_product_snapshot'
+      AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'paid order item product snapshot cutover trigger is missing';
+  END IF;
+
+  IF to_regprocedure('public.server_materialize_paid_order_v1(uuid,text,numeric)') IS NULL THEN
+    RAISE EXCEPTION 'atomic paid-order materialization RPC is missing';
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Guardian reconciliation — migration 610 commercial snapshot cutover

This is the existing #522, realigned directly onto current `main` after #523 / migration 609 merged. No new PR is used. Its legacy branch name still ends in `-609`, but the active migration identity is uniquely **610**.

## Final dependency
`#517 / 606` → `#520 shipment runtime` → `#519 / 607 shipment DB` → `#515 / 608 active-account authorization` → `#523 / 609 Storage` → **#522 / 610 commercial snapshots**.

## Scope — exact 15-file functional slice
### Canonical producer / materialisation contract
- `supabase/610_snapshot_order_commercial_identity.sql`
- `netlify/functions/create-checkout.ts`
- `netlify/functions/create-payment-intent.ts`
- `netlify/functions/stripe-webhook.ts`
- `netlify/functions/__tests__/commercial-snapshot-cutover.test.ts`

### Historical consumers / authority hardening
- `netlify/functions/__tests__/commercial-history-consumers.test.ts`
- `netlify/functions/admin-orders.ts`
- `netlify/functions/generate-invoice.ts`
- `netlify/functions/track-shipment.ts`
- `src/pages/MobileOrdersPage.tsx`
- `src/pages/pixel-perfect/buyer/BuyerDashboard.tsx`
- `src/pages/pixel-perfect/buyer/BuyerOrders.tsx`
- `src/pages/pixel-perfect/buyer/BuyerReviews.tsx`
- `src/pages/pixel-perfect/seller/SellerDashboard.tsx`
- `src/pages/pixel-perfect/seller/SellerOrders.tsx`

The buyer/seller page changes are data-source/identity changes only: they prefer immutable checkout-time snapshots for post-cutover history and retain current live data only as a legacy display fallback. No Workspace/Super Admin visual redesign, no PR #359 visual import, no Supplier Commerce runtime, and no intended CSS/layout redesign is part of this PR.

## Fail-closed DB cutover
Migration 610:
- adds immutable order and order-item commercial snapshot fields;
- preserves legacy unknowns as NULL and performs no reconstruction from current mutable product/profile state;
- strictly validates `commercialSnapshotVersion = 1` payment-session evidence and treats malformed/missing structures as false/fail-closed;
- rejects new payment-session inserts without complete buyer/seller/item evidence;
- rejects new Stripe-backed orders without immutable order snapshots;
- rejects order-items for Stripe-backed orders without immutable product snapshots;
- makes captured snapshots immutable for later lifecycle/admin updates;
- exposes `public.server_materialize_paid_order_v1(...)` only to `service_role` as the canonical atomic post-payment persistence boundary;
- uses `auth.jwt() ->> 'role'` in snapshot-capture guards; no new `auth.role()` usage is introduced.

The pre-cutover web producer already expires an orphaned Stripe Checkout Session when local `payment_sessions` insertion fails, and the mobile producer cancels an orphaned PaymentIntent. Therefore, installing 610 before upgraded runtime fails closed instead of creating incomplete post-cutover commerce.

## Producers — Web + Mobile same evidence contract
Both checkout producers persist:
- verified buyer id, name, email, company/VAT where present;
- immutable B2B/reverse-charge decision;
- verified seller id and business identity;
- per-item product id, seller id, title, primary image/null, normalized `product|service` listing context, quantity and verified DB price;
- `commercialSnapshotVersion: 1`.

The cutover does not intentionally change shipping-rate selection, VAT formula, or Stripe charge amount.

## Atomic webhook materialisation
The webhook delegates post-payment persistence to `server_materialize_paid_order_v1`.

That single DB transaction:
- locks the payment-session evidence;
- validates buyer/seller/item/amount invariants;
- creates or validates the `awaiting_payment` order with immutable order identity;
- creates/validates complete immutable order-item snapshots;
- finalizes every item stock/reservation mutation;
- verifies the complete finalized item set;
- transitions `awaiting_payment → paid` only after all required history exists;
- completes the payment-session row in the same transaction;
- returns `firstPaidTransition` so notifications/email/push remain first-transition-only.

Any failure rolls the whole persistence unit back. Retry remains idempotent.

## Historical consumers
Post-cutover commercial history must not silently mutate when today's buyer name, seller business name, product title, product image or email changes. The invoice, tracking, admin order list, buyer order/review surfaces and seller order/dashboard surfaces therefore prefer the immutable snapshots whenever the snapshot source is present. Live profile/product state is retained only as a display-only fallback for legacy rows with no authoritative snapshot.

## Test / build evidence
- Netlify Deploy Preview for exact HEAD `9c65c2300a79ee557cba88c3bbb38e3fd04cd242`: **SUCCESS**.
- GitHub Actions run was created, but all four first-stage jobs failed before any steps were instantiated (`steps=[]`); job logs are unavailable. This is infrastructure failure, not executed test failure.
- Focused source-contract tests cover identical Web/Mobile evidence, service-role atomic materialisation, first-transition-only webhook effects, strict DB gates, and immutable-history consumers.

## Branch Guard
- base: current `main` `613883fa6292182eb7ce0ce9102a11358ad6a70f`;
- head after controlled realignment: `9c65c2300a79ee557cba88c3bbb38e3fd04cd242`;
- 0 behind `main`, one commit ahead;
- PR mergeable;
- exactly 15 changed files listed above;
- unique migration identity 610;
- no migration 609 changes in this diff;
- no Workspace/Super Admin visual work and no Supplier Commerce runtime work.

## Live / production status
- migration 610: **NOT APPLIED**;
- production DB/runtime: **UNCHANGED** at this stage;
- post-cutover production E2E: **NOT RUN**.

Controlled order after merge: verify the new `main` runtime is live in Netlify production, then apply migration 610 with `apply_migration`, then run rollback-safe production contract tests. Until those gates pass, Checkpoint A remains NOT PASS, Baseline Freeze remains HOLD, and Supplier Commerce runtime remains blocked.