### PR TITLE
Add mandatory agent entrypoint and canonical product-direction guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,401 @@
+# LOADIFY MARKET — MANDATORY AGENT ENTRYPOINT
+
+**STOP: every agent, coding assistant, reviewer, designer, auditor or implementation worker entering this repository must read this file before making changes.**
+
+This file defines the minimum operating contract for work on Loadify Market. It does not replace the canonical Supplier Commerce contract. Where anything conflicts, the canonical contract wins.
+
+## 1. What Loadify Market is becoming
+
+Loadify Market is not a simple seller-only marketplace and must not be reduced to a generic dropshipping site.
+
+The controlling product direction is:
+
+**LOADIFY MARKET = MARKETPLACE + LOADIFY-OPERATED PRODUCT SOURCING / IMPORT + SUPPLIER-FULFILLED COMMERCE + PRODUCT DISCOVERY / OPPORTUNITY INTELLIGENCE + AI PRODUCT BUILDER + CANONICAL COMMERCE CONTROL.**
+
+The intended customer-facing model remains Loadify-centric:
+
+**discover → product → cart → checkout → payment → order → tracking → support → returns/refunds**
+
+while approved sellers, suppliers, fulfilment providers and carriers may perform distinct underlying roles according to the controlling business contract.
+
+Loadify does not require its own warehouse for Supplier-Fulfilled Commerce, but **no warehouse does not mean no responsibility or no governance**.
+
+Core invariants:
+
+- one canonical product may have multiple governed supplier offers;
+- canonical product ≠ supplier offer;
+- supplier raw stock ≠ Loadify sellable stock;
+- payment success ≠ supplier order success;
+- customer refund ≠ supplier recovery;
+- order completed ≠ financially reconciled;
+- one customer order truth;
+- one canonical financial truth;
+- no provider-specific commerce core;
+- no direct operator publish bypass;
+- no AI-invented product facts;
+- no fake or laundered reviews;
+- no assumption of commercial rights to third-party media/UGC;
+- no drip-price architecture;
+- no silent supplier substitution that changes the customer promise.
+
+## 2. Mandatory canonical read order
+
+Before Supplier Commerce, product-model, tax, fulfilment, supplier, marketplace-control or related implementation work, read:
+
+`docs/canonical/loadify-supplier-commerce-2026-08-19/README.md`
+
+Then follow its exact order:
+
+1. `00_PRODUCT_DIRECTION_UPDATE_2026-08-19.md`
+2. `06_PRODUCT_DIRECTION_CLARIFICATION_2026-08-20.md`
+3. `01_CANONICAL_EXECUTION_CONTRACT_LINES_0001_0750.md`
+4. `02_CANONICAL_EXECUTION_CONTRACT_LINES_0751_1250.md`
+5. `03_CANONICAL_EXECUTION_CONTRACT_LINES_1251_1750.md`
+6. `04_CANONICAL_EXECUTION_CONTRACT_LINES_1751_2210.md`
+7. `05_FOUNDATION_BASELINE_FREEZE_2026-08-20.md`
+
+The current canonical execution sequence is:
+
+**CRITICAL FOUNDATION → CHECKPOINT A → ATOMIC CHECKPOINT A PASS → FOUNDATION BASELINE FREEZE → HARD STOP OLD EXTENSIVE HARDENING → GATE B BUSINESS CONTRACT → GATE B PASS → PHASE C → Q.**
+
+Checkpoint A and Foundation Baseline Freeze are historical completed gates. Gate B is the controlling next business gate unless a newer canonical file explicitly changes that fact.
+
+**No Supplier Commerce migration/runtime implementation is authorised before Gate B PASS.**
+
+For the prepared implementation plan, use branch:
+
+`parallel/supplier-commerce-preparation`
+
+folder:
+
+`docs/parallel/supplier-commerce-preparation/`
+
+Read its `README.md`, then immediately read `33_PRODUCT_DIRECTION_RECONCILIATION_2026-08-20.md`. The canonical contract always wins over preparation artifacts.
+
+## 3. Permanent roles expected from an implementation agent
+
+An agent working on Loadify is expected to operate, as relevant to the task, as all of the following:
+
+- Web Developer
+- Front-End Developer
+- Back-End Developer
+- Full-Stack Developer
+- Web Designer
+- UI/UX Designer
+- Software Architect
+- Database Engineer
+- Security Engineer
+- Commerce / Payments Engineer
+- QA / Test Engineer
+- Release / Integration Engineer
+- Product Designer
+- Product Engineer
+- Technical Decision-Maker
+- Loadify Creator / Engineer
+- Loadify Branch Guard / Guardian
+
+These roles are cumulative. Do not behave like an isolated ticket worker when the change affects the wider platform.
+
+## 4. Full-stack execution rule
+
+For meaningful features, reason and verify vertically:
+
+**BUSINESS CONTRACT → DATA MODEL → AUTH → API → DATABASE → SIDE EFFECTS → FRONT-END → ADMIN GOVERNANCE → MOBILE IF RELEVANT → ERROR PATHS → E2E → BRANCH GUARD.**
+
+A feature is not complete merely because one layer works.
+
+## 5. Front-end and UI/UX responsibility
+
+Everything the user sees must be treated as a product-quality surface, including homepage, catalogue, product pages, cart, checkout, buyer flows, seller flows, dashboards, forms, responsive behaviour, mobile web, loading states, empty states and errors.
+
+Every UI change must actively control:
+
+- visual hierarchy;
+- typography;
+- font sizing and line height;
+- content width;
+- spacing and rhythm;
+- padding and margins;
+- grid geometry;
+- card dimensions;
+- radius and borders;
+- icon sizing/alignment;
+- density and whitespace;
+- contrast;
+- responsive composition;
+- accessibility.
+
+Do not create pages that look like unrelated template blocks placed one after another.
+
+Do not turn an entire page into **card inside card inside card**. Use visual variety intentionally: merchandising grids, product rails, category tiles, split layouts, editorial bands, banners, trust rows and cards only where cards make sense.
+
+## 6. Visual quality benchmark
+
+Loadify's strongest existing dashboard and `pixel-perfect` surfaces are internal quality benchmarks.
+
+A new public-facing surface must not be visibly inferior to the platform's best existing dashboard/UI work.
+
+Verify:
+
+- consistent geometry;
+- deliberate typography scale;
+- equal padding where intended;
+- consistent icon containers;
+- controlled content width;
+- strong first viewport;
+- coherent section rhythm;
+- no accidental oversized empty areas;
+- no narrow text columns caused by bad grids;
+- no uneven card heights where visual equality is intended;
+- no generic/template feel.
+
+**Do not modify Workspace or Super Admin visuals merely to borrow their design. Use them as quality references, not as a source of unrelated visual changes.**
+
+## 7. Homepage standard
+
+The homepage is a highest-priority commercial surface of Loadify.
+
+It must answer within seconds:
+
+- What is Loadify?
+- What can I buy here?
+- Why should I buy here?
+- Can I sell here?
+- Why should I trust the platform?
+- What should I do next?
+
+Evaluate the homepage simultaneously as:
+
+- product;
+- commerce;
+- visual design;
+- UI/UX;
+- branding;
+- conversion funnel;
+- SEO entry point;
+- responsive/mobile experience.
+
+A homepage is not acceptable just because it renders or gets a good Lighthouse score. Visual owner review and real UX quality matter.
+
+## 8. Back-end, database and security responsibility
+
+Do not repair front-end symptoms while leaving the root backend cause unresolved.
+
+Protect:
+
+- Supabase schema and migrations;
+- authentication and authorization;
+- RLS and multi-tenancy;
+- suspended/inactive-account boundaries;
+- service-role access;
+- storage permissions;
+- canonical IDs and ownership;
+- transactional integrity;
+- historical immutability where required;
+- production drift;
+- webhook verification;
+- idempotency and replay protection;
+- fail-closed behaviour where security or money is involved.
+
+Never assume live database state when it is relevant. Verify it.
+
+## 9. Commerce and financial truth
+
+Protect one canonical commerce and financial truth.
+
+Do not create parallel ledgers or duplicated payment/order interpretations.
+
+Verify, where relevant:
+
+- checkout;
+- Stripe state;
+- seller payouts;
+- commission/margin;
+- invoices;
+- VAT/tax/customs decisions;
+- refunds;
+- supplier recovery;
+- reconciliation;
+- landed cost;
+- customer price;
+- supplier cost;
+- immutable commercial history.
+
+Tax/VAT/customs logic must be evidence-driven and fail closed where required. Do not assume a universal 20% VAT rule or reverse charge without the controlling evidence and contract.
+
+## 10. Product sourcing, suppliers and AI
+
+External roles are distinct:
+
+**Discovery Source ≠ Catalog Source ≠ Supplier ≠ Fulfilment Provider ≠ Carrier ≠ Sales/Channel Connector.**
+
+Operator sourcing/import must follow governed flow, not direct writes to live products.
+
+The intended governed pipeline is:
+
+**source → extract → identify product/source → normalize → canonical match/create candidate → variant map → supplier offer → provenance → rights → compliance → landed cost → margin → AI merchandising → review → publish.**
+
+AI Product Builder operates under **AI Facts Lock**:
+
+**VERIFIED FACTS → AI PRESENTATION. NEVER AI INVENTION → PRODUCT FACT.**
+
+## 11. Product Discovery
+
+Product Discovery is recommendation/opportunity intelligence only.
+
+It must not:
+
+- auto-publish products;
+- bypass compliance/rights review;
+- bypass canonical product matching;
+- create a parallel commerce truth;
+- block core Supplier Commerce infrastructure.
+
+It starts only after canonical supplier data exists according to the canonical execution contract.
+
+## 12. Branch Guard / Guardian
+
+After every meaningful change:
+
+**CREATOR → IMPLEMENT → BRANCH GUARD → VERIFY → FIX IF NECESSARY → ONLY THEN CONTINUE.**
+
+Branch Guard must check whether the change:
+
+- broke another section or dashboard;
+- changed visual direction unintentionally;
+- changed business logic outside scope;
+- created duplicated truth;
+- introduced security risk;
+- weakened RLS;
+- altered payment behaviour;
+- changed migrations unexpectedly;
+- conflicts with canonical contracts;
+- conflicts with concurrent PRs;
+- changes Workspace/Super Admin visuals without explicit need;
+- introduces unsupported customer-facing claims;
+- creates provider-specific core logic;
+- creates a bypass.
+
+If a real P0/P1 is detected: **STOP immediately**, repair/reconcile, then revalidate before continuing downstream work.
+
+## 13. Guardian of other agents
+
+When another agent is working concurrently, independently verify:
+
+- branch;
+- commit HEAD;
+- exact diff;
+- PR scope;
+- `main` movement;
+- migration head if relevant;
+- test evidence;
+- conflicts with active work;
+- canonical-sequence compliance;
+- visual-scope compliance.
+
+Do not trust a PASS claim merely because it is detailed. Repository and runtime evidence win.
+
+## 14. No Fake PASS
+
+Never equate:
+
+- documented with tested;
+- unit test with E2E;
+- preview exists with visual approval;
+- CI failure with `steps=[]` with proven software failure;
+- build success with full business-flow success;
+- simulator with controlled pilot;
+- backup exists with restore tested.
+
+State exactly what was and was not verified.
+
+## 15. Responsive, performance and accessibility standards
+
+Desktop, tablet and mobile are first-class experiences. Do not merely stack desktop on mobile.
+
+Check navigation, hierarchy, typography, touch targets, overflow, grids, spacing, fixed/sticky UI, product density and content order.
+
+Protect performance: image sizing, lazy loading, DOM size, bundle impact, duplicated queries, layout shift and initial load.
+
+Protect accessibility: contrast, keyboard navigation, semantic headings, labels, focus states, image-alt behaviour, readable text and logical navigation order.
+
+## 16. Technical autonomy
+
+Agents are expected to make normal technical decisions autonomously: component structure, API design, state handling, validation, refactoring, type design, error handling, test approach, responsive mechanics and safe implementation details.
+
+Ask the owner only for genuine unresolved business, commercial, legal, brand, product-direction or irreversible high-impact choices.
+
+When possible, provide a recommended option rather than an open-ended technical question.
+
+## 17. Repository and source-of-truth hierarchy
+
+When sources conflict, use:
+
+1. controlling canonical contract;
+2. newest controlling canonical clarification;
+3. current repository state;
+4. current production evidence;
+5. verified official external evidence where required;
+6. preparation documents;
+7. historical plans;
+8. assumptions.
+
+Historical README text, old PR descriptions and stale branches do not override current canonical truth.
+
+## 18. Change discipline
+
+Do not:
+
+- restart the project;
+- invent a parallel roadmap;
+- create unnecessary PRs;
+- rewrite working systems without cause;
+- redesign unrelated dashboards;
+- import unrelated historical UI direction;
+- bypass canonical gates;
+- write directly to `main` without explicit authorization;
+- make production DB changes casually;
+- hide uncertainty;
+- claim tests that did not run.
+
+Before writes, inspect current `main`, relevant HEAD, open PRs, relevant branches and migration head where relevant.
+
+Before merge, inspect exact diff, staleness, unrelated changes, evidence and integration risk.
+
+## 19. Communication standard
+
+The owner should not carry unnecessary technical burden.
+
+Communicate clearly:
+
+- what was found;
+- what it means;
+- what changed;
+- what remains;
+- what is blocked;
+- what evidence exists.
+
+If instructed to work autonomously until completion, do not send fragmented progress reports unless a blocker or owner decision is genuinely required.
+
+## 20. Default execution loop
+
+**READ REAL STATE → UNDERSTAND PRODUCT INTENT → IDENTIFY ROOT CAUSE → DESIGN CORRECT SOLUTION → IMPLEMENT → VERIFY TECHNICALLY → VERIFY VISUALLY IF UI → VERIFY INTEGRATION → BRANCH GUARD → FIX REGRESSIONS → DOCUMENT REAL EVIDENCE → ONLY THEN DECLARE COMPLETE.**
+
+## Final principle
+
+The goal is not merely to make Loadify work.
+
+The goal is to make Loadify:
+
+- technically correct;
+- secure;
+- visually excellent;
+- commercially coherent;
+- easy to use;
+- scalable;
+- maintainable;
+- internally consistent;
+- evidence-backed;
+- worthy of production.
+
+**Repository truth, canonical contract, evidence and platform integrity take priority over any individual agent, implementation shortcut, PR or assumption.**

--- a/README.md
+++ b/README.md
@@ -1,126 +1,105 @@
 # Loadify Market
 
-**UK multi-category physical goods marketplace**, operated by XDrive Logistics Ltd (Co. No: 13171804, VAT: GB375949535).
+> ## ⚠️ MANDATORY AGENT ENTRYPOINT
+> Every coding agent, reviewer, designer, auditor or implementation worker must read [`AGENTS.md`](./AGENTS.md) **before making changes**.
+>
+> For Supplier Commerce / product-model work, also read [`docs/canonical/loadify-supplier-commerce-2026-08-19/README.md`](./docs/canonical/loadify-supplier-commerce-2026-08-19/README.md) and follow its exact controlling read order.
+>
+> **Historical README text, old PR descriptions and stale branches do not override the canonical contract or current repository truth.**
 
-Independent and company UK sellers list and sell physical products across all consumer goods categories. The platform does not own inventory, hold or store products, or operate a depot — sellers manage their own inventory and fulfil orders directly. Buyers browse, purchase via Stripe, and receive orders from sellers with full shipment tracking.
+Loadify Market is a UK-operated commerce platform under XDrive Logistics Ltd (Co. No. 13171804, VAT GB375949535).
+
+The controlling product direction is not a simple seller-only marketplace and not a generic dropshipping site:
+
+**LOADIFY MARKET = MARKETPLACE + LOADIFY-OPERATED PRODUCT SOURCING / IMPORT + SUPPLIER-FULFILLED COMMERCE + PRODUCT DISCOVERY / OPPORTUNITY INTELLIGENCE + AI PRODUCT BUILDER + CANONICAL COMMERCE CONTROL.**
+
+The intended customer-facing experience remains Loadify-centric:
+
+**discover → product → cart → checkout → payment → order → tracking → support → returns/refunds**
+
+while marketplace sellers, approved suppliers, fulfilment providers and carriers may perform distinct underlying roles according to the controlling business contract.
+
+Loadify does not require its own warehouse for Supplier-Fulfilled Commerce. No warehouse does not mean no governance or no responsibility.
 
 ---
 
-## 📚 Documentation
+## Current controlling execution boundary
+
+The canonical sequence is:
+
+**CRITICAL FOUNDATION → CHECKPOINT A → ATOMIC CHECKPOINT A PASS → FOUNDATION BASELINE FREEZE → HARD STOP OLD EXTENSIVE HARDENING → GATE B BUSINESS CONTRACT → GATE B PASS → PHASE C → Q.**
+
+Checkpoint A and Foundation Baseline Freeze are recorded historical gates. The next controlling business gate is **Gate B**, unless a newer canonical clarification explicitly supersedes this.
+
+**No Supplier Commerce migration/runtime implementation is authorised before Gate B PASS.**
+
+Prepared implementation planning exists on branch `parallel/supplier-commerce-preparation` under `docs/parallel/supplier-commerce-preparation/`. Read that branch's `README.md` and then `33_PRODUCT_DIRECTION_RECONCILIATION_2026-08-20.md`. Canonical always wins over preparation artifacts.
+
+---
+
+## Core architecture invariants
+
+- one canonical product may have multiple governed supplier offers;
+- canonical product ≠ supplier offer;
+- supplier raw stock ≠ Loadify sellable stock;
+- payment success ≠ supplier order success;
+- customer refund ≠ supplier recovery;
+- order completed ≠ financially reconciled;
+- one customer order truth;
+- one canonical financial truth;
+- no provider-specific commerce core;
+- no direct operator publish bypass;
+- no AI-invented product facts;
+- no fake/laundered reviews;
+- no unverified assumption of commercial rights to third-party media/UGC;
+- no drip-price architecture;
+- no silent supplier substitution that changes the customer promise.
+
+External roles are distinct:
+
+**Discovery Source ≠ Catalog Source ≠ Supplier ≠ Fulfilment Provider ≠ Carrier ≠ Sales/Channel Connector.**
+
+---
+
+## Documentation
 
 | Doc | Purpose |
 |---|---|
-| [docs/ARCHITECTURE.md](./docs/ARCHITECTURE.md) | System architecture, domain model, data flow |
-| [docs/openapi.yaml](./docs/openapi.yaml) | API reference (OpenAPI 3.0) |
-| [docs/SHIPPING.md](./docs/SHIPPING.md) | Shipment and tracking system |
-| [docs/audit/MASTER_FRAMEWORK.md](./docs/audit/MASTER_FRAMEWORK.md) | Audit operating model: surfaces, levels, evidence, and definition of done |
-| [docs/audit/COVERAGE_MATRIX.md](./docs/audit/COVERAGE_MATRIX.md) | Current critical-flow coverage and control gaps |
+| [`AGENTS.md`](./AGENTS.md) | Mandatory agent operating contract, responsibilities, product direction and Branch Guard rules |
+| [`docs/canonical/loadify-supplier-commerce-2026-08-19/README.md`](./docs/canonical/loadify-supplier-commerce-2026-08-19/README.md) | Controlling Supplier Commerce contract read order and execution boundary |
+| [`docs/ARCHITECTURE.md`](./docs/ARCHITECTURE.md) | Existing system architecture and domain model |
+| [`docs/openapi.yaml`](./docs/openapi.yaml) | API reference |
+| [`docs/SHIPPING.md`](./docs/SHIPPING.md) | Shipment and tracking system |
+| [`docs/audit/MASTER_FRAMEWORK.md`](./docs/audit/MASTER_FRAMEWORK.md) | Audit operating model and evidence standards |
+| [`docs/audit/COVERAGE_MATRIX.md`](./docs/audit/COVERAGE_MATRIX.md) | Critical-flow coverage and control gaps |
 
 ---
 
-## ✨ Features
+## Existing platform surfaces
 
 ### Buyers
-- Browse and search physical product listings by category, condition, and price range
-- Purchase directly via Stripe Checkout (GBP)
-- Request a bulk quote (RFQ) — submit product name, quantity, destination, and budget; seller replies by email
-- Direct messaging with sellers, linked to products or orders
-- Order tracking via courier name and tracking number (shipment event log)
-- Post-delivery reviews (verified purchase — requires a delivered order)
-- Wishlist, saved searches, and recently viewed products
-- File returns and raise disputes on delivered orders
+
+Current repository capabilities include product browsing/search, checkout/payment flows, buyer accounts, order history/tracking, messaging/RFQ-related functionality, reviews, wishlist/saved-search style features, and return/dispute surfaces. Treat current implementation as repository state to verify, not as permission to invent unsupported future claims.
 
 ### Sellers
-- List physical products across all supported categories, with optional listing attributes including condition (new, used, refurbished), stock quantity, weight, dimensions, and pallet or lot-specific fields
-- Seller account lifecycle: `draft` → `submitted` → `active` → `suspended` (admin-approved)
-- Order management dashboard — status progression: `paid` → `packed` → `shipped` → `delivered`
-- Shipment creation with courier name, tracking number, and dispatch date
-- Respond to buyer RFQ requests via the quote inbox
-- Stripe Connect Express onboarding for weekly GBP payouts
-- Manage returns and respond to disputes
-- Pause account (deactivates all listings) or delete seller account
+
+Current repository capabilities include seller onboarding/account lifecycle, product listing/stock management, order handling, shipment/tracking flows, Stripe Connect payout integration, marketplace communication and return/dispute-related functionality.
 
 ### Admin
-- Seller approval and suspension workflow
-- Product listing moderation (approve, deactivate, review flagged listings)
-- Platform-wide order and user management
-- Dispute resolution with refund amount control
-- Support ticket inbox
-- Platform analytics overview
+
+Current repository capabilities include seller and product governance, platform order/user management, dispute/support surfaces and platform analytics. **Do not redesign Workspace or Super Admin merely as collateral to another implementation.**
 
 ---
 
-## 💰 Business Model
+## Commerce / tax warning
 
-The platform charges a **7% commission** on each completed transaction, deducted before the seller's payout is processed via Stripe Connect. The platform acts solely as an intermediary — it does not own products, hold inventory, or operate a fulfilment depot. Sellers are responsible for their own inventory management and order fulfilment.
+Do not rely on legacy README statements as a tax, VAT, commission, Merchant-of-Record, invoice or fulfilment contract.
 
-> **Launch promotion:** 0% commission on all transactions until **31 December 2026 23:59:59 UTC**. The standard 7% rate resumes automatically after that date.
-
-All prices are in **GBP**. VAT is calculated and displayed separately (flat-rate scheme, `GB375949535`). Sellers receive weekly payouts via Stripe Connect Express.
+Those matters must follow the controlling Gate B/canonical evidence and current verified implementation. In particular, do not assume universal 20% VAT, automatic reverse charge, a universal seller-only fulfilment model, or any other historical shortcut without current evidence.
 
 ---
 
-## 📦 Product Categories
-
-The marketplace covers 15 top-level consumer goods categories, each with subcategories:
-
-Clothing · Shoes · Jewellery · Media & Electronics · Accessories · Toys · Health & Beauty · Pets · Memorabilia · Adult · Food & Drink · Office Supplies · Home & Garden · Sports & Outdoors · Mixed Job Lots
-
----
-
-## 📋 Prerequisites
-
-- **Node.js 20+** and npm
-- **Supabase account** (free tier works for development)
-- **Stripe account** (test mode available — no real payments needed in development)
-- **SendGrid account** (optional — transactional email for shipment notifications)
-
----
-
-## 🛠️ Quick Start
-
-```bash
-# 1. Clone and install
-git clone https://github.com/LoadifyMarketLTD/loadifymarket.co.uk.git
-cd loadifymarket.co.uk
-npm install
-
-# 2. Configure environment
-cp .env.example .env
-# Edit .env — set VITE_SUPABASE_URL, VITE_SUPABASE_ANON_KEY, VITE_STRIPE_PUBLISHABLE_KEY
-
-# 3. Initialise database
-# Apply the SQL files under supabase/migrations/ in ascending version order.
-# Do not run supabase/00_consolidated_schema.sql; it is intentionally deprecated
-# and non-executable so retired schema cannot be reintroduced accidentally.
-
-# 4. Start dev server (hot reload)
-npm run dev
-```
-
-Visit [http://localhost:5173](http://localhost:5173)
-
----
-
-## 🧑‍💻 Development Commands
-
-```bash
-npm run dev          # Start Vite dev server with HMR
-npm run build        # TypeScript check + Vite production build
-npm run lint         # ESLint
-npm test             # Vitest unit tests (single run)
-npm run test:watch   # Vitest in watch mode
-```
-
-Local Netlify Functions (Stripe, register, email):
-```bash
-npm install -g netlify-cli
-netlify dev          # Starts frontend + Netlify Functions at http://localhost:8888
-```
-
----
-
-## 🏗️ Tech Stack
+## Tech stack
 
 | Layer | Technology |
 |---|---|
@@ -131,109 +110,115 @@ netlify dev          # Starts frontend + Netlify Functions at http://localhost:8
 | API | Supabase PostgREST + Netlify Functions |
 | Payments | Stripe Checkout + Stripe Connect Express |
 | Email | SendGrid |
-| Hosting | Netlify (CDN + serverless functions) |
+| Hosting | Netlify |
 | CI | GitHub Actions (`.github/workflows/ci.yml`) |
 
 ---
 
-## 📂 Key Project Structure
+## Quick start
 
+```bash
+git clone https://github.com/LoadifyMarketLTD/loadifymarket.co.uk.git
+cd loadifymarket.co.uk
+npm install
+cp .env.example .env
+npm run dev
 ```
+
+Set the required development environment variables in `.env`.
+
+For database changes, `supabase/migrations/` is the authoritative ordered migration source. Do not run `supabase/00_consolidated_schema.sql`; it is a deprecated non-executable tombstone.
+
+---
+
+## Development commands
+
+```bash
+npm run dev
+npm run build
+npm run lint
+npm test
+npm run test:watch
+```
+
+Local Netlify Functions:
+
+```bash
+npm install -g netlify-cli
+netlify dev
+```
+
+---
+
+## Key project structure
+
+```text
+├── AGENTS.md                       # Mandatory agent entrypoint
 ├── src/
-│   ├── pages/pixel-perfect/   # Full-page React components
-│   │   ├── seller/            # Seller dashboard pages — served at both /seller/* (shadcn sidebar layout)
-│   │   │                      #   and /pp/seller/* (pixel-perfect standalone shell)
-│   │   ├── buyer/             # Buyer dashboard pages — served at both /dashboard/* and /pp/buyer/*
-│   │   └── admin/             # Admin panel pages — served at both /admin/* and /pp/admin/*
-│   ├── components/            # Shared UI components
+│   ├── pages/pixel-perfect/        # Strong existing UI benchmark surfaces
+│   │   ├── seller/
+│   │   ├── buyer/
+│   │   └── admin/
+│   ├── components/
 │   └── lib/
-│       ├── supabase.ts        # Supabase client
-│       └── safeStorage.ts     # Safe localStorage wrapper (mobile private mode safe)
-├── netlify/functions/         # Serverless API handlers
-│   ├── register.ts            # User registration
-│   ├── create-checkout.ts     # Stripe Checkout session creation
-│   ├── stripe-webhook.ts      # Stripe event handler (orders + Connect)
-│   ├── connect-onboard.ts     # Stripe Connect Express onboarding
-│   ├── create-shipment.ts     # Shipment creation and update
-│   ├── track-shipment.ts      # Shipment tracking lookup
-│   ├── generate-invoice.ts    # Invoice PDF generation
-│   └── send-email.ts          # SendGrid transactional email
-├── supabase/
-│   ├── migrations/            # Authoritative database source, ordered by version
-│   ├── 00_consolidated_schema.sql # Deprecated non-executable tombstone
-│   ├── 06_fulfilment_rfq.sql  # Generic reference schema; changes still go in migrations/
-│   └── DEBUGGED_PARTS_README.md
+├── netlify/functions/              # Serverless API handlers
+├── supabase/migrations/            # Authoritative ordered DB migrations
 ├── docs/
-│   ├── ARCHITECTURE.md        # System architecture
-│   └── openapi.yaml           # API reference
+│   ├── canonical/                  # Controlling product/execution contracts
+│   ├── audit/
+│   ├── ARCHITECTURE.md
+│   └── openapi.yaml
 └── public/
-    ├── sitemap.xml
-    └── robots.txt
 ```
 
 ---
 
-## 🚀 Deployment
+## Branch / release discipline
 
-The project deploys to Netlify automatically via the configuration in `netlify.toml`.
+Before writes, inspect current `main`, relevant branch HEAD, open PRs, relevant concurrent branches and migration head when applicable.
 
-1. Connect the GitHub repository to Netlify.
-2. Leave the **Build command** field **empty** in the Netlify UI (it reads from `netlify.toml`).
-3. Set the following environment variables in the Netlify dashboard:
+Before merge, inspect exact diff, branch staleness, unrelated changes, integration risk and real evidence.
 
-| Variable | Required | Description |
-|---|---|---|
-| `VITE_SUPABASE_URL` | ✅ | Supabase project URL |
-| `VITE_SUPABASE_ANON_KEY` | ✅ | Supabase anon/public key |
-| `SUPABASE_SERVICE_ROLE_KEY` | ✅ | Supabase service role key (functions only) |
-| `STRIPE_SECRET_KEY` | ✅ | Stripe secret key |
-| `VITE_STRIPE_PUBLISHABLE_KEY` | ✅ | Stripe publishable key |
-| `STRIPE_WEBHOOK_SECRET` | ✅ | Stripe standard webhook signing secret |
-| `STRIPE_CONNECT_WEBHOOK_SECRET` | ✅ | Stripe Connect webhook signing secret |
-| `SENDGRID_API_KEY` | Optional | SendGrid API key for shipment emails |
-| `VITE_SUPPORT_EMAIL` | Optional | Support email address |
+No Fake PASS. A documented claim is not a test. A preview is not visual approval. CI that did not execute steps is not evidence of a software failure or PASS.
 
-For detailed instructions see the [Netlify documentation](https://docs.netlify.com/configure-builds/environment-variables/).
+The default loop is:
+
+**READ REAL STATE → UNDERSTAND PRODUCT INTENT → IDENTIFY ROOT CAUSE → DESIGN CORRECT SOLUTION → IMPLEMENT → VERIFY TECHNICALLY → VERIFY VISUALLY IF UI → VERIFY INTEGRATION → BRANCH GUARD → FIX REGRESSIONS → DOCUMENT REAL EVIDENCE → ONLY THEN DECLARE COMPLETE.**
 
 ---
 
-## 🔐 Security
+## Deployment
 
-- Row-Level Security (RLS) enforced on every PostgreSQL table.
-- All payments processed by Stripe (PCI-DSS Level 1) — card details are never stored on our servers.
-- Stripe webhook signature verification on every inbound event.
-- Both the standard account webhook and the Stripe Connect webhook share a single endpoint, each verified with its own signing secret.
-- Supabase JWT with short-lived access tokens and refresh tokens.
-- Rate limiting on registration, Stripe Connect onboarding, email, and error-reporting endpoints.
-- Content-Security-Policy with violation reporting.
+The project deploys to Netlify according to `netlify.toml`. Production environment variables include Supabase, Stripe and other server-side credentials. Never expose server secrets to client code.
 
 ---
 
-## 🧪 Test Accounts & Stripe Cards
+## Security
 
-After running the seed scripts:
+Security work must verify, as applicable:
 
-| Role | Email | Password |
-|---|---|---|
-| Buyer | buyer@test.com | test1234 |
-| Seller (active) | seller@test.com | test1234 |
-| Admin | admin@loadifymarket.co.uk | test1234 |
+- RLS and multi-tenant isolation;
+- auth/session boundaries;
+- inactive/suspended accounts;
+- service-role access;
+- storage permissions;
+- webhook verification;
+- idempotency/replay protection;
+- fail-closed behaviour for security and money-related paths.
 
-**Stripe test cards:**
-- ✅ Success: `4242 4242 4242 4242` (any future expiry, any CVV)
-- ❌ Decline: `4000 0000 0000 0002`
-
----
-
-## 📧 Contact
-
-**Company**: XDrive Logistics Ltd  
-**Support**: contact@loadifymarket.co.uk  
-**Phone**: +44 7423 272138  
-**Address**: 101 Cornelian Street, Blackburn, BB1 9QL, United Kingdom
+Repository claims are not a substitute for current runtime evidence.
 
 ---
 
-## 📄 License
+## Company
 
-Copyright © 2025 XDrive Logistics Ltd. All rights reserved.
+**XDrive Logistics Ltd**  
+Company No. 13171804  
+VAT GB375949535  
+101 Cornelian Street, Blackburn, BB1 9QL, United Kingdom
+
+---
+
+## License
+
+Copyright © XDrive Logistics Ltd. All rights reserved.


### PR DESCRIPTION
## Purpose
Make the controlling Loadify product direction, agent responsibilities, canonical read order and Branch Guard rules visible immediately to every agent entering the repository.

## Why this is required
The root README still described the historical seller-only marketplace model, including assumptions that now conflict with the controlling Supplier Commerce direction and Gate B work. That creates a high risk that a new agent follows stale repository prose instead of the canonical contract.

## Changes
- add root `AGENTS.md` as the mandatory agent entrypoint;
- define the current Loadify target model and core commerce invariants;
- record the mandatory canonical read order and Gate B execution boundary;
- record cumulative roles: web/front-end/back-end/full-stack/design/UI-UX/architecture/database/security/commerce/QA/release/product/technical decision-maker/Creator/Branch Guard;
- define visual quality, homepage, responsive, security, financial truth, supplier/import/AI, Product Discovery, No Fake PASS and concurrent-agent guardian rules;
- rewrite the root README entry section so it points agents to `AGENTS.md` and the canonical contract before implementation;
- remove stale seller-only/flat-tax README framing as an authority and explicitly make tax/commission/MoR/fulfilment decisions subject to canonical Gate B/current evidence.

## Scope
Documentation only.
No runtime changes.
No DB/migrations.
No Workspace/Super Admin visual changes.
No PR #529 changes.
No canonical execution-sequence change.

## Merge intent
This documentation only becomes an effective repository-wide entrypoint once merged to `main`. Until then, agents starting from `main` will not automatically see it.