### PR TITLE
Reconcile payment safety hold after escrow/shipping hardening (migration 611)

### DIFF
--- a/supabase/611_reconcile_payment_safety_hold.sql
+++ b/supabase/611_reconcile_payment_safety_hold.sql
@@ -1,0 +1,115 @@
+-- 611_reconcile_payment_safety_hold.sql
+--
+-- Checkpoint A Foundation reconciliation for two emergency payment controls that
+-- were installed before the later escrow and checkout-shipping hardening landed.
+--
+-- Current runtime contract before this migration:
+--   * marketplace-held funds are transferred to the seller only from the
+--     escrow-release boundary after delivery/completion + protection window;
+--   * escrow release re-checks dispute/refund/order state and compensates Stripe
+--     transfers when eligibility changes;
+--   * checkout persists shipping as an explicit Stripe line item;
+--   * migration 610 fail-closes payment sessions to complete immutable commercial
+--     snapshot evidence and materialises paid history atomically.
+--
+-- Preserve the global safety switch as an emergency fail-closed mechanism, but
+-- return it to its normal disabled state after proving there is no in-flight
+-- financial state. Remove only the obsolete shipping guard whose old heuristic
+-- would now reject legitimate web checkout even though shipping is charged by
+-- the current Stripe producer.
+
+DO $$
+BEGIN
+  IF to_regprocedure('public.server_materialize_paid_order_v1(uuid,text,numeric)') IS NULL THEN
+    RAISE EXCEPTION 'payment safety reconciliation requires migration 610 atomic materialization';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM public.platform_settings
+     WHERE key = 'payments_safety_hold'
+  ) THEN
+    RAISE EXCEPTION 'payments_safety_hold setting is missing';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_trigger
+     WHERE tgrelid = 'public.payment_sessions'::regclass
+       AND tgname = 'trg_guard_payment_sessions_during_safety_hold'
+       AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'emergency payment safety-hold trigger is missing';
+  END IF;
+
+  -- Refuse to reopen checkout over any state that could be mid-cutover.
+  IF EXISTS (
+    SELECT 1 FROM public.payment_sessions WHERE status = 'pending'
+  ) THEN
+    RAISE EXCEPTION 'payment safety reconciliation blocked: pending payment session exists';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM public.orders
+     WHERE status IN ('paid', 'packed', 'shipped', 'delivered')
+        OR "escrowStatus" = 'held'
+  ) THEN
+    RAISE EXCEPTION 'payment safety reconciliation blocked: financially active/held order exists';
+  END IF;
+END;
+$$;
+
+-- The current create-checkout producer adds shipping directly to Stripe line_items
+-- and persists shippingAmountPence/totalPence in the canonical payment evidence.
+-- This older heuristic no longer represents the runtime contract and would
+-- incorrectly reject legitimate web shipping after the global hold is disabled.
+DROP TRIGGER IF EXISTS trg_guard_web_checkout_shipping_charge
+  ON public.payment_sessions;
+DROP FUNCTION IF EXISTS private.guard_web_checkout_shipping_charge();
+
+-- Keep the emergency switch and its trigger available for immediate fail-closed
+-- use, but disable the historical blanket hold now that its prerequisite
+-- Foundation fixes are installed and the cutover pre-state is empty.
+UPDATE public.platform_settings
+   SET value = 'false'::jsonb,
+       description = 'Emergency checkout safety switch. Set true to fail closed. Historical escrow/shipping hold reconciled after verified marketplace-held-funds, transfer-compensation, explicit Stripe shipping-line, and migration-610 atomic commercial-history hardening.',
+       "updatedAt" = now()
+ WHERE key = 'payments_safety_hold';
+
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1
+      FROM pg_trigger
+     WHERE tgrelid = 'public.payment_sessions'::regclass
+       AND tgname = 'trg_guard_web_checkout_shipping_charge'
+       AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'obsolete web checkout shipping guard remains installed';
+  END IF;
+
+  IF to_regprocedure('private.guard_web_checkout_shipping_charge()') IS NOT NULL THEN
+    RAISE EXCEPTION 'obsolete web checkout shipping guard function remains installed';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM public.platform_settings
+     WHERE key = 'payments_safety_hold'
+       AND value = 'false'::jsonb
+  ) THEN
+    RAISE EXCEPTION 'payments_safety_hold was not disabled';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+      FROM pg_trigger
+     WHERE tgrelid = 'public.payment_sessions'::regclass
+       AND tgname = 'trg_guard_payment_sessions_during_safety_hold'
+       AND NOT tgisinternal
+  ) THEN
+    RAISE EXCEPTION 'emergency payment safety-hold trigger was not preserved';
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Checkpoint A Foundation reconciliation — migration 611

This is a narrow production-safety reconciliation discovered during the final atomic Checkpoint A audit. It is not Supplier Commerce work and contains no UI/Workspace/Super Admin changes.

## Why this exists
Production still carries two emergency controls installed on 10 August 2026 before later hardening landed:
- global `payments_safety_hold=true`, installed as `payments_safety_hold_until_escrow_fix`;
- `trg_guard_web_checkout_shipping_charge`, which blocks web checkout whenever shipping is non-zero.

Current main now contains the prerequisite fixes:
- seller funds are marketplace-held and released only from `escrow-release` after delivery/completion + protection window;
- transfer discovery/idempotency, refund/dispute/order-state race rechecks and compensating reversals are implemented;
- the current web checkout explicitly adds shipping to Stripe `line_items` and persists integer-pence shipping/total evidence;
- migration 610 atomically materializes paid order + item commercial history from verified payment-session evidence.

The old shipping heuristic is therefore stale and would falsely block legitimate web shipping if the global safety switch were disabled.

## Exact scope
Exactly one file:
`supabase/611_reconcile_payment_safety_hold.sql`

The migration:
1. fails closed unless migration-610 atomic materialization exists;
2. requires the existing emergency safety-hold setting + trigger;
3. refuses to run if any payment session is pending;
4. refuses to run if any order is financially active (`paid|packed|shipped|delivered`) or escrow-held;
5. removes only the obsolete web shipping guard trigger/function;
6. preserves the global emergency fail-closed mechanism but sets its switch to `false`;
7. updates the setting description to record the reconciled contract;
8. verifies postconditions before commit.

## Production pre-state audited before branch creation
- pending payment sessions: 0
- financially active orders: 0
- escrow-held orders: 0
- open/in-review disputes: 0
- historical orders: 2, both cancelled, no Stripe PaymentIntent; legacy `escrowStatus=released` retained factually rather than rewritten
- historical payout: one legacy £1 record with no `orderId` and no Stripe transfer; retained factually

No historical financial state is rewritten by 611.

## Branch Guard
- base: `main` `18d4dfed08e7101b9008e544230af8873b558f4a`
- head: `d1f6baaf5e7066c1d0c281885784f3e080892a42`
- 0 behind / 1 ahead
- exactly 1 changed file
- no `auth.role()`
- no UI, Workspace, Super Admin, Android, Supplier Commerce, checkout runtime or Stripe formula changes

## Rollout
Do not apply before merge. After merge, re-check the fail-closed zero-in-flight pre-state, apply the exact merged migration with `apply_migration`, verify the global emergency trigger remains installed but setting=false, verify obsolete shipping guard is gone, then run post-DDL advisors.

Checkpoint A remains NOT PASS until this gate and PR #514 Android release/Firebase evidence are both closed.