### PR TITLE
Lock Storage writes to explicit bucket contracts (migration 609)

### DIFF
--- a/supabase/609_lock_storage_writes_to_bucket_contracts.sql
+++ b/supabase/609_lock_storage_writes_to_bucket_contracts.sql
@@ -1,0 +1,118 @@
+-- 609_lock_storage_writes_to_bucket_contracts.sql
+--
+-- Checkpoint A storage-policy reconciliation.
+--
+-- Production currently contains three legacy cross-bucket policies that are not
+-- represented in migration history:
+--   authenticated_insert_own_folder
+--   authenticated_update_own_objects
+--   authenticated_delete_own_objects
+--
+-- Those policies weaken the canonical per-bucket contracts by allowing a client
+-- write whenever ownership/path rules happen to match, even for private buckets
+-- whose intended contract is server-managed or admin-only.
+--
+-- Canonical rule after this migration:
+--   * product-images: public read; seller/admin writes only under
+--     sellers/{sellerId}/...;
+--   * avatars: existing bucket-specific own-folder policies remain authoritative;
+--   * documents / proof-of-delivery: existing server/admin write policies remain
+--     authoritative;
+--   * seller-documents / order-documents: no generic client-write fallback;
+--   * no object rows or commercial history are deleted by this migration.
+
+-- Remove live drift that grants write capability across bucket boundaries.
+DROP POLICY IF EXISTS authenticated_insert_own_folder ON storage.objects;
+DROP POLICY IF EXISTS authenticated_update_own_objects ON storage.objects;
+DROP POLICY IF EXISTS authenticated_delete_own_objects ON storage.objects;
+
+-- Restore explicit product-image update/delete capabilities that are part of the
+-- original bucket contract, but scope them to the same seller path convention as
+-- the canonical product image INSERT policy.
+DROP POLICY IF EXISTS product_images_update ON storage.objects;
+DROP POLICY IF EXISTS product_images_seller_update ON storage.objects;
+CREATE POLICY product_images_seller_update
+ON storage.objects
+FOR UPDATE
+TO authenticated
+USING (
+  bucket_id = 'product-images'
+  AND (
+    public.is_admin()
+    OR (
+      public.is_seller()
+      AND (storage.foldername(name))[1] = 'sellers'
+      AND (storage.foldername(name))[2] = (SELECT auth.uid())::text
+    )
+  )
+)
+WITH CHECK (
+  bucket_id = 'product-images'
+  AND (
+    public.is_admin()
+    OR (
+      public.is_seller()
+      AND (storage.foldername(name))[1] = 'sellers'
+      AND (storage.foldername(name))[2] = (SELECT auth.uid())::text
+    )
+  )
+);
+
+DROP POLICY IF EXISTS product_images_delete ON storage.objects;
+DROP POLICY IF EXISTS product_images_seller_delete ON storage.objects;
+CREATE POLICY product_images_seller_delete
+ON storage.objects
+FOR DELETE
+TO authenticated
+USING (
+  bucket_id = 'product-images'
+  AND (
+    public.is_admin()
+    OR (
+      public.is_seller()
+      AND (storage.foldername(name))[1] = 'sellers'
+      AND (storage.foldername(name))[2] = (SELECT auth.uid())::text
+    )
+  )
+);
+
+-- Fail the migration rather than accepting an unexpected policy surface.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+      FROM pg_policies
+     WHERE schemaname = 'storage'
+       AND tablename = 'objects'
+       AND policyname = ANY (ARRAY[
+         'authenticated_insert_own_folder',
+         'authenticated_update_own_objects',
+         'authenticated_delete_own_objects'
+       ])
+  ) THEN
+    RAISE EXCEPTION 'legacy cross-bucket storage write policy remains installed';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_policies
+     WHERE schemaname = 'storage'
+       AND tablename = 'objects'
+       AND policyname = 'product_images_seller_update'
+       AND cmd = 'UPDATE'
+  ) THEN
+    RAISE EXCEPTION 'product_images_seller_update policy was not installed';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_policies
+     WHERE schemaname = 'storage'
+       AND tablename = 'objects'
+       AND policyname = 'product_images_seller_delete'
+       AND cmd = 'DELETE'
+  ) THEN
+    RAISE EXCEPTION 'product_images_seller_delete policy was not installed';
+  END IF;
+END;
+$$;

--- a/supabase/609_lock_storage_writes_to_bucket_contracts.sql
+++ b/supabase/609_lock_storage_writes_to_bucket_contracts.sql
@@ -13,8 +13,12 @@
 -- whose intended contract is server-managed or admin-only.
 --
 -- Canonical rule after this migration:
---   * product-images: public read; seller/admin writes only under
---     sellers/{sellerId}/...;
+--   * product-images: public read; new seller uploads only under
+--     sellers/{sellerId}/...; seller/admin UPDATE/DELETE remain explicit and
+--     bucket-scoped;
+--   * existing product-images/uploads/... rows remain UPDATE/DELETE-manageable
+--     only by their active seller owner (or admin), but no new legacy-path INSERT
+--     capability is preserved;
 --   * avatars: existing bucket-specific own-folder policies remain authoritative;
 --   * documents / proof-of-delivery: existing server/admin write policies remain
 --     authoritative;
@@ -26,9 +30,13 @@ DROP POLICY IF EXISTS authenticated_insert_own_folder ON storage.objects;
 DROP POLICY IF EXISTS authenticated_update_own_objects ON storage.objects;
 DROP POLICY IF EXISTS authenticated_delete_own_objects ON storage.objects;
 
--- Restore explicit product-image update/delete capabilities that are part of the
--- original bucket contract, but scope them to the same seller path convention as
--- the canonical product image INSERT policy.
+-- Restore explicit product-image update/delete capabilities. Canonical objects
+-- use sellers/{sellerId}/... and are authorised from the live active-account
+-- helpers installed by migration 608. Production also contains historical
+-- product-image objects under uploads/...; preserve UPDATE/DELETE for those rows
+-- only when the authenticated active seller owns the existing storage object.
+-- This is compatibility for existing rows, not a legacy INSERT path: the only
+-- product-image INSERT policy remains product_images_seller_insert.
 DROP POLICY IF EXISTS product_images_update ON storage.objects;
 DROP POLICY IF EXISTS product_images_seller_update ON storage.objects;
 CREATE POLICY product_images_seller_update
@@ -41,8 +49,16 @@ USING (
     public.is_admin()
     OR (
       public.is_seller()
-      AND (storage.foldername(name))[1] = 'sellers'
-      AND (storage.foldername(name))[2] = (SELECT auth.uid())::text
+      AND (
+        (
+          (storage.foldername(name))[1] = 'sellers'
+          AND (storage.foldername(name))[2] = (SELECT auth.uid())::text
+        )
+        OR (
+          (storage.foldername(name))[1] = 'uploads'
+          AND owner = (SELECT auth.uid())
+        )
+      )
     )
   )
 )
@@ -52,8 +68,16 @@ WITH CHECK (
     public.is_admin()
     OR (
       public.is_seller()
-      AND (storage.foldername(name))[1] = 'sellers'
-      AND (storage.foldername(name))[2] = (SELECT auth.uid())::text
+      AND (
+        (
+          (storage.foldername(name))[1] = 'sellers'
+          AND (storage.foldername(name))[2] = (SELECT auth.uid())::text
+        )
+        OR (
+          (storage.foldername(name))[1] = 'uploads'
+          AND owner = (SELECT auth.uid())
+        )
+      )
     )
   )
 );
@@ -70,8 +94,16 @@ USING (
     public.is_admin()
     OR (
       public.is_seller()
-      AND (storage.foldername(name))[1] = 'sellers'
-      AND (storage.foldername(name))[2] = (SELECT auth.uid())::text
+      AND (
+        (
+          (storage.foldername(name))[1] = 'sellers'
+          AND (storage.foldername(name))[2] = (SELECT auth.uid())::text
+        )
+        OR (
+          (storage.foldername(name))[1] = 'uploads'
+          AND owner = (SELECT auth.uid())
+        )
+      )
     )
   )
 );


### PR DESCRIPTION
## Guardian reconciliation — Storage boundary (migration 609)

This PR is the corrected replacement for closed/superseded #521 and is now retargeted directly to current `main` after migration 608 passed production verification.

## Linear dependency
`#517 / 606` → `#520 shipment runtime` → `#519 / 607 shipment DB` → `#515 / 608 active-account authorization` → **this PR / 609 Storage** → `#522 / 610 commercial snapshot cutover`.

## Scope
Exactly one changed file relative to current main:
`supabase/609_lock_storage_writes_to_bucket_contracts.sql`

No Workspace/Super Admin visual changes. No Supplier Commerce runtime work.

## Production pre-state audit
- current main: `37c7a0cfbb8599f93e8bbe692922ec0d993ad4d7`
- migration 608: applied and production PASS
- six Storage buckets exist: `avatars`, `documents`, `order-documents`, `product-images`, `proof-of-delivery`, `seller-documents`
- only `product-images` currently contains objects: 67 total
- 4 objects already use canonical `sellers/{sellerId}/...` paths
- 63 historical objects use `uploads/...`; all are owned by active seller accounts
- current seller upload runtime uses only `sellers/{sellerId}/...`
- no current frontend code path directly deletes product-image Storage objects when a listing image is removed; the listing image URL array is updated instead

## Migration contract
The migration removes the three live generic cross-bucket authenticated write policies:
- `authenticated_insert_own_folder`
- `authenticated_update_own_objects`
- `authenticated_delete_own_objects`

It then installs explicit `product-images` UPDATE/DELETE policies using migration-608 live active-account helpers.

Canonical new writes remain restricted to `sellers/{sellerId}/...` by the existing `product_images_seller_insert` policy.

To avoid orphaning the 63 live historical `uploads/...` objects, UPDATE/DELETE compatibility is retained **only** when:
- bucket is `product-images`;
- caller is an active seller (`public.is_seller()`), and
- the legacy object is owned by that authenticated seller;
- or caller is an active admin.

No legacy-path INSERT capability is retained, so the compatibility surface cannot grow. Private buckets lose the generic client-write fallback. No Storage object rows or commercial data are deleted by the migration.

## Branch Guard
- base: `main` at `37c7a0cfbb8599f93e8bbe692922ec0d993ad4d7`
- head after live-data compatibility correction: `52fc960e7ca0a2c8b36fa574c1aaf7246b6b489b`
- PR is mergeable
- exactly one changed file relative to main
- unique migration identity 609
- #521 remains CLOSED/SUPERSEDED
- production migration 609 is NOT yet applied

Checkpoint A remains NOT PASS until 609 and downstream 610 complete their production gates. Baseline Freeze HOLD. No Supplier Commerce runtime work.