### PR TITLE
Phase F: Import and normalisation

### DIFF
--- a/netlify/functions/__tests__/supplier-import-runtime.test.ts
+++ b/netlify/functions/__tests__/supplier-import-runtime.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+import { mutateSupplierImport } from '../_shared/supplierImport';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const runtimeGuards = repo('supabase/624_supplier_import_runtime_guards.sql');
+const shared = repo('netlify/functions/_shared/supplierImport.ts');
+const adminApi = repo('netlify/functions/admin-supplier-import.ts');
+
+const ACTOR_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const BATCH_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+
+describe('Phase F runtime import closure', () => {
+  it('enforces the Phase C import kill switch before a batch can be created', () => {
+    expect(runtimeGuards).toContain("public.server_supplier_commerce_control_decision_v1(");
+    expect(runtimeGuards).toContain("'import'");
+    expect(runtimeGuards).toContain("'providerRef'");
+    expect(runtimeGuards).toContain("'supplierRef'");
+    expect(runtimeGuards).toContain('supplier import blocked by Phase C control');
+    expect(runtimeGuards).toContain('BEFORE INSERT ON private.supplier_import_batches');
+    expect(runtimeGuards).not.toContain('SET enabled = true');
+  });
+
+  it('makes normalized fact recording idempotent', () => {
+    expect(runtimeGuards).toContain('fact_idempotency_key text');
+    expect(runtimeGuards).toContain('normalized_product_fact_idempotency_unique');
+    expect(runtimeGuards).toContain('server_record_supplier_import_fact_v1');
+    expect(runtimeGuards).toContain('factIdempotencyKey is required');
+    expect(runtimeGuards).toContain('ON CONFLICT (import_item_id, fact_idempotency_key)');
+    expect(shared).toContain("action === 'record_normalized_fact'");
+    expect(shared).toContain("client.rpc('server_record_supplier_import_fact_v1'");
+  });
+
+  it('provides durable resumable checkpoints without rewriting terminal batches', () => {
+    expect(runtimeGuards).toContain('server_checkpoint_supplier_import_v1');
+    expect(runtimeGuards).toContain('last_checkpoint = v_checkpoint');
+    expect(runtimeGuards).toContain('resume_token = COALESCE');
+    expect(runtimeGuards).toContain("v_batch.status IN ('accepted','rejected','failed')");
+    expect(runtimeGuards).toContain('terminal import batch cannot be resumed');
+    expect(shared).toContain("'checkpoint_import_batch'");
+    expect(adminApi).toContain("'checkpoint_import_batch'");
+  });
+
+  it('routes fact writes through the dedicated idempotent server boundary', async () => {
+    const rpc = vi.fn(async () => ({ data: { ok: true, factId: 'fact-1', idempotent: true }, error: null }));
+    const client = { rpc } as unknown as SupabaseClient;
+
+    await expect(mutateSupplierImport(client, ACTOR_ID, 'record_normalized_fact', {
+      importItemId: BATCH_ID,
+      canonicalProductId: BATCH_ID,
+      factKey: 'material',
+      factValue: 'steel',
+      factIdempotencyKey: 'source:item:material:v1',
+      sourceClass: 'supplier_source',
+    })).resolves.toEqual({ ok: true, data: { ok: true, factId: 'fact-1', idempotent: true } });
+
+    expect(rpc).toHaveBeenCalledWith('server_record_supplier_import_fact_v1', {
+      p_actor_id: ACTOR_ID,
+      p_payload: expect.objectContaining({ factIdempotencyKey: 'source:item:material:v1' }),
+    });
+  });
+
+  it('routes checkpoints through the dedicated resumable server boundary', async () => {
+    const rpc = vi.fn(async () => ({ data: { ok: true, batchId: BATCH_ID, resumable: true }, error: null }));
+    const client = { rpc } as unknown as SupabaseClient;
+
+    await expect(mutateSupplierImport(client, ACTOR_ID, 'checkpoint_import_batch', {
+      batchId: BATCH_ID,
+      checkpoint: 'compliance_review',
+      resumeToken: 'page:42',
+    })).resolves.toEqual({ ok: true, data: { ok: true, batchId: BATCH_ID, resumable: true } });
+
+    expect(rpc).toHaveBeenCalledWith('server_checkpoint_supplier_import_v1', {
+      p_actor_id: ACTOR_ID,
+      p_batch_id: BATCH_ID,
+      p_checkpoint: 'compliance_review',
+      p_resume_token: 'page:42',
+    });
+  });
+
+  it('fails checkpoint validation closed before calling the DB', async () => {
+    const rpc = vi.fn();
+    const client = { rpc } as unknown as SupabaseClient;
+    await expect(mutateSupplierImport(client, ACTOR_ID, 'checkpoint_import_batch', {
+      batchId: 'not-a-uuid',
+      checkpoint: '',
+    })).resolves.toEqual({ ok: false, error: 'valid batchId and checkpoint are required' });
+    expect(rpc).not.toHaveBeenCalled();
+  });
+});

--- a/netlify/functions/__tests__/supplier-import.test.ts
+++ b/netlify/functions/__tests__/supplier-import.test.ts
@@ -1,0 +1,157 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SUPPLIER_IMPORT_INTERFACE_VERSION,
+  evaluateSupplierImport,
+} from '../_shared/supplierImport';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const migration = repo('supabase/622_supplier_import_normalisation.sql');
+const guards = repo('supabase/623_supplier_import_normalisation_guards.sql');
+const adminApi = repo('netlify/functions/admin-supplier-import.ts');
+
+const ITEM_ID = '11111111-1111-4111-8111-111111111111';
+const PRODUCT_ID = '22222222-2222-4222-8222-222222222222';
+
+describe('Phase F Supplier Import / Normalisation', () => {
+  it('implements the canonical import evidence stages without URL-to-publish bypass', () => {
+    expect(migration).toContain('private.supplier_import_batches');
+    expect(migration).toContain('private.supplier_import_items');
+    expect(migration).toContain('private.normalized_product_facts');
+    expect(migration).toContain('private.supplier_import_asset_rights');
+    expect(migration).toContain('private.supplier_import_compliance_reviews');
+    expect(migration).toContain('private.supplier_import_review_audit');
+    expect(migration).not.toMatch(/URL\s*[-=]>\s*PUBLISH/i);
+  });
+
+  it('makes import retry idempotent and resumable instead of duplicating products', () => {
+    expect(guards).toContain('idempotency_key text');
+    expect(guards).toContain('supplier_import_batch_idempotency_unique');
+    expect(guards).toContain('item_idempotency_key text');
+    expect(guards).toContain('supplier_import_item_idempotency_unique');
+    expect(guards).toContain('resume_token text');
+    expect(guards).toContain('last_checkpoint text');
+    expect(guards).toContain('ON CONFLICT (supplier_id, provider_key, idempotency_key)');
+    expect(guards).toContain('ON CONFLICT (batch_id, item_idempotency_key)');
+  });
+
+  it('enforces AI Facts Lock at schema, trigger and mutation boundaries', () => {
+    expect(migration).toContain("source_class IN ('supplier_source','verified_external_source','admin_asserted','ai_proposed')");
+    expect(migration).toContain("source_class <> 'ai_proposed'");
+    expect(guards).toContain('AI FACTS LOCK: AI proposal cannot become a verified fact');
+    expect(guards).toContain("NEW.source_class = 'ai_proposed'");
+    expect(guards).toContain('AI proposal requires model provenance');
+    expect(guards).toContain("v_fact.source_class = 'ai_proposed'");
+  });
+
+  it('keeps verified factual evidence immutable', () => {
+    expect(guards).toContain("OLD.review_status = 'verified'");
+    expect(guards).toContain('verified normalized fact evidence is immutable');
+    expect(guards).toContain('source_evidence_hash');
+  });
+
+  it('requires rights evidence before imported assets can clear review', () => {
+    expect(migration).toContain("rights_status IN ('unknown','verified','restricted','prohibited')");
+    expect(migration).toContain('rights_basis');
+    expect(migration).toContain('evidence_hash');
+    expect(guards).toContain('uncleared asset rights block import approval');
+    expect(guards).toContain("r.rights_status <> 'verified'");
+  });
+
+  it('requires a complete current GB compliance review before approval', () => {
+    for (const reviewClass of [
+      'product_safety', 'restricted_goods', 'claims', 'labelling', 'documentation', 'marketability',
+    ]) {
+      expect(migration).toContain(`'${reviewClass}'`);
+      expect(guards).toContain(`'${reviewClass}'`);
+    }
+    expect(guards).toContain('complete current GB compliance review is required before import approval');
+    expect(guards).toContain("c.status = 'approved'");
+    expect(guards).toContain('c.expires_at > now()');
+  });
+
+  it('requires verified non-AI facts and blocks pending/stale facts at approval', () => {
+    expect(guards).toContain('approved import item requires verified non-AI facts');
+    expect(guards).toContain("f.source_class <> 'ai_proposed'");
+    expect(guards).toContain("f.review_status IN ('pending','stale')");
+    expect(guards).toContain('pending or stale facts block import approval');
+  });
+
+  it('keeps terminal batch history immutable and audited', () => {
+    expect(guards).toContain("OLD.status IN ('accepted','rejected','failed')");
+    expect(guards).toContain('terminal import batch status is immutable');
+    expect(migration).toContain('private.supplier_import_review_audit');
+    expect(guards).toContain('INSERT INTO private.supplier_import_review_audit');
+  });
+
+  it('keeps all Phase F data private and exposes only service-role RPCs', () => {
+    for (const table of [
+      'supplier_import_batches', 'supplier_import_items', 'normalized_product_facts',
+      'supplier_import_asset_rights', 'supplier_import_compliance_reviews', 'supplier_import_review_audit',
+    ]) {
+      expect(migration).toContain(`REVOKE ALL ON TABLE private.${table} FROM PUBLIC, anon, authenticated, service_role`);
+    }
+    expect(migration).toContain('GRANT EXECUTE ON FUNCTION public.server_supplier_import_decision_v1(uuid, uuid) TO service_role');
+    expect(guards).toContain('GRANT EXECUTE ON FUNCTION public.server_mutate_supplier_import_v1(uuid, text, jsonb) TO service_role');
+  });
+
+  it('requires active-admin authority and rejects secret-bearing payloads', () => {
+    expect(guards).toContain("u.role = 'admin'");
+    expect(guards).toContain('u."isActive" = true');
+    expect(adminApi).toContain("authenticateActiveAccount(event, admin, ['admin'])");
+    expect(adminApi).toContain('password|secret|access[_-]?token');
+  });
+
+  it('does not smuggle Phase G economics or activate Supplier Commerce', () => {
+    expect(migration).toContain('Phase G commercial economics are intentionally deferred');
+    expect(migration).not.toMatch(/CREATE TABLE IF NOT EXISTS private\.(landed_cost|financial_ledger|pricing)/i);
+    expect(migration).not.toContain('SET enabled = true');
+    expect(guards).not.toContain('SET enabled = true');
+  });
+
+  it('fails closed when import readiness RPC is unavailable or malformed', async () => {
+    const rpc = vi.fn(async () => ({ data: { eligible: true }, error: null }));
+    const client = { rpc } as unknown as SupabaseClient;
+    await expect(evaluateSupplierImport(client, {
+      supplierCatalogItemId: ITEM_ID,
+      canonicalProductId: PRODUCT_ID,
+    })).resolves.toEqual({
+      eligible: false,
+      reason: 'supplier_import_unavailable',
+      interfaceVersion: SUPPLIER_IMPORT_INTERFACE_VERSION,
+    });
+
+    rpc.mockRejectedValueOnce(new Error('network unavailable'));
+    await expect(evaluateSupplierImport(client, {
+      supplierCatalogItemId: ITEM_ID,
+      canonicalProductId: PRODUCT_ID,
+    })).resolves.toEqual({
+      eligible: false,
+      reason: 'supplier_import_unavailable',
+      interfaceVersion: SUPPLIER_IMPORT_INTERFACE_VERSION,
+    });
+  });
+
+  it('accepts only structurally complete server readiness evidence', async () => {
+    const expected = {
+      eligible: true,
+      reason: 'supplier_import_ready',
+      supplierCatalogItemId: ITEM_ID,
+      canonicalProductId: PRODUCT_ID,
+      interfaceVersion: 1,
+    };
+    const rpc = vi.fn(async () => ({ data: expected, error: null }));
+    const client = { rpc } as unknown as SupabaseClient;
+
+    await expect(evaluateSupplierImport(client, {
+      supplierCatalogItemId: ITEM_ID,
+      canonicalProductId: PRODUCT_ID,
+    })).resolves.toEqual(expected);
+    expect(rpc).toHaveBeenCalledWith('server_supplier_import_decision_v1', {
+      p_supplier_catalog_item_id: ITEM_ID,
+      p_canonical_product_id: PRODUCT_ID,
+    });
+  });
+});

--- a/netlify/functions/_shared/supplierImport.ts
+++ b/netlify/functions/_shared/supplierImport.ts
@@ -9,7 +9,8 @@ export type SupplierImportAdminAction =
   | 'review_normalized_fact'
   | 'record_asset_rights'
   | 'record_compliance_review'
-  | 'set_import_item_status';
+  | 'set_import_item_status'
+  | 'checkpoint_import_batch';
 
 export interface SupplierImportDecision {
   eligible: boolean;
@@ -54,7 +55,34 @@ export async function mutateSupplierImport(
   payload: Record<string, unknown>,
 ): Promise<{ ok: true; data: unknown } | { ok: false; error: string }> {
   if (!UUID_RE.test(actorId)) return { ok: false, error: 'active admin authority is required' };
+
   try {
+    if (action === 'record_normalized_fact') {
+      const { data, error } = await client.rpc('server_record_supplier_import_fact_v1', {
+        p_actor_id: actorId,
+        p_payload: payload,
+      });
+      if (error) return { ok: false, error: error.message || 'supplier import fact mutation failed' };
+      return { ok: true, data };
+    }
+
+    if (action === 'checkpoint_import_batch') {
+      const batchId = typeof payload.batchId === 'string' ? payload.batchId : '';
+      const checkpoint = typeof payload.checkpoint === 'string' ? payload.checkpoint : '';
+      const resumeToken = typeof payload.resumeToken === 'string' ? payload.resumeToken : null;
+      if (!UUID_RE.test(batchId) || !checkpoint.trim()) {
+        return { ok: false, error: 'valid batchId and checkpoint are required' };
+      }
+      const { data, error } = await client.rpc('server_checkpoint_supplier_import_v1', {
+        p_actor_id: actorId,
+        p_batch_id: batchId,
+        p_checkpoint: checkpoint,
+        p_resume_token: resumeToken,
+      });
+      if (error) return { ok: false, error: error.message || 'supplier import checkpoint failed' };
+      return { ok: true, data };
+    }
+
     const { data, error } = await client.rpc('server_mutate_supplier_import_v1', {
       p_actor_id: actorId,
       p_action: action,

--- a/netlify/functions/_shared/supplierImport.ts
+++ b/netlify/functions/_shared/supplierImport.ts
@@ -1,0 +1,68 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const SUPPLIER_IMPORT_INTERFACE_VERSION = 1 as const;
+
+export type SupplierImportAdminAction =
+  | 'create_import_batch'
+  | 'record_import_item'
+  | 'record_normalized_fact'
+  | 'review_normalized_fact'
+  | 'record_asset_rights'
+  | 'record_compliance_review'
+  | 'set_import_item_status';
+
+export interface SupplierImportDecision {
+  eligible: boolean;
+  reason: string;
+  supplierCatalogItemId?: string;
+  canonicalProductId?: string;
+  interfaceVersion: typeof SUPPLIER_IMPORT_INTERFACE_VERSION;
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export async function evaluateSupplierImport(
+  client: SupabaseClient,
+  input: { supplierCatalogItemId: string; canonicalProductId: string },
+): Promise<SupplierImportDecision> {
+  if (!UUID_RE.test(input.supplierCatalogItemId) || !UUID_RE.test(input.canonicalProductId)) {
+    return { eligible: false, reason: 'invalid_import_identity', interfaceVersion: SUPPLIER_IMPORT_INTERFACE_VERSION };
+  }
+
+  try {
+    const { data, error } = await client.rpc('server_supplier_import_decision_v1', {
+      p_supplier_catalog_item_id: input.supplierCatalogItemId,
+      p_canonical_product_id: input.canonicalProductId,
+    });
+    if (error || !data || typeof data !== 'object' || Array.isArray(data)) {
+      return { eligible: false, reason: 'supplier_import_unavailable', interfaceVersion: SUPPLIER_IMPORT_INTERFACE_VERSION };
+    }
+    const candidate = data as Record<string, unknown>;
+    if (typeof candidate.eligible !== 'boolean' || typeof candidate.reason !== 'string' || candidate.interfaceVersion !== 1) {
+      return { eligible: false, reason: 'supplier_import_unavailable', interfaceVersion: SUPPLIER_IMPORT_INTERFACE_VERSION };
+    }
+    return candidate as unknown as SupplierImportDecision;
+  } catch {
+    return { eligible: false, reason: 'supplier_import_unavailable', interfaceVersion: SUPPLIER_IMPORT_INTERFACE_VERSION };
+  }
+}
+
+export async function mutateSupplierImport(
+  client: SupabaseClient,
+  actorId: string,
+  action: SupplierImportAdminAction,
+  payload: Record<string, unknown>,
+): Promise<{ ok: true; data: unknown } | { ok: false; error: string }> {
+  if (!UUID_RE.test(actorId)) return { ok: false, error: 'active admin authority is required' };
+  try {
+    const { data, error } = await client.rpc('server_mutate_supplier_import_v1', {
+      p_actor_id: actorId,
+      p_action: action,
+      p_payload: payload,
+    });
+    if (error) return { ok: false, error: error.message || 'supplier import mutation failed' };
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : 'supplier import mutation failed' };
+  }
+}

--- a/netlify/functions/admin-supplier-import.ts
+++ b/netlify/functions/admin-supplier-import.ts
@@ -13,6 +13,7 @@ const ACTIONS = new Set<SupplierImportAdminAction>([
   'record_asset_rights',
   'record_compliance_review',
   'set_import_item_status',
+  'checkpoint_import_batch',
 ]);
 
 interface Body {

--- a/netlify/functions/admin-supplier-import.ts
+++ b/netlify/functions/admin-supplier-import.ts
@@ -1,0 +1,69 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { jsonResponse, optionsResponse } from './_shared/http';
+import { mutateSupplierImport, type SupplierImportAdminAction } from './_shared/supplierImport';
+
+const METHODS = 'POST, OPTIONS';
+const ACTIONS = new Set<SupplierImportAdminAction>([
+  'create_import_batch',
+  'record_import_item',
+  'record_normalized_fact',
+  'review_normalized_fact',
+  'record_asset_rights',
+  'record_compliance_review',
+  'set_import_item_status',
+]);
+
+interface Body {
+  action?: string;
+  payload?: Record<string, unknown>;
+}
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return optionsResponse(METHODS);
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' }, METHODS);
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    return jsonResponse(500, { error: 'Server configuration error' }, METHODS);
+  }
+
+  const admin = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+  const auth = await authenticateActiveAccount(event, admin, ['admin']);
+  if (!auth.ok) return jsonResponse(auth.status, { error: 'Unauthorized' }, METHODS);
+
+  let body: Body;
+  try {
+    body = JSON.parse(event.body || '{}') as Body;
+  } catch {
+    return jsonResponse(400, { error: 'Invalid JSON body' }, METHODS);
+  }
+
+  const action = typeof body.action === 'string' ? body.action.trim() as SupplierImportAdminAction : null;
+  const payload = body.payload;
+  if (!action || !ACTIONS.has(action) || !payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return jsonResponse(400, { error: 'A supported action and object payload are required' }, METHODS);
+  }
+
+  // Phase F accepts evidence references/hashes, never provider credentials or payment secrets.
+  const serialized = JSON.stringify(payload);
+  if (/password|secret|access[_-]?token|refresh[_-]?token|api[_-]?key|card(number)?/i.test(serialized)) {
+    return jsonResponse(400, { error: 'Secrets or payment credentials are not accepted in Supplier Import payloads' }, METHODS);
+  }
+
+  const result = await mutateSupplierImport(admin, auth.actor.id, action, payload);
+  if (!result.ok) {
+    const validation = /required|invalid|incomplete|must|not found|blocked|cannot|lock|evidence|supplier/i.test(result.error);
+    const forbidden = /authority|required admin|permission/i.test(result.error);
+    console.error('admin-supplier-import: mutation failed:', result.error);
+    return jsonResponse(validation ? 400 : forbidden ? 403 : 500, {
+      error: validation ? result.error : forbidden ? 'Unauthorized' : 'Unable to update Supplier Import',
+    }, METHODS);
+  }
+
+  return jsonResponse(200, { ok: true, result: result.data }, METHODS);
+};

--- a/supabase/622_supplier_import_normalisation.sql
+++ b/supabase/622_supplier_import_normalisation.sql
@@ -1,0 +1,282 @@
+-- 622_supplier_import_normalisation.sql
+-- Phase F — Import / Normalisation: AI Facts Lock, Rights, Compliance, Review.
+-- Supplier Commerce remains fail-closed under Phase C controls.
+-- Phase G commercial economics are intentionally deferred.
+
+CREATE SCHEMA IF NOT EXISTS private;
+
+CREATE TABLE IF NOT EXISTS private.supplier_import_batches (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  supplier_id uuid NOT NULL REFERENCES private.supplier_foundation_suppliers(id) ON DELETE RESTRICT,
+  provider_key text NOT NULL,
+  source_ref text NOT NULL,
+  source_observed_at timestamptz NOT NULL,
+  adapter_version text NOT NULL,
+  status text NOT NULL DEFAULT 'received',
+  correlation_id uuid NOT NULL DEFAULT gen_random_uuid(),
+  created_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  completed_at timestamptz,
+  CONSTRAINT supplier_import_batch_status_check CHECK (
+    status IN ('received','normalising','review','accepted','rejected','failed')
+  ),
+  CONSTRAINT supplier_import_batch_source_check CHECK (
+    NULLIF(BTRIM(provider_key), '') IS NOT NULL
+    AND NULLIF(BTRIM(source_ref), '') IS NOT NULL
+    AND NULLIF(BTRIM(adapter_version), '') IS NOT NULL
+  )
+);
+
+CREATE INDEX IF NOT EXISTS supplier_import_batches_supplier_idx
+  ON private.supplier_import_batches(supplier_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS private.supplier_import_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  batch_id uuid NOT NULL REFERENCES private.supplier_import_batches(id) ON DELETE RESTRICT,
+  supplier_catalog_item_id uuid NOT NULL REFERENCES private.supplier_catalog_items(id) ON DELETE RESTRICT,
+  canonical_product_id uuid REFERENCES private.canonical_products(id) ON DELETE RESTRICT,
+  source_payload_ref text NOT NULL,
+  source_payload_hash text NOT NULL,
+  source_observed_at timestamptz NOT NULL,
+  status text NOT NULL DEFAULT 'captured',
+  review_reason text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_import_item_status_check CHECK (
+    status IN ('captured','normalised','review','approved','restricted','rejected')
+  ),
+  CONSTRAINT supplier_import_item_source_check CHECK (
+    NULLIF(BTRIM(source_payload_ref), '') IS NOT NULL
+    AND NULLIF(BTRIM(source_payload_hash), '') IS NOT NULL
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_import_item_unique
+  ON private.supplier_import_items(batch_id, supplier_catalog_item_id);
+CREATE INDEX IF NOT EXISTS supplier_import_item_review_idx
+  ON private.supplier_import_items(status, updated_at DESC);
+
+CREATE TABLE IF NOT EXISTS private.normalized_product_facts (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  import_item_id uuid NOT NULL REFERENCES private.supplier_import_items(id) ON DELETE RESTRICT,
+  canonical_product_id uuid NOT NULL REFERENCES private.canonical_products(id) ON DELETE RESTRICT,
+  fact_key text NOT NULL,
+  fact_value jsonb NOT NULL,
+  source_class text NOT NULL,
+  source_ref text,
+  source_evidence_hash text,
+  ai_model_ref text,
+  confidence numeric(6,5) CHECK (confidence IS NULL OR confidence BETWEEN 0 AND 1),
+  review_status text NOT NULL DEFAULT 'pending',
+  review_reason text,
+  reviewed_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  reviewed_at timestamptz,
+  fact_version integer NOT NULL DEFAULT 1 CHECK (fact_version > 0),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT normalized_fact_key_check CHECK (
+    fact_key = lower(BTRIM(fact_key)) AND fact_key ~ '^[a-z0-9][a-z0-9._-]{1,127}$'
+  ),
+  CONSTRAINT normalized_fact_source_class_check CHECK (
+    source_class IN ('supplier_source','verified_external_source','admin_asserted','ai_proposed')
+  ),
+  CONSTRAINT normalized_fact_review_status_check CHECK (
+    review_status IN ('pending','verified','rejected','stale')
+  ),
+  CONSTRAINT normalized_fact_verified_evidence_check CHECK (
+    review_status <> 'verified'
+    OR (
+      reviewed_by IS NOT NULL
+      AND reviewed_at IS NOT NULL
+      AND NULLIF(BTRIM(source_ref), '') IS NOT NULL
+      AND NULLIF(BTRIM(source_evidence_hash), '') IS NOT NULL
+      AND source_class <> 'ai_proposed'
+    )
+  ),
+  CONSTRAINT normalized_fact_ai_lock_check CHECK (
+    source_class <> 'ai_proposed'
+    OR review_status <> 'verified'
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS normalized_product_fact_unique
+  ON private.normalized_product_facts(import_item_id, fact_key, fact_version);
+CREATE INDEX IF NOT EXISTS normalized_product_fact_lookup_idx
+  ON private.normalized_product_facts(canonical_product_id, fact_key, review_status);
+
+CREATE TABLE IF NOT EXISTS private.supplier_import_asset_rights (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  import_item_id uuid NOT NULL REFERENCES private.supplier_import_items(id) ON DELETE RESTRICT,
+  asset_ref text NOT NULL,
+  asset_type text NOT NULL,
+  source_ref text NOT NULL,
+  rights_status text NOT NULL DEFAULT 'unknown',
+  rights_basis text,
+  evidence_hash text,
+  reviewed_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  reviewed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_import_asset_type_check CHECK (
+    asset_type IN ('image','video','document','copy','specification')
+  ),
+  CONSTRAINT supplier_import_asset_rights_status_check CHECK (
+    rights_status IN ('unknown','verified','restricted','prohibited')
+  ),
+  CONSTRAINT supplier_import_asset_verified_check CHECK (
+    rights_status <> 'verified'
+    OR (
+      NULLIF(BTRIM(rights_basis), '') IS NOT NULL
+      AND NULLIF(BTRIM(evidence_hash), '') IS NOT NULL
+      AND reviewed_by IS NOT NULL
+      AND reviewed_at IS NOT NULL
+    )
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_import_asset_rights_unique
+  ON private.supplier_import_asset_rights(import_item_id, asset_ref);
+
+CREATE TABLE IF NOT EXISTS private.supplier_import_compliance_reviews (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  import_item_id uuid NOT NULL REFERENCES private.supplier_import_items(id) ON DELETE RESTRICT,
+  territory text NOT NULL DEFAULT 'GB',
+  review_class text NOT NULL,
+  status text NOT NULL DEFAULT 'pending',
+  evidence_refs jsonb NOT NULL DEFAULT '[]'::jsonb,
+  decision_reason text,
+  reviewed_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  reviewed_at timestamptz,
+  expires_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_import_compliance_territory_check CHECK (
+    territory = upper(BTRIM(territory)) AND territory ~ '^[A-Z]{2}$'
+  ),
+  CONSTRAINT supplier_import_compliance_class_check CHECK (
+    review_class IN ('product_safety','restricted_goods','claims','labelling','documentation','marketability')
+  ),
+  CONSTRAINT supplier_import_compliance_status_check CHECK (
+    status IN ('pending','approved','manual_review','prohibited','stale')
+  ),
+  CONSTRAINT supplier_import_compliance_evidence_check CHECK (jsonb_typeof(evidence_refs) = 'array'),
+  CONSTRAINT supplier_import_compliance_approved_check CHECK (
+    status <> 'approved'
+    OR (
+      reviewed_by IS NOT NULL
+      AND reviewed_at IS NOT NULL
+      AND jsonb_array_length(evidence_refs) > 0
+    )
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_import_compliance_unique
+  ON private.supplier_import_compliance_reviews(import_item_id, territory, review_class);
+
+CREATE TABLE IF NOT EXISTS private.supplier_import_review_audit (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  import_item_id uuid NOT NULL REFERENCES private.supplier_import_items(id) ON DELETE RESTRICT,
+  actor_id uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  action text NOT NULL,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_import_review_audit_evidence_check CHECK (jsonb_typeof(evidence) = 'object')
+);
+
+REVOKE ALL ON TABLE private.supplier_import_batches FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_import_items FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.normalized_product_facts FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_import_asset_rights FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_import_compliance_reviews FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_import_review_audit FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.server_supplier_import_decision_v1(
+  p_supplier_catalog_item_id uuid,
+  p_canonical_product_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_item private.supplier_import_items%ROWTYPE;
+BEGIN
+  SELECT * INTO v_item
+    FROM private.supplier_import_items
+   WHERE supplier_catalog_item_id = p_supplier_catalog_item_id
+     AND canonical_product_id = p_canonical_product_id
+   ORDER BY created_at DESC
+   LIMIT 1;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'import_item_not_found', 'interfaceVersion', 1);
+  END IF;
+
+  IF v_item.status <> 'approved' THEN
+    RETURN jsonb_build_object(
+      'eligible', false, 'reason', 'import_item_not_approved',
+      'supplierCatalogItemId', p_supplier_catalog_item_id,
+      'canonicalProductId', p_canonical_product_id,
+      'interfaceVersion', 1
+    );
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM private.normalized_product_facts f
+     WHERE f.import_item_id = v_item.id
+       AND f.source_class = 'ai_proposed'
+       AND f.review_status = 'verified'
+  ) THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'ai_fact_lock_violation', 'interfaceVersion', 1);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM private.normalized_product_facts f
+     WHERE f.import_item_id = v_item.id
+       AND f.review_status IN ('pending','stale')
+  ) THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'fact_review_incomplete', 'interfaceVersion', 1);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM private.supplier_import_asset_rights r
+     WHERE r.import_item_id = v_item.id
+       AND r.rights_status IN ('unknown','restricted','prohibited')
+  ) THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'asset_rights_not_clear', 'interfaceVersion', 1);
+  END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM private.supplier_import_compliance_reviews c
+     WHERE c.import_item_id = v_item.id
+       AND (
+         c.status <> 'approved'
+         OR (c.expires_at IS NOT NULL AND c.expires_at <= now())
+       )
+  ) THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'import_compliance_not_approved', 'interfaceVersion', 1);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM private.normalized_product_facts f
+     WHERE f.import_item_id = v_item.id AND f.review_status = 'verified'
+  ) THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'verified_facts_missing', 'interfaceVersion', 1);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'eligible', true,
+    'reason', 'supplier_import_ready',
+    'supplierCatalogItemId', p_supplier_catalog_item_id,
+    'canonicalProductId', p_canonical_product_id,
+    'interfaceVersion', 1
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.server_supplier_import_decision_v1(uuid, uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_import_decision_v1(uuid, uuid) TO service_role;
+
+COMMENT ON TABLE private.normalized_product_facts IS
+  'Phase F factual normalisation evidence. AI proposals are suggestions only and can never become verified facts without non-AI source evidence.';
+COMMENT ON FUNCTION public.server_supplier_import_decision_v1(uuid, uuid) IS
+  'Fail-closed Phase F import/normalisation readiness decision. Does not enable Supplier Commerce or Phase G economics.';

--- a/supabase/623_supplier_import_normalisation_guards.sql
+++ b/supabase/623_supplier_import_normalisation_guards.sql
@@ -1,0 +1,432 @@
+-- 623_supplier_import_normalisation_guards.sql
+-- Phase F hard guards + active-admin mutation boundary.
+-- Import is auditable, resumable and idempotent. AI proposals never become facts.
+
+CREATE OR REPLACE FUNCTION private.phase_f_actor_is_active_admin(p_actor_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.users u
+     WHERE u.id = p_actor_id
+       AND u.role = 'admin'
+       AND u."isActive" = true
+  );
+$$;
+REVOKE ALL ON FUNCTION private.phase_f_actor_is_active_admin(uuid) FROM PUBLIC, anon, authenticated, service_role;
+
+ALTER TABLE private.supplier_import_batches
+  ADD COLUMN IF NOT EXISTS idempotency_key text,
+  ADD COLUMN IF NOT EXISTS resume_token text,
+  ADD COLUMN IF NOT EXISTS last_checkpoint text,
+  ADD COLUMN IF NOT EXISTS updated_at timestamptz NOT NULL DEFAULT now();
+
+UPDATE private.supplier_import_batches
+   SET idempotency_key = COALESCE(idempotency_key, 'legacy:' || id::text)
+ WHERE idempotency_key IS NULL;
+ALTER TABLE private.supplier_import_batches ALTER COLUMN idempotency_key SET NOT NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_import_batch_idempotency_unique
+  ON private.supplier_import_batches(supplier_id, provider_key, idempotency_key);
+
+ALTER TABLE private.supplier_import_items
+  ADD COLUMN IF NOT EXISTS item_idempotency_key text;
+UPDATE private.supplier_import_items
+   SET item_idempotency_key = COALESCE(item_idempotency_key, 'legacy:' || id::text)
+ WHERE item_idempotency_key IS NULL;
+ALTER TABLE private.supplier_import_items ALTER COLUMN item_idempotency_key SET NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_import_item_idempotency_unique
+  ON private.supplier_import_items(batch_id, item_idempotency_key);
+
+CREATE OR REPLACE FUNCTION private.guard_normalized_product_fact_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+DECLARE
+  v_item_product uuid;
+BEGIN
+  SELECT canonical_product_id INTO v_item_product
+    FROM private.supplier_import_items
+   WHERE id = NEW.import_item_id;
+
+  IF NOT FOUND OR v_item_product IS NULL OR v_item_product <> NEW.canonical_product_id THEN
+    RAISE EXCEPTION 'normalized fact canonical identity must match import item';
+  END IF;
+
+  IF NEW.source_class = 'ai_proposed' THEN
+    IF NEW.review_status = 'verified' THEN
+      RAISE EXCEPTION 'AI FACTS LOCK: AI proposal cannot become a verified fact';
+    END IF;
+    IF NULLIF(BTRIM(NEW.ai_model_ref), '') IS NULL THEN
+      RAISE EXCEPTION 'AI proposal requires model provenance';
+    END IF;
+  END IF;
+
+  IF TG_OP = 'UPDATE' AND OLD.review_status = 'verified' AND (
+    NEW.fact_key IS DISTINCT FROM OLD.fact_key
+    OR NEW.fact_value IS DISTINCT FROM OLD.fact_value
+    OR NEW.source_class IS DISTINCT FROM OLD.source_class
+    OR NEW.source_ref IS DISTINCT FROM OLD.source_ref
+    OR NEW.source_evidence_hash IS DISTINCT FROM OLD.source_evidence_hash
+  ) THEN
+    RAISE EXCEPTION 'verified normalized fact evidence is immutable';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_normalized_product_fact_v1 ON private.normalized_product_facts;
+CREATE TRIGGER trg_guard_normalized_product_fact_v1
+BEFORE INSERT OR UPDATE ON private.normalized_product_facts
+FOR EACH ROW EXECUTE FUNCTION private.guard_normalized_product_fact_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_import_item_approval_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+DECLARE
+  v_required text;
+BEGIN
+  IF NEW.status = 'approved' THEN
+    IF NEW.canonical_product_id IS NULL THEN
+      RAISE EXCEPTION 'approved import item requires canonical product mapping';
+    END IF;
+
+    IF NOT EXISTS (
+      SELECT 1 FROM private.normalized_product_facts f
+       WHERE f.import_item_id = NEW.id
+         AND f.review_status = 'verified'
+         AND f.source_class <> 'ai_proposed'
+    ) THEN
+      RAISE EXCEPTION 'approved import item requires verified non-AI facts';
+    END IF;
+
+    IF EXISTS (
+      SELECT 1 FROM private.normalized_product_facts f
+       WHERE f.import_item_id = NEW.id
+         AND f.review_status IN ('pending','stale')
+    ) THEN
+      RAISE EXCEPTION 'pending or stale facts block import approval';
+    END IF;
+
+    FOREACH v_required IN ARRAY ARRAY[
+      'product_safety','restricted_goods','claims','labelling','documentation','marketability'
+    ]::text[] LOOP
+      IF NOT EXISTS (
+        SELECT 1 FROM private.supplier_import_compliance_reviews c
+         WHERE c.import_item_id = NEW.id
+           AND c.territory = 'GB'
+           AND c.review_class = v_required
+           AND c.status = 'approved'
+           AND (c.expires_at IS NULL OR c.expires_at > now())
+      ) THEN
+        RAISE EXCEPTION 'complete current GB compliance review is required before import approval';
+      END IF;
+    END LOOP;
+
+    IF EXISTS (
+      SELECT 1 FROM private.supplier_import_asset_rights r
+       WHERE r.import_item_id = NEW.id
+         AND r.rights_status <> 'verified'
+    ) THEN
+      RAISE EXCEPTION 'uncleared asset rights block import approval';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_import_item_approval_v1 ON private.supplier_import_items;
+CREATE TRIGGER trg_guard_import_item_approval_v1
+BEFORE INSERT OR UPDATE ON private.supplier_import_items
+FOR EACH ROW EXECUTE FUNCTION private.guard_import_item_approval_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_import_batch_terminal_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+BEGIN
+  IF TG_OP = 'UPDATE' AND OLD.status IN ('accepted','rejected','failed')
+     AND NEW.status IS DISTINCT FROM OLD.status THEN
+    RAISE EXCEPTION 'terminal import batch status is immutable; resume through a new idempotent batch attempt';
+  END IF;
+  IF NEW.status IN ('accepted','rejected','failed') AND NEW.completed_at IS NULL THEN
+    NEW.completed_at := now();
+  END IF;
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_import_batch_terminal_v1 ON private.supplier_import_batches;
+CREATE TRIGGER trg_guard_import_batch_terminal_v1
+BEFORE UPDATE ON private.supplier_import_batches
+FOR EACH ROW EXECUTE FUNCTION private.guard_import_batch_terminal_v1();
+
+CREATE OR REPLACE FUNCTION public.server_mutate_supplier_import_v1(
+  p_actor_id uuid,
+  p_action text,
+  p_payload jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_action text := lower(BTRIM(COALESCE(p_action, '')));
+  v_payload jsonb := COALESCE(p_payload, '{}'::jsonb);
+  v_batch private.supplier_import_batches%ROWTYPE;
+  v_item private.supplier_import_items%ROWTYPE;
+  v_fact private.normalized_product_facts%ROWTYPE;
+  v_supplier_id uuid;
+  v_batch_id uuid;
+  v_item_id uuid;
+  v_product_id uuid;
+  v_status text;
+  v_source_class text;
+  v_now timestamptz := now();
+BEGIN
+  IF NOT private.phase_f_actor_is_active_admin(p_actor_id) THEN
+    RAISE EXCEPTION 'active admin authority is required';
+  END IF;
+  IF jsonb_typeof(v_payload) <> 'object' THEN RAISE EXCEPTION 'payload must be an object'; END IF;
+
+  IF v_action = 'create_import_batch' THEN
+    v_supplier_id := NULLIF(v_payload->>'supplierId','')::uuid;
+    IF NOT EXISTS (
+      SELECT 1 FROM private.supplier_foundation_suppliers s
+       WHERE s.id = v_supplier_id AND s.lifecycle_status = 'approved'
+    ) THEN RAISE EXCEPTION 'approved supplier is required'; END IF;
+    IF NULLIF(BTRIM(v_payload->>'providerKey'),'') IS NULL
+       OR NULLIF(BTRIM(v_payload->>'sourceRef'),'') IS NULL
+       OR NULLIF(BTRIM(v_payload->>'adapterVersion'),'') IS NULL
+       OR NULLIF(BTRIM(v_payload->>'idempotencyKey'),'') IS NULL THEN
+      RAISE EXCEPTION 'providerKey, sourceRef, adapterVersion and idempotencyKey are required';
+    END IF;
+
+    INSERT INTO private.supplier_import_batches(
+      supplier_id, provider_key, source_ref, source_observed_at, adapter_version,
+      idempotency_key, resume_token, last_checkpoint, created_by
+    ) VALUES (
+      v_supplier_id, BTRIM(v_payload->>'providerKey'), BTRIM(v_payload->>'sourceRef'),
+      COALESCE(NULLIF(v_payload->>'sourceObservedAt','')::timestamptz, v_now),
+      BTRIM(v_payload->>'adapterVersion'), BTRIM(v_payload->>'idempotencyKey'),
+      NULLIF(BTRIM(v_payload->>'resumeToken'),''), 'received', p_actor_id
+    )
+    ON CONFLICT (supplier_id, provider_key, idempotency_key)
+    DO UPDATE SET resume_token = COALESCE(EXCLUDED.resume_token, private.supplier_import_batches.resume_token),
+                  updated_at = v_now
+    RETURNING * INTO v_batch;
+    RETURN jsonb_build_object('ok', true, 'batchId', v_batch.id, 'status', v_batch.status, 'idempotent', true);
+  END IF;
+
+  IF v_action = 'record_import_item' THEN
+    v_batch_id := NULLIF(v_payload->>'batchId','')::uuid;
+    IF NULLIF(BTRIM(v_payload->>'itemIdempotencyKey'),'') IS NULL
+       OR NULLIF(BTRIM(v_payload->>'sourcePayloadRef'),'') IS NULL
+       OR NULLIF(BTRIM(v_payload->>'sourcePayloadHash'),'') IS NULL THEN
+      RAISE EXCEPTION 'itemIdempotencyKey, sourcePayloadRef and sourcePayloadHash are required';
+    END IF;
+    IF NOT EXISTS (SELECT 1 FROM private.supplier_import_batches b WHERE b.id = v_batch_id AND b.status NOT IN ('accepted','rejected','failed')) THEN
+      RAISE EXCEPTION 'open import batch is required';
+    END IF;
+
+    INSERT INTO private.supplier_import_items(
+      batch_id, supplier_catalog_item_id, canonical_product_id, source_payload_ref,
+      source_payload_hash, source_observed_at, item_idempotency_key
+    ) VALUES (
+      v_batch_id, NULLIF(v_payload->>'supplierCatalogItemId','')::uuid,
+      NULLIF(v_payload->>'canonicalProductId','')::uuid,
+      BTRIM(v_payload->>'sourcePayloadRef'), BTRIM(v_payload->>'sourcePayloadHash'),
+      COALESCE(NULLIF(v_payload->>'sourceObservedAt','')::timestamptz, v_now),
+      BTRIM(v_payload->>'itemIdempotencyKey')
+    )
+    ON CONFLICT (batch_id, item_idempotency_key)
+    DO UPDATE SET updated_at = v_now
+    RETURNING * INTO v_item;
+    RETURN jsonb_build_object('ok', true, 'importItemId', v_item.id, 'status', v_item.status, 'idempotent', true);
+  END IF;
+
+  IF v_action = 'record_normalized_fact' THEN
+    v_item_id := NULLIF(v_payload->>'importItemId','')::uuid;
+    v_product_id := NULLIF(v_payload->>'canonicalProductId','')::uuid;
+    v_source_class := lower(BTRIM(COALESCE(v_payload->>'sourceClass','')));
+    IF v_source_class NOT IN ('supplier_source','verified_external_source','admin_asserted','ai_proposed') THEN
+      RAISE EXCEPTION 'invalid fact source class';
+    END IF;
+    IF NULLIF(BTRIM(v_payload->>'factKey'),'') IS NULL OR NOT (v_payload ? 'factValue') THEN
+      RAISE EXCEPTION 'factKey and factValue are required';
+    END IF;
+    INSERT INTO private.normalized_product_facts(
+      import_item_id, canonical_product_id, fact_key, fact_value, source_class,
+      source_ref, source_evidence_hash, ai_model_ref, confidence, review_status
+    ) VALUES (
+      v_item_id, v_product_id, lower(BTRIM(v_payload->>'factKey')), v_payload->'factValue', v_source_class,
+      NULLIF(BTRIM(v_payload->>'sourceRef'),''), NULLIF(BTRIM(v_payload->>'sourceEvidenceHash'),''),
+      NULLIF(BTRIM(v_payload->>'aiModelRef'),''), NULLIF(v_payload->>'confidence','')::numeric,
+      'pending'
+    ) RETURNING * INTO v_fact;
+    INSERT INTO private.supplier_import_review_audit(import_item_id, actor_id, action, evidence)
+    VALUES (v_item_id, p_actor_id, v_action, v_payload);
+    RETURN jsonb_build_object('ok', true, 'factId', v_fact.id, 'reviewStatus', v_fact.review_status);
+  END IF;
+
+  IF v_action = 'review_normalized_fact' THEN
+    SELECT * INTO v_fact FROM private.normalized_product_facts
+     WHERE id = NULLIF(v_payload->>'factId','')::uuid FOR UPDATE;
+    IF NOT FOUND THEN RAISE EXCEPTION 'normalized fact not found'; END IF;
+    v_status := lower(BTRIM(COALESCE(v_payload->>'status','')));
+    IF v_status NOT IN ('verified','rejected','stale') THEN RAISE EXCEPTION 'invalid fact review status'; END IF;
+    IF v_status = 'verified' AND v_fact.source_class = 'ai_proposed' THEN
+      RAISE EXCEPTION 'AI FACTS LOCK: AI proposal cannot become a verified fact';
+    END IF;
+    IF v_status = 'verified' AND (
+      NULLIF(BTRIM(v_payload->>'sourceRef'),'') IS NULL OR NULLIF(BTRIM(v_payload->>'sourceEvidenceHash'),'') IS NULL
+    ) THEN RAISE EXCEPTION 'verified fact requires non-AI evidence source and hash'; END IF;
+
+    UPDATE private.normalized_product_facts
+       SET review_status = v_status,
+           source_ref = CASE WHEN v_status = 'verified' THEN BTRIM(v_payload->>'sourceRef') ELSE source_ref END,
+           source_evidence_hash = CASE WHEN v_status = 'verified' THEN BTRIM(v_payload->>'sourceEvidenceHash') ELSE source_evidence_hash END,
+           review_reason = NULLIF(BTRIM(v_payload->>'reason'),''),
+           reviewed_by = p_actor_id, reviewed_at = v_now, updated_at = v_now
+     WHERE id = v_fact.id RETURNING * INTO v_fact;
+    INSERT INTO private.supplier_import_review_audit(import_item_id, actor_id, action, evidence)
+    VALUES (v_fact.import_item_id, p_actor_id, v_action, v_payload);
+    RETURN jsonb_build_object('ok', true, 'factId', v_fact.id, 'reviewStatus', v_fact.review_status);
+  END IF;
+
+  IF v_action = 'record_asset_rights' THEN
+    v_item_id := NULLIF(v_payload->>'importItemId','')::uuid;
+    v_status := lower(BTRIM(COALESCE(v_payload->>'rightsStatus','unknown')));
+    IF NULLIF(BTRIM(v_payload->>'assetRef'),'') IS NULL OR NULLIF(BTRIM(v_payload->>'sourceRef'),'') IS NULL THEN
+      RAISE EXCEPTION 'assetRef and sourceRef are required';
+    END IF;
+    IF v_status NOT IN ('unknown','verified','restricted','prohibited') THEN RAISE EXCEPTION 'invalid rights status'; END IF;
+    INSERT INTO private.supplier_import_asset_rights(
+      import_item_id, asset_ref, asset_type, source_ref, rights_status, rights_basis, evidence_hash, reviewed_by, reviewed_at
+    ) VALUES (
+      v_item_id, BTRIM(v_payload->>'assetRef'), lower(BTRIM(v_payload->>'assetType')), BTRIM(v_payload->>'sourceRef'),
+      v_status, NULLIF(BTRIM(v_payload->>'rightsBasis'),''), NULLIF(BTRIM(v_payload->>'evidenceHash'),''),
+      CASE WHEN v_status IN ('verified','restricted','prohibited') THEN p_actor_id ELSE NULL END,
+      CASE WHEN v_status IN ('verified','restricted','prohibited') THEN v_now ELSE NULL END
+    )
+    ON CONFLICT (import_item_id, asset_ref) DO UPDATE SET
+      rights_status = EXCLUDED.rights_status, rights_basis = EXCLUDED.rights_basis,
+      evidence_hash = EXCLUDED.evidence_hash, reviewed_by = EXCLUDED.reviewed_by, reviewed_at = EXCLUDED.reviewed_at;
+    INSERT INTO private.supplier_import_review_audit(import_item_id, actor_id, action, evidence)
+    VALUES (v_item_id, p_actor_id, v_action, v_payload);
+    RETURN jsonb_build_object('ok', true, 'importItemId', v_item_id, 'rightsStatus', v_status);
+  END IF;
+
+  IF v_action = 'record_compliance_review' THEN
+    v_item_id := NULLIF(v_payload->>'importItemId','')::uuid;
+    v_status := lower(BTRIM(COALESCE(v_payload->>'status','pending')));
+    IF v_status NOT IN ('pending','approved','manual_review','prohibited','stale') THEN RAISE EXCEPTION 'invalid compliance status'; END IF;
+    IF v_status = 'approved' AND (NOT (v_payload ? 'evidenceRefs') OR jsonb_array_length(v_payload->'evidenceRefs') = 0) THEN
+      RAISE EXCEPTION 'approved compliance review requires evidence';
+    END IF;
+    INSERT INTO private.supplier_import_compliance_reviews(
+      import_item_id, territory, review_class, status, evidence_refs, decision_reason,
+      reviewed_by, reviewed_at, expires_at
+    ) VALUES (
+      v_item_id, upper(BTRIM(COALESCE(v_payload->>'territory','GB'))), lower(BTRIM(v_payload->>'reviewClass')),
+      v_status, COALESCE(v_payload->'evidenceRefs','[]'::jsonb), NULLIF(BTRIM(v_payload->>'reason'),''),
+      CASE WHEN v_status <> 'pending' THEN p_actor_id ELSE NULL END,
+      CASE WHEN v_status <> 'pending' THEN v_now ELSE NULL END,
+      NULLIF(v_payload->>'expiresAt','')::timestamptz
+    )
+    ON CONFLICT (import_item_id, territory, review_class) DO UPDATE SET
+      status = EXCLUDED.status, evidence_refs = EXCLUDED.evidence_refs,
+      decision_reason = EXCLUDED.decision_reason, reviewed_by = EXCLUDED.reviewed_by,
+      reviewed_at = EXCLUDED.reviewed_at, expires_at = EXCLUDED.expires_at;
+    INSERT INTO private.supplier_import_review_audit(import_item_id, actor_id, action, evidence)
+    VALUES (v_item_id, p_actor_id, v_action, v_payload);
+    RETURN jsonb_build_object('ok', true, 'importItemId', v_item_id, 'complianceStatus', v_status);
+  END IF;
+
+  IF v_action = 'set_import_item_status' THEN
+    v_item_id := NULLIF(v_payload->>'importItemId','')::uuid;
+    v_status := lower(BTRIM(COALESCE(v_payload->>'status','')));
+    IF v_status NOT IN ('captured','normalised','review','approved','restricted','rejected') THEN
+      RAISE EXCEPTION 'invalid import item status';
+    END IF;
+    UPDATE private.supplier_import_items
+       SET status = v_status, review_reason = NULLIF(BTRIM(v_payload->>'reason'),''), updated_at = v_now
+     WHERE id = v_item_id RETURNING * INTO v_item;
+    IF NOT FOUND THEN RAISE EXCEPTION 'import item not found'; END IF;
+    INSERT INTO private.supplier_import_review_audit(import_item_id, actor_id, action, evidence)
+    VALUES (v_item_id, p_actor_id, v_action, v_payload);
+    RETURN jsonb_build_object('ok', true, 'importItemId', v_item.id, 'status', v_item.status);
+  END IF;
+
+  RAISE EXCEPTION 'unsupported supplier import action';
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.server_mutate_supplier_import_v1(uuid, text, jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_mutate_supplier_import_v1(uuid, text, jsonb) TO service_role;
+
+-- Strengthen readiness: compliance is required, not merely checked when present.
+CREATE OR REPLACE FUNCTION public.server_supplier_import_decision_v1(
+  p_supplier_catalog_item_id uuid,
+  p_canonical_product_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_item private.supplier_import_items%ROWTYPE;
+  v_required text;
+BEGIN
+  SELECT * INTO v_item FROM private.supplier_import_items
+   WHERE supplier_catalog_item_id = p_supplier_catalog_item_id
+     AND canonical_product_id = p_canonical_product_id
+   ORDER BY created_at DESC LIMIT 1;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible', false, 'reason', 'import_item_not_found', 'interfaceVersion', 1); END IF;
+  IF v_item.status <> 'approved' THEN RETURN jsonb_build_object('eligible', false, 'reason', 'import_item_not_approved', 'interfaceVersion', 1); END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM private.normalized_product_facts f
+     WHERE f.import_item_id = v_item.id AND f.review_status = 'verified' AND f.source_class <> 'ai_proposed'
+  ) THEN RETURN jsonb_build_object('eligible', false, 'reason', 'verified_facts_missing', 'interfaceVersion', 1); END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM private.normalized_product_facts f
+     WHERE f.import_item_id = v_item.id AND f.review_status IN ('pending','stale')
+  ) THEN RETURN jsonb_build_object('eligible', false, 'reason', 'fact_review_incomplete', 'interfaceVersion', 1); END IF;
+
+  IF EXISTS (
+    SELECT 1 FROM private.supplier_import_asset_rights r
+     WHERE r.import_item_id = v_item.id AND r.rights_status <> 'verified'
+  ) THEN RETURN jsonb_build_object('eligible', false, 'reason', 'asset_rights_not_clear', 'interfaceVersion', 1); END IF;
+
+  FOREACH v_required IN ARRAY ARRAY[
+    'product_safety','restricted_goods','claims','labelling','documentation','marketability'
+  ]::text[] LOOP
+    IF NOT EXISTS (
+      SELECT 1 FROM private.supplier_import_compliance_reviews c
+       WHERE c.import_item_id = v_item.id AND c.territory = 'GB'
+         AND c.review_class = v_required AND c.status = 'approved'
+         AND (c.expires_at IS NULL OR c.expires_at > now())
+    ) THEN RETURN jsonb_build_object('eligible', false, 'reason', 'import_compliance_incomplete', 'missingReviewClass', v_required, 'interfaceVersion', 1); END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'eligible', true, 'reason', 'supplier_import_ready',
+    'supplierCatalogItemId', p_supplier_catalog_item_id,
+    'canonicalProductId', p_canonical_product_id,
+    'interfaceVersion', 1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_supplier_import_decision_v1(uuid, uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_import_decision_v1(uuid, uuid) TO service_role;
+
+-- No Supplier Commerce control is enabled by Phase F.

--- a/supabase/624_supplier_import_runtime_guards.sql
+++ b/supabase/624_supplier_import_runtime_guards.sql
@@ -1,0 +1,156 @@
+-- 624_supplier_import_runtime_guards.sql
+-- Phase F closure: Phase C import control enforcement, durable checkpoints,
+-- and idempotent normalized-fact recording.
+
+ALTER TABLE private.normalized_product_facts
+  ADD COLUMN IF NOT EXISTS fact_idempotency_key text;
+UPDATE private.normalized_product_facts
+   SET fact_idempotency_key = COALESCE(fact_idempotency_key, 'legacy:' || id::text)
+ WHERE fact_idempotency_key IS NULL;
+ALTER TABLE private.normalized_product_facts ALTER COLUMN fact_idempotency_key SET NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS normalized_product_fact_idempotency_unique
+  ON private.normalized_product_facts(import_item_id, fact_idempotency_key);
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_import_control_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+DECLARE
+  v_control jsonb;
+BEGIN
+  v_control := public.server_supplier_commerce_control_decision_v1(
+    'import',
+    jsonb_build_object(
+      'providerRef', NEW.provider_key,
+      'supplierRef', NEW.supplier_id::text
+    )
+  );
+  IF COALESCE((v_control->>'enabled')::boolean, false) IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'supplier import blocked by Phase C control: %', COALESCE(v_control->>'reason', 'unknown');
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_guard_supplier_import_control_v1 ON private.supplier_import_batches;
+CREATE TRIGGER trg_guard_supplier_import_control_v1
+BEFORE INSERT ON private.supplier_import_batches
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_import_control_v1();
+
+CREATE OR REPLACE FUNCTION public.server_checkpoint_supplier_import_v1(
+  p_actor_id uuid,
+  p_batch_id uuid,
+  p_checkpoint text,
+  p_resume_token text DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_batch private.supplier_import_batches%ROWTYPE;
+  v_checkpoint text := NULLIF(BTRIM(p_checkpoint), '');
+BEGIN
+  IF NOT private.phase_f_actor_is_active_admin(p_actor_id) THEN
+    RAISE EXCEPTION 'active admin authority is required';
+  END IF;
+  IF v_checkpoint IS NULL THEN RAISE EXCEPTION 'checkpoint is required'; END IF;
+
+  SELECT * INTO v_batch FROM private.supplier_import_batches WHERE id = p_batch_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'import batch not found'; END IF;
+  IF v_batch.status IN ('accepted','rejected','failed') THEN
+    RAISE EXCEPTION 'terminal import batch cannot be resumed';
+  END IF;
+
+  UPDATE private.supplier_import_batches
+     SET last_checkpoint = v_checkpoint,
+         resume_token = COALESCE(NULLIF(BTRIM(p_resume_token), ''), resume_token),
+         updated_at = now()
+   WHERE id = p_batch_id
+   RETURNING * INTO v_batch;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'batchId', v_batch.id,
+    'lastCheckpoint', v_batch.last_checkpoint,
+    'resumable', true
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_checkpoint_supplier_import_v1(uuid, uuid, text, text)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_checkpoint_supplier_import_v1(uuid, uuid, text, text)
+  TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_record_supplier_import_fact_v1(
+  p_actor_id uuid,
+  p_payload jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_payload jsonb := COALESCE(p_payload, '{}'::jsonb);
+  v_item_id uuid;
+  v_product_id uuid;
+  v_source_class text;
+  v_key text;
+  v_fact private.normalized_product_facts%ROWTYPE;
+BEGIN
+  IF NOT private.phase_f_actor_is_active_admin(p_actor_id) THEN
+    RAISE EXCEPTION 'active admin authority is required';
+  END IF;
+  IF jsonb_typeof(v_payload) <> 'object' THEN RAISE EXCEPTION 'payload must be an object'; END IF;
+
+  v_item_id := NULLIF(v_payload->>'importItemId','')::uuid;
+  v_product_id := NULLIF(v_payload->>'canonicalProductId','')::uuid;
+  v_source_class := lower(BTRIM(COALESCE(v_payload->>'sourceClass','')));
+  v_key := NULLIF(BTRIM(v_payload->>'factIdempotencyKey'), '');
+
+  IF v_key IS NULL THEN RAISE EXCEPTION 'factIdempotencyKey is required'; END IF;
+  IF v_source_class NOT IN ('supplier_source','verified_external_source','admin_asserted','ai_proposed') THEN
+    RAISE EXCEPTION 'invalid fact source class';
+  END IF;
+  IF NULLIF(BTRIM(v_payload->>'factKey'),'') IS NULL OR NOT (v_payload ? 'factValue') THEN
+    RAISE EXCEPTION 'factKey and factValue are required';
+  END IF;
+
+  INSERT INTO private.normalized_product_facts(
+    import_item_id, canonical_product_id, fact_key, fact_value, source_class,
+    source_ref, source_evidence_hash, ai_model_ref, confidence, review_status,
+    fact_idempotency_key
+  ) VALUES (
+    v_item_id, v_product_id, lower(BTRIM(v_payload->>'factKey')), v_payload->'factValue', v_source_class,
+    NULLIF(BTRIM(v_payload->>'sourceRef'),''), NULLIF(BTRIM(v_payload->>'sourceEvidenceHash'),''),
+    NULLIF(BTRIM(v_payload->>'aiModelRef'),''), NULLIF(v_payload->>'confidence','')::numeric,
+    'pending', v_key
+  )
+  ON CONFLICT (import_item_id, fact_idempotency_key)
+  DO UPDATE SET updated_at = private.normalized_product_facts.updated_at
+  RETURNING * INTO v_fact;
+
+  INSERT INTO private.supplier_import_review_audit(import_item_id, actor_id, action, evidence)
+  VALUES (v_item_id, p_actor_id, 'record_normalized_fact', jsonb_build_object(
+    'factId', v_fact.id,
+    'factIdempotencyKey', v_key,
+    'idempotent', true
+  ));
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'factId', v_fact.id,
+    'reviewStatus', v_fact.review_status,
+    'idempotent', true
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_record_supplier_import_fact_v1(uuid, jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_record_supplier_import_fact_v1(uuid, jsonb)
+  TO service_role;
+
+-- Source-only migration. No Phase C controls are enabled here.

--- a/supabase/625_supplier_import_fact_idempotency_closure.sql
+++ b/supabase/625_supplier_import_fact_idempotency_closure.sql
@@ -1,0 +1,72 @@
+-- 625_supplier_import_fact_idempotency_closure.sql
+-- Portable final definition of the idempotent Phase F fact-recording boundary.
+
+CREATE OR REPLACE FUNCTION public.server_record_supplier_import_fact_v1(
+  p_actor_id uuid,
+  p_payload jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_payload jsonb := COALESCE(p_payload, '{}'::jsonb);
+  v_item_id uuid;
+  v_product_id uuid;
+  v_source_class text;
+  v_key text;
+  v_fact private.normalized_product_facts%ROWTYPE;
+BEGIN
+  IF NOT private.phase_f_actor_is_active_admin(p_actor_id) THEN
+    RAISE EXCEPTION 'active admin authority is required';
+  END IF;
+  IF jsonb_typeof(v_payload) <> 'object' THEN RAISE EXCEPTION 'payload must be an object'; END IF;
+
+  v_item_id := NULLIF(v_payload->>'importItemId','')::uuid;
+  v_product_id := NULLIF(v_payload->>'canonicalProductId','')::uuid;
+  v_source_class := lower(BTRIM(COALESCE(v_payload->>'sourceClass','')));
+  v_key := NULLIF(BTRIM(v_payload->>'factIdempotencyKey'), '');
+
+  IF v_key IS NULL THEN RAISE EXCEPTION 'factIdempotencyKey is required'; END IF;
+  IF v_source_class NOT IN ('supplier_source','verified_external_source','admin_asserted','ai_proposed') THEN
+    RAISE EXCEPTION 'invalid fact source class';
+  END IF;
+  IF NULLIF(BTRIM(v_payload->>'factKey'),'') IS NULL OR NOT (v_payload ? 'factValue') THEN
+    RAISE EXCEPTION 'factKey and factValue are required';
+  END IF;
+
+  INSERT INTO private.normalized_product_facts(
+    import_item_id, canonical_product_id, fact_key, fact_value, source_class,
+    source_ref, source_evidence_hash, ai_model_ref, confidence, review_status,
+    fact_idempotency_key
+  ) VALUES (
+    v_item_id, v_product_id, lower(BTRIM(v_payload->>'factKey')), v_payload->'factValue', v_source_class,
+    NULLIF(BTRIM(v_payload->>'sourceRef'),''), NULLIF(BTRIM(v_payload->>'sourceEvidenceHash'),''),
+    NULLIF(BTRIM(v_payload->>'aiModelRef'),''), NULLIF(v_payload->>'confidence','')::numeric,
+    'pending', v_key
+  )
+  ON CONFLICT (import_item_id, fact_idempotency_key)
+  DO UPDATE SET fact_idempotency_key = EXCLUDED.fact_idempotency_key
+  RETURNING * INTO v_fact;
+
+  INSERT INTO private.supplier_import_review_audit(import_item_id, actor_id, action, evidence)
+  VALUES (v_item_id, p_actor_id, 'record_normalized_fact', jsonb_build_object(
+    'factId', v_fact.id,
+    'factIdempotencyKey', v_key,
+    'idempotent', true
+  ));
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'factId', v_fact.id,
+    'reviewStatus', v_fact.review_status,
+    'idempotent', true
+  );
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.server_record_supplier_import_fact_v1(uuid, jsonb)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_record_supplier_import_fact_v1(uuid, jsonb)
+  TO service_role;


### PR DESCRIPTION
Implements canonical Phase F — Import / Normalisation after Phase E PASS.

Scope:
- auditable supplier import batches/items
- resumable and idempotent import controls
- canonical mapping onto Phase E supplier catalog + canonical products
- AI Facts Lock: AI proposals can never become verified facts
- evidence-backed normalized facts with immutability after verification
- asset/content rights review with fail-closed approval
- complete GB compliance review classes before approval
- active-admin-only mutation boundary
- Phase C import kill-switch enforced at server runtime
- secrets rejected from import mutation payloads
- runtime and migration guard tests
- Phase G commercial economics intentionally deferred

PowerShell Branch Guard evidence at exact tested HEAD 220d126c0d67157c360e31c96b790aa29375c425:
- Phase F supplier-import tests pass in the full suite, including supplier-import (13) and supplier-import-runtime (6)
- upstream Phase C/D/E gate command: PASS
- TypeScript: PASS
- ESLint: PASS
- production build: PASS
- full suite: same 27 known baseline failures; no new Phase F failing family
- isolated validation worktree clean

No unrelated UI changes. Migrations 622-625 are source changes only; this PR does not claim production DB deployment.