### PR TITLE
Phase E: Canonical supplier data

### DIFF
--- a/netlify/functions/__tests__/supplier-catalog.test.ts
+++ b/netlify/functions/__tests__/supplier-catalog.test.ts
@@ -1,0 +1,154 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SUPPLIER_CATALOG_INTERFACE_VERSION,
+  buildCatalogIdentityKey,
+  evaluateSupplierCatalog,
+  normalizeCatalogIdentifier,
+} from '../_shared/supplierCatalog';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const migration = repo('supabase/619_canonical_supplier_data.sql');
+const guards = repo('supabase/620_canonical_supplier_data_guards.sql');
+const adminApi = repo('netlify/functions/admin-supplier-catalog.ts');
+
+const PRODUCT_ID = '11111111-1111-4111-8111-111111111111';
+const OFFER_ID = '22222222-2222-4222-8222-222222222222';
+
+describe('Phase E Canonical Supplier Data', () => {
+  it('keeps canonical product separate from supplier offers and raw supplier catalog identity', () => {
+    expect(migration).toContain('private.canonical_products');
+    expect(migration).toContain('private.supplier_catalog_items');
+    expect(migration).toContain('private.supplier_offers');
+    expect(migration).toContain('canonical_product_id uuid NOT NULL REFERENCES private.canonical_products');
+    expect(migration).toContain('supplier_catalog_item_id uuid NOT NULL REFERENCES private.supplier_catalog_items');
+    expect(migration).not.toContain('supplier_price');
+    expect(migration).not.toContain('sellable_stock');
+  });
+
+  it('provides deterministic catalog identifiers with namespace-aware uniqueness', () => {
+    expect(normalizeCatalogIdentifier('gtin', ' 05012345-67890 ')).toBe('0501234567890');
+    expect(buildCatalogIdentityKey('brand_mpn', '  ABC  123 ')).toBe('brand_mpn:abc 123');
+    expect(() => normalizeCatalogIdentifier('gtin', 'abc')).toThrow(/invalid/i);
+
+    expect(migration).toContain("identifier_type IN ('gtin','ean','upc','isbn','mpn','brand_mpn','internal')");
+    expect(migration).toContain('canonical_verified_identifier_global_unique');
+    expect(migration).toContain("identifier_type IN ('mpn','brand_mpn','internal') AND identifier_namespace <> 'global'");
+  });
+
+  it('models deduplication as evidence and explicit resolution, never an implicit merge', () => {
+    expect(migration).toContain('private.catalog_dedup_candidates');
+    expect(migration).toContain("decision IN ('pending','same_product','different_product','manual_review')");
+    expect(migration).toContain('resolution_version integer NOT NULL DEFAULT 1');
+    expect(guards).toContain('terminal catalog dedup resolution is immutable');
+    expect(guards).toContain('terminal catalog dedup resolution requires evidence');
+    expect(guards).not.toMatch(/DELETE\s+FROM\s+private\.canonical_products/i);
+  });
+
+  it('blocks approved offers while catalog identity is unresolved', () => {
+    expect(guards).toContain("d.decision IN ('pending','manual_review')");
+    expect(guards).toContain('unresolved catalog deduplication blocks offer approval');
+    expect(migration).toContain('catalog_identity_unresolved');
+  });
+
+  it('requires strong identity evidence for verified-identifier and dedup-resolution links', () => {
+    expect(guards).toContain("NEW.identity_method = 'verified_identifier'");
+    expect(guards).toContain("si.verification_status = 'verified'");
+    expect(guards).toContain("ci.verification_status = 'verified'");
+    expect(guards).toContain("NEW.identity_method = 'dedup_resolution'");
+    expect(guards).toContain("d.decision = 'same_product'");
+  });
+
+  it('makes verified identifiers and approved offer identity immutable', () => {
+    expect(guards).toContain('verified canonical identifier identity is immutable');
+    expect(guards).toContain('approved supplier offer identity is immutable');
+    expect(guards).toContain('supplier catalog external identity is immutable');
+  });
+
+  it('keeps Phase E storage private and service-role decisions fail-closed', () => {
+    for (const table of [
+      'canonical_products', 'canonical_product_identifiers', 'supplier_catalog_items',
+      'supplier_catalog_identifiers', 'supplier_offers', 'catalog_dedup_candidates', 'catalog_identity_audit',
+    ]) {
+      expect(migration).toContain(`REVOKE ALL ON TABLE private.${table} FROM PUBLIC, anon, authenticated, service_role`);
+    }
+    expect(migration).toContain('GRANT EXECUTE ON FUNCTION public.server_supplier_catalog_decision_v1(uuid, uuid, text) TO service_role');
+    expect(guards).toContain('GRANT EXECUTE ON FUNCTION public.server_mutate_supplier_catalog_v1(uuid, text, jsonb) TO service_role');
+  });
+
+  it('reuses Phase D supplier readiness instead of creating parallel supplier truth', () => {
+    expect(migration).toContain('private.supplier_foundation_suppliers');
+    expect(migration).toContain('public.server_supplier_foundation_decision_v1');
+    expect(migration).toContain("'catalog'");
+    expect(migration).not.toContain('CREATE TABLE IF NOT EXISTS private.suppliers');
+  });
+
+  it('does not enable Supplier Commerce just because Phase E schema exists', () => {
+    expect(migration).toContain('Supplier Commerce remains fail-closed under the Phase C control plane');
+    expect(migration).not.toContain('SET enabled = true');
+    expect(guards).not.toContain('SET enabled = true');
+  });
+
+  it('requires active-admin authority and rejects secret-bearing payloads', () => {
+    expect(guards).toContain("u.role = 'admin'");
+    expect(guards).toContain('u."isActive" = true');
+    expect(adminApi).toContain("authenticateActiveAccount(event, admin, ['admin'])");
+    expect(adminApi).toContain('password|secret|access[_-]?token');
+  });
+
+  it('fails closed when the catalog readiness RPC is unavailable or malformed', async () => {
+    const rpc = vi.fn(async () => ({ data: { eligible: true }, error: null }));
+    const client = { rpc } as unknown as SupabaseClient;
+    await expect(evaluateSupplierCatalog(client, {
+      canonicalProductId: PRODUCT_ID,
+      supplierOfferId: OFFER_ID,
+    })).resolves.toEqual({
+      eligible: false,
+      reason: 'supplier_catalog_unavailable',
+      interfaceVersion: SUPPLIER_CATALOG_INTERFACE_VERSION,
+    });
+
+    rpc.mockRejectedValueOnce(new Error('network down'));
+    await expect(evaluateSupplierCatalog(client, {
+      canonicalProductId: PRODUCT_ID,
+      supplierOfferId: OFFER_ID,
+    })).resolves.toEqual({
+      eligible: false,
+      reason: 'supplier_catalog_unavailable',
+      interfaceVersion: SUPPLIER_CATALOG_INTERFACE_VERSION,
+    });
+  });
+
+  it('accepts only a structurally complete server-side readiness decision', async () => {
+    const expected = {
+      eligible: true,
+      reason: 'supplier_catalog_ready',
+      canonicalProductId: PRODUCT_ID,
+      supplierOfferId: OFFER_ID,
+      supplierId: '33333333-3333-4333-8333-333333333333',
+      interfaceVersion: 1,
+    };
+    const rpc = vi.fn(async () => ({ data: expected, error: null }));
+    const client = { rpc } as unknown as SupabaseClient;
+
+    await expect(evaluateSupplierCatalog(client, {
+      canonicalProductId: PRODUCT_ID,
+      supplierOfferId: OFFER_ID,
+      territory: 'GB',
+    })).resolves.toEqual(expected);
+    expect(rpc).toHaveBeenCalledWith('server_supplier_catalog_decision_v1', {
+      p_canonical_product_id: PRODUCT_ID,
+      p_supplier_offer_id: OFFER_ID,
+      p_territory: 'GB',
+    });
+  });
+
+  it('keeps Phase F ingestion/normalisation explicitly deferred', () => {
+    expect(migration).toContain('does NOT implement import/normalisation');
+    expect(migration).toContain('raw_snapshot_ref text');
+    expect(migration).toContain('supplier_catalog_identifiers');
+    expect(adminApi).not.toContain('attach_supplier_identifier');
+  });
+});

--- a/netlify/functions/__tests__/supplier-catalog.test.ts
+++ b/netlify/functions/__tests__/supplier-catalog.test.ts
@@ -12,6 +12,7 @@ import {
 const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
 const migration = repo('supabase/619_canonical_supplier_data.sql');
 const guards = repo('supabase/620_canonical_supplier_data_guards.sql');
+const integrity = repo('supabase/621_canonical_supplier_data_integrity.sql');
 const adminApi = repo('netlify/functions/admin-supplier-catalog.ts');
 
 const PRODUCT_ID = '11111111-1111-4111-8111-111111111111';
@@ -36,6 +37,7 @@ describe('Phase E Canonical Supplier Data', () => {
     expect(migration).toContain("identifier_type IN ('gtin','ean','upc','isbn','mpn','brand_mpn','internal')");
     expect(migration).toContain('canonical_verified_identifier_global_unique');
     expect(migration).toContain("identifier_type IN ('mpn','brand_mpn','internal') AND identifier_namespace <> 'global'");
+    expect(integrity).toContain('supplier catalog identifier namespace is required');
   });
 
   it('models deduplication as evidence and explicit resolution, never an implicit merge', () => {
@@ -44,13 +46,16 @@ describe('Phase E Canonical Supplier Data', () => {
     expect(migration).toContain('resolution_version integer NOT NULL DEFAULT 1');
     expect(guards).toContain('terminal catalog dedup resolution is immutable');
     expect(guards).toContain('terminal catalog dedup resolution requires evidence');
+    expect(integrity).toContain('catalog_dedup_one_same_product_unique');
     expect(guards).not.toMatch(/DELETE\s+FROM\s+private\.canonical_products/i);
   });
 
-  it('blocks approved offers while catalog identity is unresolved', () => {
+  it('blocks approved offers while catalog identity is unresolved or explicitly different', () => {
     expect(guards).toContain("d.decision IN ('pending','manual_review')");
     expect(guards).toContain('unresolved catalog deduplication blocks offer approval');
     expect(migration).toContain('catalog_identity_unresolved');
+    expect(integrity).toContain("d.decision = 'different_product'");
+    expect(integrity).toContain('different-product dedup resolution blocks supplier offer approval');
   });
 
   it('requires strong identity evidence for verified-identifier and dedup-resolution links', () => {
@@ -89,6 +94,7 @@ describe('Phase E Canonical Supplier Data', () => {
     expect(migration).toContain('Supplier Commerce remains fail-closed under the Phase C control plane');
     expect(migration).not.toContain('SET enabled = true');
     expect(guards).not.toContain('SET enabled = true');
+    expect(integrity).not.toContain('SET enabled = true');
   });
 
   it('requires active-admin authority and rejects secret-bearing payloads', () => {

--- a/netlify/functions/_shared/supplierCatalog.ts
+++ b/netlify/functions/_shared/supplierCatalog.ts
@@ -21,6 +21,7 @@ export type SupplierCatalogAdminAction =
   | 'set_canonical_status'
   | 'attach_identifier'
   | 'upsert_supplier_catalog_item'
+  | 'attach_supplier_identifier'
   | 'link_supplier_offer'
   | 'record_dedup_candidate'
   | 'resolve_dedup_candidate';

--- a/netlify/functions/_shared/supplierCatalog.ts
+++ b/netlify/functions/_shared/supplierCatalog.ts
@@ -1,0 +1,96 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const SUPPLIER_CATALOG_INTERFACE_VERSION = 1 as const;
+
+export type CatalogEntityStatus = 'draft' | 'review' | 'active' | 'restricted' | 'retired';
+export type SupplierOfferStatus = 'candidate' | 'review' | 'approved' | 'restricted' | 'retired';
+export type CatalogIdentifierType = 'gtin' | 'ean' | 'upc' | 'isbn' | 'mpn' | 'brand_mpn' | 'internal';
+export type DedupDecision = 'pending' | 'same_product' | 'different_product' | 'manual_review';
+
+export interface CanonicalCatalogDecision {
+  eligible: boolean;
+  reason: string;
+  canonicalProductId?: string;
+  supplierOfferId?: string;
+  supplierId?: string;
+  interfaceVersion: typeof SUPPLIER_CATALOG_INTERFACE_VERSION;
+}
+
+export type SupplierCatalogAdminAction =
+  | 'upsert_canonical_product'
+  | 'set_canonical_status'
+  | 'attach_identifier'
+  | 'upsert_supplier_catalog_item'
+  | 'link_supplier_offer'
+  | 'record_dedup_candidate'
+  | 'resolve_dedup_candidate';
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export const normalizeCatalogIdentifier = (type: CatalogIdentifierType, raw: string): string => {
+  const value = raw.trim();
+  if (!value) throw new Error('catalog identifier value is required');
+
+  if (type === 'gtin' || type === 'ean' || type === 'upc' || type === 'isbn') {
+    const digits = value.replace(/[\s-]/g, '');
+    if (!/^\d{8,14}$/.test(digits)) throw new Error('numeric catalog identifier is invalid');
+    return digits;
+  }
+
+  const normalized = value.toLowerCase().replace(/\s+/g, ' ');
+  if (normalized.length > 256) throw new Error('catalog identifier is too long');
+  return normalized;
+};
+
+export const buildCatalogIdentityKey = (type: CatalogIdentifierType, raw: string): string =>
+  `${type}:${normalizeCatalogIdentifier(type, raw)}`;
+
+export async function evaluateSupplierCatalog(
+  client: SupabaseClient,
+  input: { canonicalProductId: string; supplierOfferId: string; territory?: string },
+): Promise<CanonicalCatalogDecision> {
+  if (!UUID_RE.test(input.canonicalProductId) || !UUID_RE.test(input.supplierOfferId)) {
+    return { eligible: false, reason: 'invalid_catalog_identity', interfaceVersion: SUPPLIER_CATALOG_INTERFACE_VERSION };
+  }
+
+  try {
+    const { data, error } = await client.rpc('server_supplier_catalog_decision_v1', {
+      p_canonical_product_id: input.canonicalProductId,
+      p_supplier_offer_id: input.supplierOfferId,
+      p_territory: input.territory || 'GB',
+    });
+    if (error || !data || typeof data !== 'object' || Array.isArray(data)) {
+      return { eligible: false, reason: 'supplier_catalog_unavailable', interfaceVersion: SUPPLIER_CATALOG_INTERFACE_VERSION };
+    }
+
+    const candidate = data as Record<string, unknown>;
+    if (typeof candidate.eligible !== 'boolean' || typeof candidate.reason !== 'string' || candidate.interfaceVersion !== 1) {
+      return { eligible: false, reason: 'supplier_catalog_unavailable', interfaceVersion: SUPPLIER_CATALOG_INTERFACE_VERSION };
+    }
+
+    return candidate as unknown as CanonicalCatalogDecision;
+  } catch {
+    return { eligible: false, reason: 'supplier_catalog_unavailable', interfaceVersion: SUPPLIER_CATALOG_INTERFACE_VERSION };
+  }
+}
+
+export async function mutateSupplierCatalog(
+  client: SupabaseClient,
+  actorId: string,
+  action: SupplierCatalogAdminAction,
+  payload: Record<string, unknown>,
+): Promise<{ ok: true; data: unknown } | { ok: false; error: string }> {
+  if (!UUID_RE.test(actorId)) return { ok: false, error: 'active admin authority is required' };
+
+  try {
+    const { data, error } = await client.rpc('server_mutate_supplier_catalog_v1', {
+      p_actor_id: actorId,
+      p_action: action,
+      p_payload: payload,
+    });
+    if (error) return { ok: false, error: error.message || 'supplier catalog mutation failed' };
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : 'supplier catalog mutation failed' };
+  }
+}

--- a/netlify/functions/_shared/supplierCatalog.ts
+++ b/netlify/functions/_shared/supplierCatalog.ts
@@ -21,7 +21,6 @@ export type SupplierCatalogAdminAction =
   | 'set_canonical_status'
   | 'attach_identifier'
   | 'upsert_supplier_catalog_item'
-  | 'attach_supplier_identifier'
   | 'link_supplier_offer'
   | 'record_dedup_candidate'
   | 'resolve_dedup_candidate';

--- a/netlify/functions/admin-supplier-catalog.ts
+++ b/netlify/functions/admin-supplier-catalog.ts
@@ -1,0 +1,66 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { jsonResponse, optionsResponse } from './_shared/http';
+import { mutateSupplierCatalog, type SupplierCatalogAdminAction } from './_shared/supplierCatalog';
+
+const METHODS = 'POST, OPTIONS';
+const ACTIONS = new Set<SupplierCatalogAdminAction>([
+  'upsert_canonical_product',
+  'set_canonical_status',
+  'attach_identifier',
+  'upsert_supplier_catalog_item',
+  'link_supplier_offer',
+  'record_dedup_candidate',
+  'resolve_dedup_candidate',
+]);
+
+interface Body {
+  action?: string;
+  payload?: Record<string, unknown>;
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return optionsResponse(METHODS);
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' }, METHODS);
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) return jsonResponse(500, { error: 'Server configuration error' }, METHODS);
+
+  const admin = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  const auth = await authenticateActiveAccount(event, admin, ['admin']);
+  if (!auth.ok) return jsonResponse(auth.status, { error: 'Unauthorized' }, METHODS);
+
+  let body: Body;
+  try {
+    body = JSON.parse(event.body || '{}') as Body;
+  } catch {
+    return jsonResponse(400, { error: 'Invalid JSON body' }, METHODS);
+  }
+
+  const action = typeof body.action === 'string' ? body.action.trim() as SupplierCatalogAdminAction : null;
+  const payload = body.payload;
+  if (!action || !ACTIONS.has(action) || !payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return jsonResponse(400, { error: 'A supported action and object payload are required' }, METHODS);
+  }
+
+  const serialized = JSON.stringify(payload);
+  if (/password|secret|access[_-]?token|refresh[_-]?token|api[_-]?key|card(number)?/i.test(serialized)) {
+    return jsonResponse(400, { error: 'Secrets or payment credentials are not accepted in Supplier Catalog payloads' }, METHODS);
+  }
+
+  const result = await mutateSupplierCatalog(admin, auth.actor.id, action, payload);
+  if (!result.ok) {
+    const validation = /required|invalid|not found|cannot|must|immutable|blocked|unresolved|banned/i.test(result.error);
+    const forbidden = /authority|required admin|permission/i.test(result.error);
+    console.error('admin-supplier-catalog: mutation failed:', result.error);
+    return jsonResponse(validation ? 400 : forbidden ? 403 : 500, {
+      error: validation ? result.error : forbidden ? 'Unauthorized' : 'Unable to update Supplier Catalog',
+    }, METHODS);
+  }
+
+  return jsonResponse(200, { ok: true, result: result.data }, METHODS);
+};

--- a/supabase/619_canonical_supplier_data.sql
+++ b/supabase/619_canonical_supplier_data.sql
@@ -1,0 +1,362 @@
+-- 619_canonical_supplier_data.sql
+-- Phase E — Canonical Supplier Data: Canonical Product, Supplier Offers,
+-- Catalog Identity and Deduplication.
+--
+-- This migration deliberately does NOT implement import/normalisation, pricing,
+-- stock, checkout or supplier ordering. Later canonical phases own those concerns.
+-- Supplier Commerce remains fail-closed under the Phase C control plane.
+
+CREATE SCHEMA IF NOT EXISTS private;
+
+CREATE TABLE IF NOT EXISTS private.canonical_products (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  catalog_key text NOT NULL UNIQUE,
+  working_label text NOT NULL,
+  product_kind text NOT NULL DEFAULT 'physical_good',
+  status text NOT NULL DEFAULT 'draft',
+  identity_version integer NOT NULL DEFAULT 1 CHECK (identity_version > 0),
+  identity_reason text NOT NULL DEFAULT 'Canonical identity created',
+  created_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  reviewed_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  reviewed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT canonical_products_catalog_key_check CHECK (
+    catalog_key = lower(BTRIM(catalog_key))
+    AND catalog_key ~ '^[a-z0-9][a-z0-9._-]{2,127}$'
+  ),
+  CONSTRAINT canonical_products_kind_check CHECK (
+    product_kind IN ('physical_good','bundle','lot','service')
+  ),
+  CONSTRAINT canonical_products_status_check CHECK (
+    status IN ('draft','review','active','restricted','retired')
+  ),
+  CONSTRAINT canonical_products_active_review_check CHECK (
+    status <> 'active' OR (reviewed_by IS NOT NULL AND reviewed_at IS NOT NULL)
+  )
+);
+
+CREATE INDEX IF NOT EXISTS canonical_products_status_idx
+  ON private.canonical_products(status, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS private.canonical_product_identifiers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  canonical_product_id uuid NOT NULL REFERENCES private.canonical_products(id) ON DELETE RESTRICT,
+  identifier_type text NOT NULL,
+  identifier_namespace text NOT NULL DEFAULT 'global',
+  raw_value text NOT NULL,
+  normalized_value text NOT NULL,
+  verification_status text NOT NULL DEFAULT 'unverified',
+  source_ref text,
+  evidence_hash text,
+  verified_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  verified_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT canonical_identifier_type_check CHECK (
+    identifier_type IN ('gtin','ean','upc','isbn','mpn','brand_mpn','internal')
+  ),
+  CONSTRAINT canonical_identifier_namespace_check CHECK (
+    NULLIF(BTRIM(identifier_namespace), '') IS NOT NULL
+  ),
+  CONSTRAINT canonical_identifier_value_check CHECK (
+    NULLIF(BTRIM(raw_value), '') IS NOT NULL
+    AND normalized_value = lower(BTRIM(normalized_value))
+    AND NULLIF(BTRIM(normalized_value), '') IS NOT NULL
+  ),
+  CONSTRAINT canonical_identifier_namespace_semantics_check CHECK (
+    (identifier_type IN ('gtin','ean','upc','isbn') AND identifier_namespace = 'global')
+    OR (identifier_type IN ('mpn','brand_mpn','internal') AND identifier_namespace <> 'global')
+  ),
+  CONSTRAINT canonical_identifier_verification_check CHECK (
+    verification_status IN ('unverified','verified','rejected','stale')
+  ),
+  CONSTRAINT canonical_identifier_verified_evidence_check CHECK (
+    verification_status <> 'verified'
+    OR (
+      verified_by IS NOT NULL
+      AND verified_at IS NOT NULL
+      AND NULLIF(BTRIM(source_ref), '') IS NOT NULL
+    )
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS canonical_identifier_per_product_unique
+  ON private.canonical_product_identifiers(
+    canonical_product_id, identifier_type, identifier_namespace, normalized_value
+  );
+CREATE UNIQUE INDEX IF NOT EXISTS canonical_verified_identifier_global_unique
+  ON private.canonical_product_identifiers(identifier_type, identifier_namespace, normalized_value)
+  WHERE verification_status = 'verified';
+CREATE INDEX IF NOT EXISTS canonical_identifier_lookup_idx
+  ON private.canonical_product_identifiers(identifier_type, identifier_namespace, normalized_value, verification_status);
+
+CREATE TABLE IF NOT EXISTS private.supplier_catalog_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  supplier_id uuid NOT NULL REFERENCES private.supplier_foundation_suppliers(id) ON DELETE RESTRICT,
+  external_product_ref text NOT NULL,
+  external_variant_ref text,
+  source_ref text NOT NULL,
+  source_observed_at timestamptz NOT NULL,
+  raw_identity_hash text NOT NULL,
+  raw_snapshot_ref text,
+  status text NOT NULL DEFAULT 'captured',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_catalog_external_product_ref_check CHECK (NULLIF(BTRIM(external_product_ref), '') IS NOT NULL),
+  CONSTRAINT supplier_catalog_source_ref_check CHECK (NULLIF(BTRIM(source_ref), '') IS NOT NULL),
+  CONSTRAINT supplier_catalog_hash_check CHECK (NULLIF(BTRIM(raw_identity_hash), '') IS NOT NULL),
+  CONSTRAINT supplier_catalog_status_check CHECK (
+    status IN ('captured','identity_review','linked','restricted','retired')
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_catalog_item_identity_unique
+  ON private.supplier_catalog_items(
+    supplier_id,
+    external_product_ref,
+    COALESCE(external_variant_ref, '')
+  );
+CREATE INDEX IF NOT EXISTS supplier_catalog_items_supplier_idx
+  ON private.supplier_catalog_items(supplier_id, status, source_observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS private.supplier_catalog_identifiers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  supplier_catalog_item_id uuid NOT NULL REFERENCES private.supplier_catalog_items(id) ON DELETE RESTRICT,
+  identifier_type text NOT NULL,
+  identifier_namespace text NOT NULL DEFAULT 'global',
+  raw_value text NOT NULL,
+  normalized_value text NOT NULL,
+  evidence_source_ref text NOT NULL,
+  observed_at timestamptz NOT NULL,
+  verification_status text NOT NULL DEFAULT 'observed',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_catalog_identifier_type_check CHECK (
+    identifier_type IN ('gtin','ean','upc','isbn','mpn','brand_mpn','internal')
+  ),
+  CONSTRAINT supplier_catalog_identifier_value_check CHECK (
+    NULLIF(BTRIM(raw_value), '') IS NOT NULL
+    AND normalized_value = lower(BTRIM(normalized_value))
+    AND NULLIF(BTRIM(normalized_value), '') IS NOT NULL
+  ),
+  CONSTRAINT supplier_catalog_identifier_namespace_semantics_check CHECK (
+    (identifier_type IN ('gtin','ean','upc','isbn') AND identifier_namespace = 'global')
+    OR (identifier_type IN ('mpn','brand_mpn','internal') AND identifier_namespace <> 'global')
+  ),
+  CONSTRAINT supplier_catalog_identifier_status_check CHECK (
+    verification_status IN ('observed','verified','rejected','stale')
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_catalog_identifier_unique
+  ON private.supplier_catalog_identifiers(
+    supplier_catalog_item_id, identifier_type, identifier_namespace, normalized_value
+  );
+CREATE INDEX IF NOT EXISTS supplier_catalog_identifier_lookup_idx
+  ON private.supplier_catalog_identifiers(identifier_type, identifier_namespace, normalized_value, verification_status);
+
+CREATE TABLE IF NOT EXISTS private.supplier_offers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  offer_key text NOT NULL UNIQUE,
+  supplier_id uuid NOT NULL REFERENCES private.supplier_foundation_suppliers(id) ON DELETE RESTRICT,
+  supplier_catalog_item_id uuid NOT NULL REFERENCES private.supplier_catalog_items(id) ON DELETE RESTRICT,
+  canonical_product_id uuid NOT NULL REFERENCES private.canonical_products(id) ON DELETE RESTRICT,
+  external_offer_ref text NOT NULL,
+  territory text NOT NULL DEFAULT 'GB',
+  status text NOT NULL DEFAULT 'candidate',
+  identity_method text NOT NULL,
+  identity_confidence numeric(6,5) CHECK (identity_confidence IS NULL OR identity_confidence BETWEEN 0 AND 1),
+  identity_evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  linked_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  linked_at timestamptz,
+  approved_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  approved_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_offer_key_check CHECK (
+    offer_key = lower(BTRIM(offer_key))
+    AND offer_key ~ '^[a-z0-9][a-z0-9._-]{2,159}$'
+  ),
+  CONSTRAINT supplier_offer_external_ref_check CHECK (NULLIF(BTRIM(external_offer_ref), '') IS NOT NULL),
+  CONSTRAINT supplier_offer_territory_check CHECK (territory = upper(BTRIM(territory)) AND territory ~ '^[A-Z]{2}$'),
+  CONSTRAINT supplier_offer_status_check CHECK (
+    status IN ('candidate','review','approved','restricted','retired')
+  ),
+  CONSTRAINT supplier_offer_identity_method_check CHECK (
+    identity_method IN ('verified_identifier','manual_review','dedup_resolution')
+  ),
+  CONSTRAINT supplier_offer_identity_evidence_check CHECK (jsonb_typeof(identity_evidence) = 'object'),
+  CONSTRAINT supplier_offer_link_check CHECK (
+    linked_by IS NOT NULL AND linked_at IS NOT NULL
+  ),
+  CONSTRAINT supplier_offer_approved_check CHECK (
+    status <> 'approved'
+    OR (
+      approved_by IS NOT NULL
+      AND approved_at IS NOT NULL
+      AND jsonb_object_length(identity_evidence) > 0
+    )
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_offer_external_unique
+  ON private.supplier_offers(supplier_id, territory, external_offer_ref);
+CREATE INDEX IF NOT EXISTS supplier_offer_canonical_idx
+  ON private.supplier_offers(canonical_product_id, status, territory);
+CREATE INDEX IF NOT EXISTS supplier_offer_supplier_idx
+  ON private.supplier_offers(supplier_id, status, territory);
+
+CREATE TABLE IF NOT EXISTS private.catalog_dedup_candidates (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  supplier_catalog_item_id uuid NOT NULL REFERENCES private.supplier_catalog_items(id) ON DELETE RESTRICT,
+  candidate_canonical_product_id uuid NOT NULL REFERENCES private.canonical_products(id) ON DELETE RESTRICT,
+  candidate_key text NOT NULL,
+  score numeric(6,5) CHECK (score IS NULL OR score BETWEEN 0 AND 1),
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  decision text NOT NULL DEFAULT 'pending',
+  decision_reason text,
+  resolution_version integer NOT NULL DEFAULT 1 CHECK (resolution_version > 0),
+  resolved_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  resolved_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT catalog_dedup_candidate_key_check CHECK (NULLIF(BTRIM(candidate_key), '') IS NOT NULL),
+  CONSTRAINT catalog_dedup_evidence_check CHECK (jsonb_typeof(evidence) = 'object'),
+  CONSTRAINT catalog_dedup_decision_check CHECK (
+    decision IN ('pending','same_product','different_product','manual_review')
+  ),
+  CONSTRAINT catalog_dedup_resolution_check CHECK (
+    decision = 'pending'
+    OR (resolved_by IS NOT NULL AND resolved_at IS NOT NULL AND NULLIF(BTRIM(decision_reason), '') IS NOT NULL)
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS catalog_dedup_candidate_unique
+  ON private.catalog_dedup_candidates(supplier_catalog_item_id, candidate_canonical_product_id);
+CREATE INDEX IF NOT EXISTS catalog_dedup_pending_idx
+  ON private.catalog_dedup_candidates(decision, score DESC, created_at)
+  WHERE decision IN ('pending','manual_review');
+
+CREATE TABLE IF NOT EXISTS private.catalog_identity_audit (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  entity_type text NOT NULL,
+  entity_id uuid NOT NULL,
+  actor_id uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  action text NOT NULL,
+  previous_version integer,
+  new_version integer,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT catalog_identity_audit_entity_check CHECK (
+    entity_type IN ('canonical_product','canonical_identifier','supplier_catalog_item','supplier_offer','dedup_candidate')
+  ),
+  CONSTRAINT catalog_identity_audit_evidence_check CHECK (jsonb_typeof(evidence) = 'object')
+);
+
+CREATE INDEX IF NOT EXISTS catalog_identity_audit_entity_idx
+  ON private.catalog_identity_audit(entity_type, entity_id, created_at DESC);
+
+REVOKE ALL ON TABLE private.canonical_products FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.canonical_product_identifiers FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_catalog_items FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_catalog_identifiers FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_offers FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.catalog_dedup_candidates FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.catalog_identity_audit FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.server_supplier_catalog_decision_v1(
+  p_canonical_product_id uuid,
+  p_supplier_offer_id uuid,
+  p_territory text DEFAULT 'GB'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_product private.canonical_products%ROWTYPE;
+  v_offer private.supplier_offers%ROWTYPE;
+  v_supplier private.supplier_foundation_suppliers%ROWTYPE;
+  v_foundation jsonb;
+BEGIN
+  SELECT * INTO v_product
+    FROM private.canonical_products
+   WHERE id = p_canonical_product_id;
+
+  IF NOT FOUND OR v_product.status <> 'active' THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'canonical_product_not_active', 'interfaceVersion', 1);
+  END IF;
+
+  SELECT * INTO v_offer
+    FROM private.supplier_offers
+   WHERE id = p_supplier_offer_id
+     AND canonical_product_id = p_canonical_product_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'supplier_offer_not_linked', 'interfaceVersion', 1);
+  END IF;
+
+  IF v_offer.status <> 'approved' THEN
+    RETURN jsonb_build_object(
+      'eligible', false, 'reason', 'supplier_offer_not_approved',
+      'canonicalProductId', v_product.id, 'supplierOfferId', v_offer.id, 'interfaceVersion', 1
+    );
+  END IF;
+
+  IF upper(BTRIM(COALESCE(p_territory, 'GB'))) <> v_offer.territory THEN
+    RETURN jsonb_build_object(
+      'eligible', false, 'reason', 'supplier_offer_territory_mismatch',
+      'canonicalProductId', v_product.id, 'supplierOfferId', v_offer.id, 'interfaceVersion', 1
+    );
+  END IF;
+
+  SELECT * INTO v_supplier
+    FROM private.supplier_foundation_suppliers
+   WHERE id = v_offer.supplier_id;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'supplier_not_found', 'interfaceVersion', 1);
+  END IF;
+
+  v_foundation := public.server_supplier_foundation_decision_v1(v_supplier.supplier_key, v_offer.territory, 'catalog');
+  IF COALESCE((v_foundation->>'eligible')::boolean, false) IS NOT TRUE THEN
+    RETURN jsonb_build_object(
+      'eligible', false, 'reason', 'supplier_foundation_not_ready',
+      'canonicalProductId', v_product.id, 'supplierOfferId', v_offer.id,
+      'supplierId', v_supplier.id, 'supplierFoundation', v_foundation, 'interfaceVersion', 1
+    );
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+      FROM private.catalog_dedup_candidates d
+     WHERE d.supplier_catalog_item_id = v_offer.supplier_catalog_item_id
+       AND d.decision IN ('pending','manual_review')
+  ) THEN
+    RETURN jsonb_build_object(
+      'eligible', false, 'reason', 'catalog_identity_unresolved',
+      'canonicalProductId', v_product.id, 'supplierOfferId', v_offer.id,
+      'supplierId', v_supplier.id, 'interfaceVersion', 1
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'eligible', true,
+    'reason', 'supplier_catalog_ready',
+    'canonicalProductId', v_product.id,
+    'supplierOfferId', v_offer.id,
+    'supplierId', v_supplier.id,
+    'interfaceVersion', 1
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.server_supplier_catalog_decision_v1(uuid, uuid, text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_catalog_decision_v1(uuid, uuid, text) TO service_role;
+
+COMMENT ON TABLE private.canonical_products IS
+  'Phase E internal canonical product identity. It is not customer-facing product copy and does not authorize trading.';
+COMMENT ON TABLE private.supplier_offers IS
+  'Provider-neutral link between one supplier catalog identity and one canonical product. Price/stock are intentionally deferred to later phases.';
+COMMENT ON FUNCTION public.server_supplier_catalog_decision_v1(uuid, uuid, text) IS
+  'Fail-closed Phase E identity/readiness decision. Phase C controls and later commerce gates remain authoritative.';

--- a/supabase/619_canonical_supplier_data.sql
+++ b/supabase/619_canonical_supplier_data.sql
@@ -193,7 +193,7 @@ CREATE TABLE IF NOT EXISTS private.supplier_offers (
     OR (
       approved_by IS NOT NULL
       AND approved_at IS NOT NULL
-      AND jsonb_object_length(identity_evidence) > 0
+      AND identity_evidence <> '{}'::jsonb
     )
   )
 );

--- a/supabase/620_canonical_supplier_data_guards.sql
+++ b/supabase/620_canonical_supplier_data_guards.sql
@@ -1,0 +1,498 @@
+-- 620_canonical_supplier_data_guards.sql
+-- Phase E — hard guards and admin mutation boundary for canonical supplier data.
+-- Runtime commerce remains disabled unless later Phase C control decisions allow it.
+
+CREATE OR REPLACE FUNCTION private.phase_e_actor_is_active_admin(p_actor_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+      FROM public.users u
+     WHERE u.id = p_actor_id
+       AND u.role = 'admin'
+       AND u."isActive" = true
+  );
+$$;
+
+REVOKE ALL ON FUNCTION private.phase_e_actor_is_active_admin(uuid) FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION private.normalize_catalog_identifier_v1(p_type text, p_value text)
+RETURNS text
+LANGUAGE plpgsql
+IMMUTABLE
+SET search_path TO ''
+AS $$
+DECLARE
+  v_type text := lower(BTRIM(COALESCE(p_type, '')));
+  v_value text := BTRIM(COALESCE(p_value, ''));
+  v_result text;
+BEGIN
+  IF v_value = '' THEN
+    RAISE EXCEPTION 'catalog identifier value is required';
+  END IF;
+
+  IF v_type IN ('gtin','ean','upc','isbn') THEN
+    v_result := regexp_replace(v_value, '[[:space:]-]', '', 'g');
+    IF v_result !~ '^[0-9]{8,14}$' THEN
+      RAISE EXCEPTION 'numeric catalog identifier is invalid';
+    END IF;
+    RETURN v_result;
+  END IF;
+
+  v_result := lower(regexp_replace(v_value, '[[:space:]]+', ' ', 'g'));
+  IF length(v_result) > 256 THEN
+    RAISE EXCEPTION 'catalog identifier is too long';
+  END IF;
+  RETURN v_result;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.normalize_catalog_identifier_v1(text, text) FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION private.guard_verified_canonical_identifier_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+BEGIN
+  IF OLD.verification_status = 'verified' AND (
+    NEW.canonical_product_id IS DISTINCT FROM OLD.canonical_product_id
+    OR NEW.identifier_type IS DISTINCT FROM OLD.identifier_type
+    OR NEW.identifier_namespace IS DISTINCT FROM OLD.identifier_namespace
+    OR NEW.normalized_value IS DISTINCT FROM OLD.normalized_value
+  ) THEN
+    RAISE EXCEPTION 'verified canonical identifier identity is immutable';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_guard_verified_canonical_identifier_v1 ON private.canonical_product_identifiers;
+CREATE TRIGGER trg_guard_verified_canonical_identifier_v1
+BEFORE UPDATE ON private.canonical_product_identifiers
+FOR EACH ROW EXECUTE FUNCTION private.guard_verified_canonical_identifier_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_catalog_item_identity_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+BEGIN
+  IF NEW.supplier_id IS DISTINCT FROM OLD.supplier_id
+     OR NEW.external_product_ref IS DISTINCT FROM OLD.external_product_ref
+     OR NEW.external_variant_ref IS DISTINCT FROM OLD.external_variant_ref THEN
+    RAISE EXCEPTION 'supplier catalog external identity is immutable';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_guard_supplier_catalog_item_identity_v1 ON private.supplier_catalog_items;
+CREATE TRIGGER trg_guard_supplier_catalog_item_identity_v1
+BEFORE UPDATE ON private.supplier_catalog_items
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_catalog_item_identity_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_offer_consistency_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+DECLARE
+  v_item_supplier uuid;
+  v_item_status text;
+  v_product_status text;
+BEGIN
+  SELECT supplier_id, status INTO v_item_supplier, v_item_status
+    FROM private.supplier_catalog_items
+   WHERE id = NEW.supplier_catalog_item_id;
+
+  IF NOT FOUND OR v_item_supplier <> NEW.supplier_id THEN
+    RAISE EXCEPTION 'supplier offer must reference a catalog item owned by the same supplier';
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.status = 'approved' AND (
+    NEW.supplier_id IS DISTINCT FROM OLD.supplier_id
+    OR NEW.supplier_catalog_item_id IS DISTINCT FROM OLD.supplier_catalog_item_id
+    OR NEW.canonical_product_id IS DISTINCT FROM OLD.canonical_product_id
+    OR NEW.external_offer_ref IS DISTINCT FROM OLD.external_offer_ref
+    OR NEW.territory IS DISTINCT FROM OLD.territory
+  ) THEN
+    RAISE EXCEPTION 'approved supplier offer identity is immutable';
+  END IF;
+
+  IF NEW.status = 'approved' THEN
+    SELECT status INTO v_product_status
+      FROM private.canonical_products
+     WHERE id = NEW.canonical_product_id;
+
+    IF NOT FOUND OR v_product_status <> 'active' THEN
+      RAISE EXCEPTION 'approved supplier offer requires an active canonical product';
+    END IF;
+
+    IF v_item_status IN ('restricted','retired') THEN
+      RAISE EXCEPTION 'restricted or retired supplier catalog item cannot back an approved offer';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM private.catalog_dedup_candidates d
+       WHERE d.supplier_catalog_item_id = NEW.supplier_catalog_item_id
+         AND d.decision IN ('pending','manual_review')
+    ) THEN
+      RAISE EXCEPTION 'unresolved catalog deduplication blocks offer approval';
+    END IF;
+
+    IF NEW.identity_method = 'verified_identifier' AND NOT EXISTS (
+      SELECT 1
+        FROM private.supplier_catalog_identifiers si
+        JOIN private.canonical_product_identifiers ci
+          ON ci.identifier_type = si.identifier_type
+         AND ci.identifier_namespace = si.identifier_namespace
+         AND ci.normalized_value = si.normalized_value
+       WHERE si.supplier_catalog_item_id = NEW.supplier_catalog_item_id
+         AND si.verification_status = 'verified'
+         AND ci.canonical_product_id = NEW.canonical_product_id
+         AND ci.verification_status = 'verified'
+    ) THEN
+      RAISE EXCEPTION 'verified identifier offer link requires matching verified catalog identity';
+    END IF;
+
+    IF NEW.identity_method = 'dedup_resolution' AND NOT EXISTS (
+      SELECT 1 FROM private.catalog_dedup_candidates d
+       WHERE d.supplier_catalog_item_id = NEW.supplier_catalog_item_id
+         AND d.candidate_canonical_product_id = NEW.canonical_product_id
+         AND d.decision = 'same_product'
+    ) THEN
+      RAISE EXCEPTION 'dedup resolution offer link requires a same-product resolution';
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_guard_supplier_offer_consistency_v1 ON private.supplier_offers;
+CREATE TRIGGER trg_guard_supplier_offer_consistency_v1
+BEFORE INSERT OR UPDATE ON private.supplier_offers
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_offer_consistency_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_catalog_dedup_resolution_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE' AND OLD.decision IN ('same_product','different_product') AND (
+    NEW.decision IS DISTINCT FROM OLD.decision
+    OR NEW.supplier_catalog_item_id IS DISTINCT FROM OLD.supplier_catalog_item_id
+    OR NEW.candidate_canonical_product_id IS DISTINCT FROM OLD.candidate_canonical_product_id
+  ) THEN
+    RAISE EXCEPTION 'terminal catalog dedup resolution is immutable';
+  END IF;
+
+  IF NEW.decision IN ('same_product','different_product')
+     AND jsonb_object_length(NEW.evidence) = 0 THEN
+    RAISE EXCEPTION 'terminal catalog dedup resolution requires evidence';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_guard_catalog_dedup_resolution_v1 ON private.catalog_dedup_candidates;
+CREATE TRIGGER trg_guard_catalog_dedup_resolution_v1
+BEFORE INSERT OR UPDATE ON private.catalog_dedup_candidates
+FOR EACH ROW EXECUTE FUNCTION private.guard_catalog_dedup_resolution_v1();
+
+CREATE OR REPLACE FUNCTION public.server_mutate_supplier_catalog_v1(
+  p_actor_id uuid,
+  p_action text,
+  p_payload jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_action text := lower(BTRIM(COALESCE(p_action, '')));
+  v_payload jsonb := COALESCE(p_payload, '{}'::jsonb);
+  v_product private.canonical_products%ROWTYPE;
+  v_item private.supplier_catalog_items%ROWTYPE;
+  v_offer private.supplier_offers%ROWTYPE;
+  v_dedup private.catalog_dedup_candidates%ROWTYPE;
+  v_identifier private.canonical_product_identifiers%ROWTYPE;
+  v_supplier_id uuid;
+  v_product_id uuid;
+  v_item_id uuid;
+  v_status text;
+  v_type text;
+  v_namespace text;
+  v_normalized text;
+  v_now timestamptz := now();
+BEGIN
+  IF NOT private.phase_e_actor_is_active_admin(p_actor_id) THEN
+    RAISE EXCEPTION 'active admin authority is required';
+  END IF;
+
+  IF jsonb_typeof(v_payload) <> 'object' THEN
+    RAISE EXCEPTION 'payload must be an object';
+  END IF;
+
+  IF v_action = 'upsert_canonical_product' THEN
+    IF NULLIF(BTRIM(v_payload->>'catalogKey'), '') IS NULL OR NULLIF(BTRIM(v_payload->>'workingLabel'), '') IS NULL THEN
+      RAISE EXCEPTION 'catalogKey and workingLabel are required';
+    END IF;
+
+    SELECT * INTO v_product
+      FROM private.canonical_products
+     WHERE catalog_key = lower(BTRIM(v_payload->>'catalogKey'));
+
+    IF FOUND THEN
+      IF v_product.status IN ('active','restricted','retired') THEN
+        RAISE EXCEPTION 'active, restricted or retired canonical identity cannot be rewritten by upsert';
+      END IF;
+      UPDATE private.canonical_products
+         SET working_label = BTRIM(v_payload->>'workingLabel'),
+             product_kind = COALESCE(NULLIF(BTRIM(v_payload->>'productKind'), ''), product_kind),
+             identity_reason = COALESCE(NULLIF(BTRIM(v_payload->>'reason'), ''), identity_reason),
+             identity_version = identity_version + 1,
+             updated_at = v_now
+       WHERE id = v_product.id
+       RETURNING * INTO v_product;
+    ELSE
+      INSERT INTO private.canonical_products(
+        catalog_key, working_label, product_kind, identity_reason, created_by
+      ) VALUES (
+        lower(BTRIM(v_payload->>'catalogKey')),
+        BTRIM(v_payload->>'workingLabel'),
+        COALESCE(NULLIF(BTRIM(v_payload->>'productKind'), ''), 'physical_good'),
+        COALESCE(NULLIF(BTRIM(v_payload->>'reason'), ''), 'Canonical identity created'),
+        p_actor_id
+      ) RETURNING * INTO v_product;
+    END IF;
+
+    INSERT INTO private.catalog_identity_audit(entity_type, entity_id, actor_id, action, new_version, evidence)
+    VALUES ('canonical_product', v_product.id, p_actor_id, v_action, v_product.identity_version, v_payload);
+    RETURN jsonb_build_object('ok', true, 'canonicalProductId', v_product.id, 'identityVersion', v_product.identity_version);
+  END IF;
+
+  IF v_action = 'set_canonical_status' THEN
+    v_product_id := NULLIF(v_payload->>'canonicalProductId', '')::uuid;
+    v_status := lower(BTRIM(COALESCE(v_payload->>'status', '')));
+    SELECT * INTO v_product FROM private.canonical_products WHERE id = v_product_id FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'canonical product not found'; END IF;
+
+    IF v_status NOT IN ('draft','review','active','restricted','retired') THEN
+      RAISE EXCEPTION 'invalid canonical product status';
+    END IF;
+    IF v_product.status = 'retired' AND v_status <> 'retired' THEN
+      RAISE EXCEPTION 'retired canonical product cannot be reactivated';
+    END IF;
+    IF v_status = 'active' AND NOT EXISTS (
+      SELECT 1 FROM private.canonical_product_identifiers i
+       WHERE i.canonical_product_id = v_product.id AND i.verification_status = 'verified'
+    ) THEN
+      RAISE EXCEPTION 'active canonical product requires verified catalog identity';
+    END IF;
+
+    UPDATE private.canonical_products
+       SET status = v_status,
+           identity_reason = COALESCE(NULLIF(BTRIM(v_payload->>'reason'), ''), identity_reason),
+           identity_version = identity_version + 1,
+           reviewed_by = CASE WHEN v_status IN ('active','restricted','retired') THEN p_actor_id ELSE reviewed_by END,
+           reviewed_at = CASE WHEN v_status IN ('active','restricted','retired') THEN v_now ELSE reviewed_at END,
+           updated_at = v_now
+     WHERE id = v_product.id
+     RETURNING * INTO v_product;
+
+    INSERT INTO private.catalog_identity_audit(entity_type, entity_id, actor_id, action, previous_version, new_version, evidence)
+    VALUES ('canonical_product', v_product.id, p_actor_id, v_action, v_product.identity_version - 1, v_product.identity_version, v_payload);
+    RETURN jsonb_build_object('ok', true, 'canonicalProductId', v_product.id, 'status', v_product.status, 'identityVersion', v_product.identity_version);
+  END IF;
+
+  IF v_action = 'attach_identifier' THEN
+    v_product_id := NULLIF(v_payload->>'canonicalProductId', '')::uuid;
+    v_type := lower(BTRIM(COALESCE(v_payload->>'identifierType', '')));
+    v_namespace := lower(BTRIM(COALESCE(v_payload->>'identifierNamespace', CASE WHEN v_type IN ('gtin','ean','upc','isbn') THEN 'global' ELSE '' END)));
+    v_normalized := private.normalize_catalog_identifier_v1(v_type, v_payload->>'value');
+    v_status := lower(BTRIM(COALESCE(v_payload->>'verificationStatus', 'unverified')));
+
+    IF v_type NOT IN ('gtin','ean','upc','isbn','mpn','brand_mpn','internal') THEN RAISE EXCEPTION 'invalid identifier type'; END IF;
+    IF NULLIF(v_namespace, '') IS NULL THEN RAISE EXCEPTION 'identifier namespace is required'; END IF;
+    IF v_status NOT IN ('unverified','verified','rejected','stale') THEN RAISE EXCEPTION 'invalid identifier verification status'; END IF;
+    IF v_status = 'verified' AND NULLIF(BTRIM(v_payload->>'sourceRef'), '') IS NULL THEN RAISE EXCEPTION 'verified identifier sourceRef is required'; END IF;
+    IF NOT EXISTS (SELECT 1 FROM private.canonical_products WHERE id = v_product_id) THEN RAISE EXCEPTION 'canonical product not found'; END IF;
+
+    INSERT INTO private.canonical_product_identifiers(
+      canonical_product_id, identifier_type, identifier_namespace, raw_value, normalized_value,
+      verification_status, source_ref, evidence_hash, verified_by, verified_at
+    ) VALUES (
+      v_product_id, v_type, v_namespace, BTRIM(v_payload->>'value'), v_normalized,
+      v_status, NULLIF(BTRIM(v_payload->>'sourceRef'), ''), NULLIF(BTRIM(v_payload->>'evidenceHash'), ''),
+      CASE WHEN v_status = 'verified' THEN p_actor_id ELSE NULL END,
+      CASE WHEN v_status = 'verified' THEN v_now ELSE NULL END
+    )
+    ON CONFLICT (canonical_product_id, identifier_type, identifier_namespace, normalized_value)
+    DO UPDATE SET
+      verification_status = EXCLUDED.verification_status,
+      source_ref = EXCLUDED.source_ref,
+      evidence_hash = EXCLUDED.evidence_hash,
+      verified_by = EXCLUDED.verified_by,
+      verified_at = EXCLUDED.verified_at
+    RETURNING * INTO v_identifier;
+
+    INSERT INTO private.catalog_identity_audit(entity_type, entity_id, actor_id, action, evidence)
+    VALUES ('canonical_identifier', v_identifier.id, p_actor_id, v_action, v_payload);
+    RETURN jsonb_build_object('ok', true, 'identifierId', v_identifier.id, 'normalizedValue', v_identifier.normalized_value);
+  END IF;
+
+  IF v_action = 'upsert_supplier_catalog_item' THEN
+    v_supplier_id := NULLIF(v_payload->>'supplierId', '')::uuid;
+    IF NOT EXISTS (SELECT 1 FROM private.supplier_foundation_suppliers s WHERE s.id = v_supplier_id AND s.lifecycle_status <> 'banned') THEN
+      RAISE EXCEPTION 'supplier not found or banned';
+    END IF;
+    IF NULLIF(BTRIM(v_payload->>'externalProductRef'), '') IS NULL
+       OR NULLIF(BTRIM(v_payload->>'sourceRef'), '') IS NULL
+       OR NULLIF(BTRIM(v_payload->>'rawIdentityHash'), '') IS NULL THEN
+      RAISE EXCEPTION 'externalProductRef, sourceRef and rawIdentityHash are required';
+    END IF;
+
+    SELECT * INTO v_item
+      FROM private.supplier_catalog_items
+     WHERE supplier_id = v_supplier_id
+       AND external_product_ref = BTRIM(v_payload->>'externalProductRef')
+       AND COALESCE(external_variant_ref, '') = COALESCE(NULLIF(BTRIM(v_payload->>'externalVariantRef'), ''), '');
+
+    IF FOUND THEN
+      UPDATE private.supplier_catalog_items
+         SET source_ref = BTRIM(v_payload->>'sourceRef'),
+             source_observed_at = COALESCE(NULLIF(v_payload->>'sourceObservedAt', '')::timestamptz, v_now),
+             raw_identity_hash = BTRIM(v_payload->>'rawIdentityHash'),
+             raw_snapshot_ref = NULLIF(BTRIM(v_payload->>'rawSnapshotRef'), ''),
+             status = CASE WHEN status = 'retired' THEN status ELSE 'identity_review' END,
+             updated_at = v_now
+       WHERE id = v_item.id
+       RETURNING * INTO v_item;
+    ELSE
+      INSERT INTO private.supplier_catalog_items(
+        supplier_id, external_product_ref, external_variant_ref, source_ref,
+        source_observed_at, raw_identity_hash, raw_snapshot_ref, status
+      ) VALUES (
+        v_supplier_id, BTRIM(v_payload->>'externalProductRef'), NULLIF(BTRIM(v_payload->>'externalVariantRef'), ''),
+        BTRIM(v_payload->>'sourceRef'), COALESCE(NULLIF(v_payload->>'sourceObservedAt', '')::timestamptz, v_now),
+        BTRIM(v_payload->>'rawIdentityHash'), NULLIF(BTRIM(v_payload->>'rawSnapshotRef'), ''), 'captured'
+      ) RETURNING * INTO v_item;
+    END IF;
+
+    INSERT INTO private.catalog_identity_audit(entity_type, entity_id, actor_id, action, evidence)
+    VALUES ('supplier_catalog_item', v_item.id, p_actor_id, v_action, v_payload);
+    RETURN jsonb_build_object('ok', true, 'supplierCatalogItemId', v_item.id, 'status', v_item.status);
+  END IF;
+
+  IF v_action = 'link_supplier_offer' THEN
+    v_item_id := NULLIF(v_payload->>'supplierCatalogItemId', '')::uuid;
+    v_product_id := NULLIF(v_payload->>'canonicalProductId', '')::uuid;
+    SELECT * INTO v_item FROM private.supplier_catalog_items WHERE id = v_item_id;
+    IF NOT FOUND THEN RAISE EXCEPTION 'supplier catalog item not found'; END IF;
+    IF NOT EXISTS (SELECT 1 FROM private.canonical_products WHERE id = v_product_id) THEN RAISE EXCEPTION 'canonical product not found'; END IF;
+
+    v_status := lower(BTRIM(COALESCE(v_payload->>'status', 'candidate')));
+    INSERT INTO private.supplier_offers(
+      offer_key, supplier_id, supplier_catalog_item_id, canonical_product_id, external_offer_ref,
+      territory, status, identity_method, identity_confidence, identity_evidence,
+      linked_by, linked_at, approved_by, approved_at
+    ) VALUES (
+      lower(BTRIM(v_payload->>'offerKey')), v_item.supplier_id, v_item.id, v_product_id,
+      BTRIM(v_payload->>'externalOfferRef'), upper(BTRIM(COALESCE(v_payload->>'territory', 'GB'))),
+      v_status, lower(BTRIM(v_payload->>'identityMethod')),
+      NULLIF(v_payload->>'identityConfidence', '')::numeric,
+      COALESCE(v_payload->'identityEvidence', '{}'::jsonb),
+      p_actor_id, v_now,
+      CASE WHEN v_status = 'approved' THEN p_actor_id ELSE NULL END,
+      CASE WHEN v_status = 'approved' THEN v_now ELSE NULL END
+    )
+    ON CONFLICT (offer_key) DO UPDATE SET
+      status = EXCLUDED.status,
+      identity_method = EXCLUDED.identity_method,
+      identity_confidence = EXCLUDED.identity_confidence,
+      identity_evidence = EXCLUDED.identity_evidence,
+      approved_by = EXCLUDED.approved_by,
+      approved_at = EXCLUDED.approved_at,
+      updated_at = v_now
+    RETURNING * INTO v_offer;
+
+    UPDATE private.supplier_catalog_items SET status = 'linked', updated_at = v_now
+     WHERE id = v_item.id AND status IN ('captured','identity_review');
+
+    INSERT INTO private.catalog_identity_audit(entity_type, entity_id, actor_id, action, evidence)
+    VALUES ('supplier_offer', v_offer.id, p_actor_id, v_action, v_payload);
+    RETURN jsonb_build_object('ok', true, 'supplierOfferId', v_offer.id, 'status', v_offer.status);
+  END IF;
+
+  IF v_action = 'record_dedup_candidate' THEN
+    v_item_id := NULLIF(v_payload->>'supplierCatalogItemId', '')::uuid;
+    v_product_id := NULLIF(v_payload->>'candidateCanonicalProductId', '')::uuid;
+    IF NOT EXISTS (SELECT 1 FROM private.supplier_catalog_items WHERE id = v_item_id) THEN RAISE EXCEPTION 'supplier catalog item not found'; END IF;
+    IF NOT EXISTS (SELECT 1 FROM private.canonical_products WHERE id = v_product_id) THEN RAISE EXCEPTION 'canonical product not found'; END IF;
+    IF NULLIF(BTRIM(v_payload->>'candidateKey'), '') IS NULL THEN RAISE EXCEPTION 'candidateKey is required'; END IF;
+
+    INSERT INTO private.catalog_dedup_candidates(
+      supplier_catalog_item_id, candidate_canonical_product_id, candidate_key, score, evidence
+    ) VALUES (
+      v_item_id, v_product_id, BTRIM(v_payload->>'candidateKey'),
+      NULLIF(v_payload->>'score', '')::numeric, COALESCE(v_payload->'evidence', '{}'::jsonb)
+    )
+    ON CONFLICT (supplier_catalog_item_id, candidate_canonical_product_id)
+    DO UPDATE SET
+      candidate_key = EXCLUDED.candidate_key,
+      score = EXCLUDED.score,
+      evidence = EXCLUDED.evidence,
+      decision = CASE WHEN private.catalog_dedup_candidates.decision IN ('same_product','different_product') THEN private.catalog_dedup_candidates.decision ELSE 'pending' END,
+      updated_at = v_now
+    RETURNING * INTO v_dedup;
+
+    INSERT INTO private.catalog_identity_audit(entity_type, entity_id, actor_id, action, evidence)
+    VALUES ('dedup_candidate', v_dedup.id, p_actor_id, v_action, v_payload);
+    RETURN jsonb_build_object('ok', true, 'dedupCandidateId', v_dedup.id, 'decision', v_dedup.decision);
+  END IF;
+
+  IF v_action = 'resolve_dedup_candidate' THEN
+    v_status := lower(BTRIM(COALESCE(v_payload->>'decision', '')));
+    IF v_status NOT IN ('same_product','different_product','manual_review') THEN RAISE EXCEPTION 'invalid dedup decision'; END IF;
+    IF NULLIF(BTRIM(v_payload->>'reason'), '') IS NULL THEN RAISE EXCEPTION 'dedup resolution reason is required'; END IF;
+
+    SELECT * INTO v_dedup
+      FROM private.catalog_dedup_candidates
+     WHERE id = NULLIF(v_payload->>'dedupCandidateId', '')::uuid
+     FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'dedup candidate not found'; END IF;
+    IF v_dedup.decision IN ('same_product','different_product') THEN RAISE EXCEPTION 'terminal dedup resolution is immutable'; END IF;
+
+    UPDATE private.catalog_dedup_candidates
+       SET decision = v_status,
+           decision_reason = BTRIM(v_payload->>'reason'),
+           evidence = CASE WHEN v_payload ? 'evidence' THEN v_payload->'evidence' ELSE evidence END,
+           resolution_version = resolution_version + 1,
+           resolved_by = p_actor_id,
+           resolved_at = v_now,
+           updated_at = v_now
+     WHERE id = v_dedup.id
+     RETURNING * INTO v_dedup;
+
+    INSERT INTO private.catalog_identity_audit(entity_type, entity_id, actor_id, action, previous_version, new_version, evidence)
+    VALUES ('dedup_candidate', v_dedup.id, p_actor_id, v_action, v_dedup.resolution_version - 1, v_dedup.resolution_version, v_payload);
+    RETURN jsonb_build_object('ok', true, 'dedupCandidateId', v_dedup.id, 'decision', v_dedup.decision, 'resolutionVersion', v_dedup.resolution_version);
+  END IF;
+
+  RAISE EXCEPTION 'unsupported Supplier Catalog action';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.server_mutate_supplier_catalog_v1(uuid, text, jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_mutate_supplier_catalog_v1(uuid, text, jsonb) TO service_role;
+
+COMMENT ON FUNCTION public.server_mutate_supplier_catalog_v1(uuid, text, jsonb) IS
+  'Active-admin-only Phase E catalog identity mutation boundary. It does not enable Supplier Commerce runtime.';

--- a/supabase/621_canonical_supplier_data_integrity.sql
+++ b/supabase/621_canonical_supplier_data_integrity.sql
@@ -7,6 +7,31 @@ CREATE UNIQUE INDEX IF NOT EXISTS catalog_dedup_one_same_product_unique
   ON private.catalog_dedup_candidates(supplier_catalog_item_id)
   WHERE decision = 'same_product';
 
+-- Final portable definition: PostgreSQL exposes jsonb_array_length but not a
+-- jsonb_object_length helper. Empty-object comparison keeps this guard native.
+CREATE OR REPLACE FUNCTION private.guard_catalog_dedup_resolution_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE' AND OLD.decision IN ('same_product','different_product') AND (
+    NEW.decision IS DISTINCT FROM OLD.decision
+    OR NEW.supplier_catalog_item_id IS DISTINCT FROM OLD.supplier_catalog_item_id
+    OR NEW.candidate_canonical_product_id IS DISTINCT FROM OLD.candidate_canonical_product_id
+  ) THEN
+    RAISE EXCEPTION 'terminal catalog dedup resolution is immutable';
+  END IF;
+
+  IF NEW.decision IN ('same_product','different_product')
+     AND NEW.evidence = '{}'::jsonb THEN
+    RAISE EXCEPTION 'terminal catalog dedup resolution requires evidence';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
 CREATE OR REPLACE FUNCTION private.guard_supplier_offer_dedup_conflict_v1()
 RETURNS trigger
 LANGUAGE plpgsql

--- a/supabase/621_canonical_supplier_data_integrity.sql
+++ b/supabase/621_canonical_supplier_data_integrity.sql
@@ -1,0 +1,52 @@
+-- 621_canonical_supplier_data_integrity.sql
+-- Phase E integrity closure: a supplier catalog item can resolve to at most one
+-- canonical product as same_product, and an explicit different_product decision
+-- can never back an approved supplier offer.
+
+CREATE UNIQUE INDEX IF NOT EXISTS catalog_dedup_one_same_product_unique
+  ON private.catalog_dedup_candidates(supplier_catalog_item_id)
+  WHERE decision = 'same_product';
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_offer_dedup_conflict_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+BEGIN
+  IF NEW.status = 'approved' AND EXISTS (
+    SELECT 1
+      FROM private.catalog_dedup_candidates d
+     WHERE d.supplier_catalog_item_id = NEW.supplier_catalog_item_id
+       AND d.candidate_canonical_product_id = NEW.canonical_product_id
+       AND d.decision = 'different_product'
+  ) THEN
+    RAISE EXCEPTION 'different-product dedup resolution blocks supplier offer approval';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_guard_supplier_offer_dedup_conflict_v1 ON private.supplier_offers;
+CREATE TRIGGER trg_guard_supplier_offer_dedup_conflict_v1
+BEFORE INSERT OR UPDATE ON private.supplier_offers
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_offer_dedup_conflict_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_catalog_identifier_namespace_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+BEGIN
+  IF NULLIF(BTRIM(NEW.identifier_namespace), '') IS NULL THEN
+    RAISE EXCEPTION 'supplier catalog identifier namespace is required';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_guard_supplier_catalog_identifier_namespace_v1 ON private.supplier_catalog_identifiers;
+CREATE TRIGGER trg_guard_supplier_catalog_identifier_namespace_v1
+BEFORE INSERT OR UPDATE ON private.supplier_catalog_identifiers
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_catalog_identifier_namespace_v1();
+
+-- Phase E remains source-only and fail-closed. No control is enabled here.


### PR DESCRIPTION
Implements canonical Phase E — Canonical Supplier Data after Phase D PASS.

Scope:
- canonical product identity separated from supplier catalog identities and supplier offers
- namespace-aware catalog identifiers and deterministic normalization
- explicit catalog identity evidence
- deduplication candidates with evidence-backed resolution and no implicit merges
- approved-offer identity immutability and conflict guards
- supplier readiness reuse through Phase D; no parallel supplier truth
- private data model with service-role-only server decisions
- active-admin mutation boundary
- fail-closed supplier catalog decision
- Phase F import/normalisation explicitly deferred
- Supplier Commerce remains disabled/fail-closed under Phase C controls

PowerShell Branch Guard evidence at exact branch HEAD 0419d2a88544822df764ba2b6754d79921a8f6c7:
- Phase E focused tests: 13/13 PASS
- Phase C/D upstream control tests: 24/24 PASS
- TypeScript: PASS
- ESLint: PASS
- production build: PASS
- full suite: same 27 known baseline failures; Phase E adds no new failing test family
- isolated validation worktree clean

No unrelated UI changes. Migrations 619-621 are source changes only; this PR does not claim production DB deployment.