### PR TITLE
Phase G: Commercial Economics

### DIFF
--- a/netlify/functions/__tests__/supplier-economics.test.ts
+++ b/netlify/functions/__tests__/supplier-economics.test.ts
@@ -1,0 +1,143 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SUPPLIER_ECONOMICS_INTERFACE_VERSION,
+  evaluateSupplierEconomics,
+} from '../_shared/supplierEconomics';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const migration = repo('supabase/626_supplier_commercial_economics.sql');
+const guards = repo('supabase/627_supplier_commercial_economics_guards.sql');
+const adminApi = repo('netlify/functions/admin-supplier-economics.ts');
+
+const OFFER_ID = '11111111-1111-4111-8111-111111111111';
+const PRODUCT_ID = '22222222-2222-4222-8222-222222222222';
+
+describe('Phase G Commercial Economics', () => {
+  it('models landed cost, tax rule versions, pricing and canonical financial ledger separately', () => {
+    expect(migration).toContain('private.supplier_landed_cost_snapshots');
+    expect(migration).toContain('private.supplier_tax_rule_versions');
+    expect(migration).toContain('private.supplier_pricing_snapshots');
+    expect(migration).toContain('private.commerce_financial_ledger_entries');
+  });
+
+  it('keeps landed-cost components explicit instead of hiding them inside retail price', () => {
+    for (const field of ['supplier_product_cost','supplier_shipping_cost','carrier_cost','customs_duty','import_vat','fx_cost','other_cost','total_landed_cost']) {
+      expect(migration).toContain(field);
+    }
+    expect(migration).toContain('importer_of_record');
+    expect(migration).toContain('ship_from_country');
+  });
+
+  it('requires evidence-driven versioned tax rules and keeps NI fail-closed', () => {
+    expect(migration).toContain('version integer NOT NULL');
+    expect(migration).toContain('evidence_refs jsonb');
+    expect(migration).toContain('evidence_hash text');
+    expect(migration).toContain("commercial_mode IN ('marketplace_seller','loadify_supplier_fulfilled','loadify_direct')");
+    expect(migration).toContain("v_territory <> 'GB'");
+    expect(guards).toContain('NI requires a separately verified rule set');
+  });
+
+  it('enforces transparent buyer-price components and a margin guard', () => {
+    for (const field of ['merchandise_amount','mandatory_fee_amount','customer_shipping_charge','tax_amount','gross_customer_price']) {
+      expect(migration).toContain(field);
+    }
+    expect(migration).toContain('gross_customer_price = merchandise_amount + mandatory_fee_amount + customer_shipping_charge + tax_amount');
+    expect(migration).toContain('expected_contribution >= minimum_contribution');
+    expect(migration).toContain("'margin_guard_failed'");
+  });
+
+  it('makes the financial ledger append-only and uses correction events', () => {
+    expect(migration).toContain('financial ledger entries are append-only; record an adjustment or reversal event');
+    expect(migration).toContain('BEFORE UPDATE OR DELETE ON private.commerce_financial_ledger_entries');
+    expect(migration).toContain("'customer_refund'");
+    expect(migration).toContain("'supplier_recovery'");
+    expect(migration).toContain("'chargeback'");
+    expect(migration).toContain("'unrecovered_loss'");
+    expect(migration).toContain("'adjustment'");
+    expect(migration).toContain("'reversal'");
+  });
+
+  it('keeps verified tax, landed-cost and pricing history immutable by versioning', () => {
+    expect(guards).toContain('verified commercial evidence is immutable; create a new version/snapshot');
+    expect(guards).toContain('trg_guard_tax_rule_history_v1');
+    expect(guards).toContain('trg_guard_landed_cost_history_v1');
+    expect(guards).toContain('trg_guard_pricing_history_v1');
+  });
+
+  it('requires upstream catalog and import readiness before commercial eligibility', () => {
+    expect(migration).toContain('server_supplier_catalog_decision_v1');
+    expect(migration).toContain('server_supplier_import_decision_v1');
+    expect(migration).toContain("'catalog_not_ready'");
+    expect(migration).toContain("'import_not_ready'");
+  });
+
+  it('keeps all Phase G storage private and exposes only server RPC boundaries', () => {
+    for (const table of ['supplier_tax_rule_versions','supplier_landed_cost_snapshots','supplier_pricing_snapshots','commerce_financial_ledger_entries']) {
+      expect(migration).toContain(`REVOKE ALL ON TABLE private.${table} FROM PUBLIC, anon, authenticated, service_role`);
+    }
+    expect(migration).toContain('GRANT EXECUTE ON FUNCTION public.server_supplier_commercial_decision_v1');
+    expect(migration).toContain('GRANT EXECUTE ON FUNCTION public.server_append_financial_ledger_v1');
+    expect(guards).toContain('GRANT EXECUTE ON FUNCTION public.server_admin_supplier_economics_v1');
+  });
+
+  it('requires active-admin authority and rejects secret-bearing admin payloads', () => {
+    expect(guards).toContain("u.role = 'admin'");
+    expect(guards).toContain('u."isActive" = true');
+    expect(adminApi).toContain("authenticateActiveAccount(event, admin, ['admin'])");
+    expect(adminApi).toContain('password|secret|access[_-]?token');
+  });
+
+  it('does not enable Supplier Commerce while installing economics foundations', () => {
+    expect(migration).not.toContain('SET enabled = true');
+    expect(guards).not.toContain('SET enabled = true');
+    expect(guards).toContain('No control is enabled by Phase G');
+  });
+
+  it('fails closed when commercial-economics RPC evidence is unavailable or malformed', async () => {
+    const rpc = vi.fn(async () => ({ data: { eligible: true }, error: null }));
+    const client = { rpc } as unknown as SupabaseClient;
+    await expect(evaluateSupplierEconomics(client, {
+      supplierOfferId: OFFER_ID,
+      canonicalProductId: PRODUCT_ID,
+      commercialMode: 'loadify_supplier_fulfilled',
+    })).resolves.toEqual({
+      eligible: false,
+      reason: 'supplier_economics_unavailable',
+      interfaceVersion: SUPPLIER_ECONOMICS_INTERFACE_VERSION,
+    });
+  });
+
+  it('accepts only structurally complete server commercial evidence', async () => {
+    const expected = {
+      eligible: true,
+      reason: 'commercial_economics_ready',
+      supplierOfferId: OFFER_ID,
+      canonicalProductId: PRODUCT_ID,
+      pricingSnapshotId: '33333333-3333-4333-8333-333333333333',
+      landedCostSnapshotId: '44444444-4444-4444-8444-444444444444',
+      taxRuleVersionId: '55555555-5555-4555-8555-555555555555',
+      currency: 'GBP',
+      grossCustomerPrice: 19.99,
+      pricingPolicyVersion: 1,
+      interfaceVersion: 1,
+    };
+    const rpc = vi.fn(async () => ({ data: expected, error: null }));
+    const client = { rpc } as unknown as SupabaseClient;
+
+    await expect(evaluateSupplierEconomics(client, {
+      supplierOfferId: OFFER_ID,
+      canonicalProductId: PRODUCT_ID,
+      commercialMode: 'loadify_supplier_fulfilled',
+    })).resolves.toEqual(expected);
+
+    expect(rpc).toHaveBeenCalledWith('server_supplier_commercial_decision_v1', {
+      p_supplier_offer_id: OFFER_ID,
+      p_canonical_product_id: PRODUCT_ID,
+      p_commercial_mode: 'loadify_supplier_fulfilled',
+      p_territory: 'GB',
+    });
+  });
+});

--- a/netlify/functions/_shared/supplierEconomics.ts
+++ b/netlify/functions/_shared/supplierEconomics.ts
@@ -1,0 +1,82 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const SUPPLIER_ECONOMICS_INTERFACE_VERSION = 1;
+
+export interface SupplierEconomicsDecisionInput {
+  supplierOfferId: string;
+  canonicalProductId: string;
+  commercialMode: 'marketplace_seller' | 'loadify_supplier_fulfilled' | 'loadify_direct';
+  territory?: string;
+}
+
+export interface SupplierEconomicsDecision {
+  eligible: boolean;
+  reason: string;
+  interfaceVersion: number;
+  supplierOfferId?: string;
+  canonicalProductId?: string;
+  pricingSnapshotId?: string;
+  landedCostSnapshotId?: string;
+  taxRuleVersionId?: string;
+  currency?: string;
+  grossCustomerPrice?: number;
+  pricingPolicyVersion?: number;
+}
+
+function validDecision(data: unknown): data is SupplierEconomicsDecision {
+  if (!data || typeof data !== 'object') return false;
+  const v = data as Record<string, unknown>;
+  if (typeof v.eligible !== 'boolean' || typeof v.reason !== 'string' || v.interfaceVersion !== SUPPLIER_ECONOMICS_INTERFACE_VERSION) return false;
+  if (!v.eligible) return true;
+  return typeof v.supplierOfferId === 'string'
+    && typeof v.canonicalProductId === 'string'
+    && typeof v.pricingSnapshotId === 'string'
+    && typeof v.landedCostSnapshotId === 'string'
+    && typeof v.taxRuleVersionId === 'string'
+    && typeof v.currency === 'string'
+    && typeof v.grossCustomerPrice === 'number'
+    && typeof v.pricingPolicyVersion === 'number';
+}
+
+export async function evaluateSupplierEconomics(
+  client: SupabaseClient,
+  input: SupplierEconomicsDecisionInput,
+): Promise<SupplierEconomicsDecision> {
+  try {
+    const { data, error } = await client.rpc('server_supplier_commercial_decision_v1', {
+      p_supplier_offer_id: input.supplierOfferId,
+      p_canonical_product_id: input.canonicalProductId,
+      p_commercial_mode: input.commercialMode,
+      p_territory: input.territory || 'GB',
+    });
+    if (error || !validDecision(data)) throw error || new Error('invalid commercial economics evidence');
+    return data;
+  } catch {
+    return {
+      eligible: false,
+      reason: 'supplier_economics_unavailable',
+      interfaceVersion: SUPPLIER_ECONOMICS_INTERFACE_VERSION,
+    };
+  }
+}
+
+export type SupplierEconomicsAdminAction = 'record_tax_rule' | 'record_landed_cost' | 'record_pricing';
+
+export async function mutateSupplierEconomics(
+  client: SupabaseClient,
+  actorId: string,
+  action: SupplierEconomicsAdminAction,
+  payload: Record<string, unknown>,
+): Promise<{ ok: true; data: unknown } | { ok: false; error: string }> {
+  try {
+    const { data, error } = await client.rpc('server_admin_supplier_economics_v1', {
+      p_actor_id: actorId,
+      p_action: action,
+      p_payload: payload,
+    });
+    if (error) return { ok: false, error: error.message || 'supplier economics mutation failed' };
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : 'supplier economics mutation failed' };
+  }
+}

--- a/netlify/functions/admin-supplier-economics.ts
+++ b/netlify/functions/admin-supplier-economics.ts
@@ -1,0 +1,50 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { jsonResponse, optionsResponse } from './_shared/http';
+import { mutateSupplierEconomics, type SupplierEconomicsAdminAction } from './_shared/supplierEconomics';
+
+const METHODS = 'POST, OPTIONS';
+const ACTIONS = new Set<SupplierEconomicsAdminAction>(['record_tax_rule', 'record_landed_cost', 'record_pricing']);
+
+interface Body { action?: string; payload?: Record<string, unknown>; }
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return optionsResponse(METHODS);
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' }, METHODS);
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) return jsonResponse(500, { error: 'Server configuration error' }, METHODS);
+
+  const admin = createClient(supabaseUrl, serviceRoleKey, { auth: { autoRefreshToken: false, persistSession: false } });
+  const auth = await authenticateActiveAccount(event, admin, ['admin']);
+  if (!auth.ok) return jsonResponse(auth.status, { error: 'Unauthorized' }, METHODS);
+
+  let body: Body;
+  try { body = JSON.parse(event.body || '{}') as Body; }
+  catch { return jsonResponse(400, { error: 'Invalid JSON body' }, METHODS); }
+
+  const action = typeof body.action === 'string' ? body.action.trim() as SupplierEconomicsAdminAction : null;
+  const payload = body.payload;
+  if (!action || !ACTIONS.has(action) || !payload || typeof payload !== 'object' || Array.isArray(payload)) {
+    return jsonResponse(400, { error: 'A supported action and object payload are required' }, METHODS);
+  }
+
+  const serialized = JSON.stringify(payload);
+  if (/password|secret|access[_-]?token|refresh[_-]?token|api[_-]?key|card(number)?/i.test(serialized)) {
+    return jsonResponse(400, { error: 'Secrets or payment credentials are not accepted in Supplier Economics payloads' }, METHODS);
+  }
+
+  const result = await mutateSupplierEconomics(admin, auth.actor.id, action, payload);
+  if (!result.ok) {
+    const validation = /required|invalid|missing|match|currency|territory|margin|evidence|future|not found/i.test(result.error);
+    const forbidden = /authority|required admin|permission/i.test(result.error);
+    console.error('admin-supplier-economics: mutation failed:', result.error);
+    return jsonResponse(validation ? 400 : forbidden ? 403 : 500, {
+      error: validation ? result.error : forbidden ? 'Unauthorized' : 'Unable to update Supplier Economics',
+    }, METHODS);
+  }
+
+  return jsonResponse(200, { ok: true, result: result.data }, METHODS);
+};

--- a/supabase/626_supplier_commercial_economics.sql
+++ b/supabase/626_supplier_commercial_economics.sql
@@ -1,0 +1,313 @@
+-- 626_supplier_commercial_economics.sql
+-- Phase G — Commercial Economics: landed cost, tax rule versioning, pricing and append-only financial ledger.
+-- Supplier Commerce remains fail-closed under Phase C controls. This migration does not enable any runtime operation.
+
+CREATE SCHEMA IF NOT EXISTS private;
+
+CREATE TABLE IF NOT EXISTS private.supplier_tax_rule_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  rule_key text NOT NULL,
+  version integer NOT NULL CHECK (version > 0),
+  territory text NOT NULL,
+  commercial_mode text NOT NULL,
+  status text NOT NULL DEFAULT 'draft',
+  effective_from timestamptz NOT NULL,
+  effective_to timestamptz,
+  rule_payload jsonb NOT NULL,
+  evidence_refs jsonb NOT NULL DEFAULT '[]'::jsonb,
+  evidence_hash text,
+  verified_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  verified_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_tax_rule_key_check CHECK (rule_key = lower(BTRIM(rule_key)) AND rule_key ~ '^[a-z0-9][a-z0-9._-]{2,127}$'),
+  CONSTRAINT supplier_tax_rule_territory_check CHECK (territory = upper(BTRIM(territory)) AND territory ~ '^[A-Z]{2}$'),
+  CONSTRAINT supplier_tax_rule_mode_check CHECK (commercial_mode IN ('marketplace_seller','loadify_supplier_fulfilled','loadify_direct')),
+  CONSTRAINT supplier_tax_rule_status_check CHECK (status IN ('draft','verified','stale','retired')),
+  CONSTRAINT supplier_tax_rule_dates_check CHECK (effective_to IS NULL OR effective_to > effective_from),
+  CONSTRAINT supplier_tax_rule_payload_check CHECK (jsonb_typeof(rule_payload) = 'object'),
+  CONSTRAINT supplier_tax_rule_evidence_refs_check CHECK (jsonb_typeof(evidence_refs) = 'array'),
+  CONSTRAINT supplier_tax_rule_verified_check CHECK (
+    status <> 'verified' OR (
+      verified_by IS NOT NULL AND verified_at IS NOT NULL
+      AND jsonb_array_length(evidence_refs) > 0
+      AND NULLIF(BTRIM(evidence_hash), '') IS NOT NULL
+    )
+  )
+);
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_tax_rule_version_unique
+  ON private.supplier_tax_rule_versions(rule_key, version);
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_tax_rule_one_verified_current_unique
+  ON private.supplier_tax_rule_versions(rule_key, territory, commercial_mode)
+  WHERE status = 'verified' AND effective_to IS NULL;
+
+CREATE TABLE IF NOT EXISTS private.supplier_landed_cost_snapshots (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  supplier_offer_id uuid NOT NULL REFERENCES private.supplier_offers(id) ON DELETE RESTRICT,
+  import_item_id uuid NOT NULL REFERENCES private.supplier_import_items(id) ON DELETE RESTRICT,
+  currency text NOT NULL,
+  supplier_product_cost numeric(18,4) NOT NULL CHECK (supplier_product_cost >= 0),
+  supplier_shipping_cost numeric(18,4) NOT NULL DEFAULT 0 CHECK (supplier_shipping_cost >= 0),
+  carrier_cost numeric(18,4) NOT NULL DEFAULT 0 CHECK (carrier_cost >= 0),
+  customs_duty numeric(18,4) NOT NULL DEFAULT 0 CHECK (customs_duty >= 0),
+  import_vat numeric(18,4) NOT NULL DEFAULT 0 CHECK (import_vat >= 0),
+  fx_cost numeric(18,4) NOT NULL DEFAULT 0 CHECK (fx_cost >= 0),
+  other_cost numeric(18,4) NOT NULL DEFAULT 0 CHECK (other_cost >= 0),
+  total_landed_cost numeric(18,4) GENERATED ALWAYS AS (
+    supplier_product_cost + supplier_shipping_cost + carrier_cost + customs_duty + import_vat + fx_cost + other_cost
+  ) STORED,
+  ship_from_country text,
+  destination_territory text NOT NULL DEFAULT 'GB',
+  importer_of_record text,
+  source_refs jsonb NOT NULL DEFAULT '[]'::jsonb,
+  evidence_hash text NOT NULL,
+  status text NOT NULL DEFAULT 'draft',
+  valid_from timestamptz NOT NULL,
+  valid_to timestamptz,
+  reviewed_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  reviewed_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_landed_cost_currency_check CHECK (currency = upper(BTRIM(currency)) AND currency ~ '^[A-Z]{3}$'),
+  CONSTRAINT supplier_landed_cost_destination_check CHECK (destination_territory = upper(BTRIM(destination_territory)) AND destination_territory ~ '^[A-Z]{2}$'),
+  CONSTRAINT supplier_landed_cost_source_refs_check CHECK (jsonb_typeof(source_refs) = 'array'),
+  CONSTRAINT supplier_landed_cost_status_check CHECK (status IN ('draft','verified','stale','retired')),
+  CONSTRAINT supplier_landed_cost_dates_check CHECK (valid_to IS NULL OR valid_to > valid_from),
+  CONSTRAINT supplier_landed_cost_verified_check CHECK (
+    status <> 'verified' OR (
+      reviewed_by IS NOT NULL AND reviewed_at IS NOT NULL
+      AND jsonb_array_length(source_refs) > 0
+      AND NULLIF(BTRIM(evidence_hash), '') IS NOT NULL
+    )
+  )
+);
+CREATE INDEX IF NOT EXISTS supplier_landed_cost_offer_idx
+  ON private.supplier_landed_cost_snapshots(supplier_offer_id, status, valid_from DESC);
+
+CREATE TABLE IF NOT EXISTS private.supplier_pricing_snapshots (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  supplier_offer_id uuid NOT NULL REFERENCES private.supplier_offers(id) ON DELETE RESTRICT,
+  canonical_product_id uuid NOT NULL REFERENCES private.canonical_products(id) ON DELETE RESTRICT,
+  landed_cost_snapshot_id uuid NOT NULL REFERENCES private.supplier_landed_cost_snapshots(id) ON DELETE RESTRICT,
+  tax_rule_version_id uuid NOT NULL REFERENCES private.supplier_tax_rule_versions(id) ON DELETE RESTRICT,
+  commercial_mode text NOT NULL,
+  currency text NOT NULL,
+  merchandise_amount numeric(18,4) NOT NULL CHECK (merchandise_amount >= 0),
+  mandatory_fee_amount numeric(18,4) NOT NULL DEFAULT 0 CHECK (mandatory_fee_amount >= 0),
+  customer_shipping_charge numeric(18,4) NOT NULL DEFAULT 0 CHECK (customer_shipping_charge >= 0),
+  tax_amount numeric(18,4) NOT NULL DEFAULT 0 CHECK (tax_amount >= 0),
+  gross_customer_price numeric(18,4) NOT NULL CHECK (gross_customer_price >= 0),
+  expected_contribution numeric(18,4) NOT NULL,
+  minimum_contribution numeric(18,4) NOT NULL DEFAULT 0,
+  pricing_policy_version integer NOT NULL CHECK (pricing_policy_version > 0),
+  status text NOT NULL DEFAULT 'candidate',
+  valid_from timestamptz NOT NULL,
+  valid_to timestamptz,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  approved_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  approved_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_pricing_mode_check CHECK (commercial_mode IN ('marketplace_seller','loadify_supplier_fulfilled','loadify_direct')),
+  CONSTRAINT supplier_pricing_currency_check CHECK (currency = upper(BTRIM(currency)) AND currency ~ '^[A-Z]{3}$'),
+  CONSTRAINT supplier_pricing_status_check CHECK (status IN ('candidate','approved','stale','withdrawn')),
+  CONSTRAINT supplier_pricing_dates_check CHECK (valid_to IS NULL OR valid_to > valid_from),
+  CONSTRAINT supplier_pricing_evidence_check CHECK (jsonb_typeof(evidence) = 'object'),
+  CONSTRAINT supplier_pricing_total_check CHECK (
+    gross_customer_price = merchandise_amount + mandatory_fee_amount + customer_shipping_charge + tax_amount
+  ),
+  CONSTRAINT supplier_pricing_margin_check CHECK (
+    status <> 'approved' OR expected_contribution >= minimum_contribution
+  ),
+  CONSTRAINT supplier_pricing_approval_check CHECK (
+    status <> 'approved' OR (approved_by IS NOT NULL AND approved_at IS NOT NULL AND evidence <> '{}'::jsonb)
+  )
+);
+CREATE INDEX IF NOT EXISTS supplier_pricing_offer_idx
+  ON private.supplier_pricing_snapshots(supplier_offer_id, status, valid_from DESC);
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_pricing_one_current_approved_unique
+  ON private.supplier_pricing_snapshots(supplier_offer_id, commercial_mode)
+  WHERE status = 'approved' AND valid_to IS NULL;
+
+CREATE TABLE IF NOT EXISTS private.commerce_financial_ledger_entries (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_key text NOT NULL UNIQUE,
+  correlation_id uuid NOT NULL,
+  order_id uuid REFERENCES public.orders(id) ON DELETE RESTRICT,
+  supplier_offer_id uuid REFERENCES private.supplier_offers(id) ON DELETE RESTRICT,
+  commercial_mode text NOT NULL,
+  event_type text NOT NULL,
+  account_code text NOT NULL,
+  currency text NOT NULL,
+  signed_amount numeric(18,4) NOT NULL,
+  reversal_of uuid REFERENCES private.commerce_financial_ledger_entries(id) ON DELETE RESTRICT,
+  external_ref text,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  occurred_at timestamptz NOT NULL,
+  recorded_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT commerce_financial_ledger_mode_check CHECK (commercial_mode IN ('marketplace_seller','loadify_supplier_fulfilled','loadify_direct')),
+  CONSTRAINT commerce_financial_ledger_event_check CHECK (event_type IN (
+    'customer_payment','processor_fee','platform_commission','retail_margin','supplier_product_cost',
+    'supplier_shipping_cost','carrier_cost','tax_vat','customs_duty','import_vat','fx',
+    'seller_payable','supplier_payable','payout','customer_refund','supplier_recovery',
+    'chargeback','unrecovered_loss','adjustment','reversal'
+  )),
+  CONSTRAINT commerce_financial_ledger_currency_check CHECK (currency = upper(BTRIM(currency)) AND currency ~ '^[A-Z]{3}$'),
+  CONSTRAINT commerce_financial_ledger_account_check CHECK (NULLIF(BTRIM(account_code), '') IS NOT NULL),
+  CONSTRAINT commerce_financial_ledger_event_key_check CHECK (NULLIF(BTRIM(event_key), '') IS NOT NULL),
+  CONSTRAINT commerce_financial_ledger_evidence_check CHECK (jsonb_typeof(evidence) = 'object'),
+  CONSTRAINT commerce_financial_ledger_reversal_check CHECK ((event_type = 'reversal' AND reversal_of IS NOT NULL) OR event_type <> 'reversal')
+);
+CREATE INDEX IF NOT EXISTS commerce_financial_ledger_order_idx
+  ON private.commerce_financial_ledger_entries(order_id, occurred_at, recorded_at);
+CREATE INDEX IF NOT EXISTS commerce_financial_ledger_correlation_idx
+  ON private.commerce_financial_ledger_entries(correlation_id, occurred_at, recorded_at);
+
+REVOKE ALL ON TABLE private.supplier_tax_rule_versions FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_landed_cost_snapshots FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_pricing_snapshots FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.commerce_financial_ledger_entries FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION private.guard_commerce_financial_ledger_immutable_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+BEGIN
+  RAISE EXCEPTION 'financial ledger entries are append-only; record an adjustment or reversal event';
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_commerce_financial_ledger_update_v1 ON private.commerce_financial_ledger_entries;
+CREATE TRIGGER trg_guard_commerce_financial_ledger_update_v1
+BEFORE UPDATE OR DELETE ON private.commerce_financial_ledger_entries
+FOR EACH ROW EXECUTE FUNCTION private.guard_commerce_financial_ledger_immutable_v1();
+
+CREATE OR REPLACE FUNCTION public.server_supplier_commercial_decision_v1(
+  p_supplier_offer_id uuid,
+  p_canonical_product_id uuid,
+  p_commercial_mode text,
+  p_territory text DEFAULT 'GB'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_mode text := lower(BTRIM(COALESCE(p_commercial_mode, '')));
+  v_territory text := upper(BTRIM(COALESCE(p_territory, 'GB')));
+  v_offer private.supplier_offers%ROWTYPE;
+  v_price private.supplier_pricing_snapshots%ROWTYPE;
+  v_landed private.supplier_landed_cost_snapshots%ROWTYPE;
+  v_tax private.supplier_tax_rule_versions%ROWTYPE;
+  v_catalog jsonb;
+  v_import jsonb;
+BEGIN
+  IF v_mode NOT IN ('marketplace_seller','loadify_supplier_fulfilled','loadify_direct') THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'invalid_commercial_mode', 'interfaceVersion', 1);
+  END IF;
+  IF v_territory <> 'GB' THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'territory_not_enabled', 'territory', v_territory, 'interfaceVersion', 1);
+  END IF;
+
+  SELECT * INTO v_offer FROM private.supplier_offers
+   WHERE id = p_supplier_offer_id AND canonical_product_id = p_canonical_product_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'supplier_offer_not_linked', 'interfaceVersion', 1);
+  END IF;
+
+  v_catalog := public.server_supplier_catalog_decision_v1(p_canonical_product_id, p_supplier_offer_id, v_territory);
+  IF COALESCE((v_catalog->>'eligible')::boolean, false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'catalog_not_ready', 'catalog', v_catalog, 'interfaceVersion', 1);
+  END IF;
+
+  v_import := public.server_supplier_import_decision_v1(v_offer.supplier_catalog_item_id, p_canonical_product_id);
+  IF COALESCE((v_import->>'eligible')::boolean, false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'import_not_ready', 'import', v_import, 'interfaceVersion', 1);
+  END IF;
+
+  SELECT * INTO v_price FROM private.supplier_pricing_snapshots p
+   WHERE p.supplier_offer_id = p_supplier_offer_id
+     AND p.canonical_product_id = p_canonical_product_id
+     AND p.commercial_mode = v_mode
+     AND p.status = 'approved'
+     AND p.valid_from <= now()
+     AND (p.valid_to IS NULL OR p.valid_to > now())
+   ORDER BY p.valid_from DESC LIMIT 1;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'approved_pricing_missing', 'interfaceVersion', 1);
+  END IF;
+
+  SELECT * INTO v_landed FROM private.supplier_landed_cost_snapshots l WHERE l.id = v_price.landed_cost_snapshot_id;
+  IF NOT FOUND OR v_landed.status <> 'verified' OR v_landed.valid_from > now() OR (v_landed.valid_to IS NOT NULL AND v_landed.valid_to <= now()) THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'landed_cost_not_current', 'interfaceVersion', 1);
+  END IF;
+
+  SELECT * INTO v_tax FROM private.supplier_tax_rule_versions t WHERE t.id = v_price.tax_rule_version_id;
+  IF NOT FOUND OR v_tax.status <> 'verified' OR v_tax.territory <> v_territory OR v_tax.commercial_mode <> v_mode
+     OR v_tax.effective_from > now() OR (v_tax.effective_to IS NOT NULL AND v_tax.effective_to <= now()) THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'tax_rule_not_current', 'interfaceVersion', 1);
+  END IF;
+
+  IF v_price.expected_contribution < v_price.minimum_contribution THEN
+    RETURN jsonb_build_object('eligible', false, 'reason', 'margin_guard_failed', 'interfaceVersion', 1);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'eligible', true,
+    'reason', 'commercial_economics_ready',
+    'supplierOfferId', p_supplier_offer_id,
+    'canonicalProductId', p_canonical_product_id,
+    'pricingSnapshotId', v_price.id,
+    'landedCostSnapshotId', v_landed.id,
+    'taxRuleVersionId', v_tax.id,
+    'currency', v_price.currency,
+    'grossCustomerPrice', v_price.gross_customer_price,
+    'pricingPolicyVersion', v_price.pricing_policy_version,
+    'interfaceVersion', 1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_supplier_commercial_decision_v1(uuid, uuid, text, text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_commercial_decision_v1(uuid, uuid, text, text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_append_financial_ledger_v1(
+  p_event_key text,
+  p_correlation_id uuid,
+  p_order_id uuid,
+  p_supplier_offer_id uuid,
+  p_commercial_mode text,
+  p_event_type text,
+  p_account_code text,
+  p_currency text,
+  p_signed_amount numeric,
+  p_reversal_of uuid,
+  p_external_ref text,
+  p_evidence jsonb,
+  p_occurred_at timestamptz
+)
+RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE v_id uuid;
+BEGIN
+  IF NULLIF(BTRIM(p_event_key), '') IS NULL OR p_correlation_id IS NULL THEN
+    RAISE EXCEPTION 'event key and correlation id are required';
+  END IF;
+  INSERT INTO private.commerce_financial_ledger_entries(
+    event_key, correlation_id, order_id, supplier_offer_id, commercial_mode,
+    event_type, account_code, currency, signed_amount, reversal_of, external_ref, evidence, occurred_at
+  ) VALUES (
+    BTRIM(p_event_key), p_correlation_id, p_order_id, p_supplier_offer_id,
+    lower(BTRIM(p_commercial_mode)), lower(BTRIM(p_event_type)), BTRIM(p_account_code),
+    upper(BTRIM(p_currency)), p_signed_amount, p_reversal_of, NULLIF(BTRIM(p_external_ref), ''),
+    COALESCE(p_evidence, '{}'::jsonb), COALESCE(p_occurred_at, now())
+  ) ON CONFLICT (event_key) DO NOTHING RETURNING id INTO v_id;
+  IF v_id IS NULL THEN SELECT id INTO v_id FROM private.commerce_financial_ledger_entries WHERE event_key = BTRIM(p_event_key); END IF;
+  RETURN v_id;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_append_financial_ledger_v1(text, uuid, uuid, uuid, text, text, text, text, numeric, uuid, text, jsonb, timestamptz) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_append_financial_ledger_v1(text, uuid, uuid, uuid, text, text, text, text, numeric, uuid, text, jsonb, timestamptz) TO service_role;
+
+COMMENT ON TABLE private.commerce_financial_ledger_entries IS 'Append-only canonical financial truth. Corrections use explicit adjustment/reversal events; historical entries are never rewritten.';
+COMMENT ON FUNCTION public.server_supplier_commercial_decision_v1(uuid, uuid, text, text) IS 'Phase G fail-closed commercial economics readiness decision. Does not enable Supplier Commerce controls.';

--- a/supabase/627_supplier_commercial_economics_guards.sql
+++ b/supabase/627_supplier_commercial_economics_guards.sql
@@ -1,0 +1,205 @@
+-- 627_supplier_commercial_economics_guards.sql
+-- Phase G hard guards and active-admin mutation boundary.
+
+CREATE OR REPLACE FUNCTION private.phase_g_actor_is_active_admin(p_actor_id uuid)
+RETURNS boolean
+LANGUAGE sql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.users u
+     WHERE u.id = p_actor_id AND u.role = 'admin' AND u."isActive" = true
+  );
+$$;
+REVOKE ALL ON FUNCTION private.phase_g_actor_is_active_admin(uuid) FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_landed_cost_consistency_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+DECLARE
+  v_offer_item uuid;
+  v_import_item uuid;
+BEGIN
+  SELECT supplier_catalog_item_id INTO v_offer_item FROM private.supplier_offers WHERE id = NEW.supplier_offer_id;
+  SELECT supplier_catalog_item_id INTO v_import_item FROM private.supplier_import_items WHERE id = NEW.import_item_id;
+  IF v_offer_item IS NULL OR v_import_item IS NULL OR v_offer_item <> v_import_item THEN
+    RAISE EXCEPTION 'landed cost must reference import evidence for the supplier offer catalog item';
+  END IF;
+  IF NEW.destination_territory <> 'GB' THEN
+    RAISE EXCEPTION 'Phase G currently supports GB only; NI requires a separately verified rule set';
+  END IF;
+  IF NEW.status = 'verified' AND NEW.valid_from > now() THEN
+    RAISE EXCEPTION 'verified landed cost cannot start in the future';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_landed_cost_consistency_v1 ON private.supplier_landed_cost_snapshots;
+CREATE TRIGGER trg_guard_supplier_landed_cost_consistency_v1
+BEFORE INSERT OR UPDATE ON private.supplier_landed_cost_snapshots
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_landed_cost_consistency_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_pricing_consistency_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+DECLARE
+  v_offer_product uuid;
+  v_landed_offer uuid;
+  v_landed_currency text;
+  v_tax_mode text;
+  v_tax_territory text;
+BEGIN
+  SELECT canonical_product_id INTO v_offer_product FROM private.supplier_offers WHERE id = NEW.supplier_offer_id;
+  SELECT supplier_offer_id, currency INTO v_landed_offer, v_landed_currency
+    FROM private.supplier_landed_cost_snapshots WHERE id = NEW.landed_cost_snapshot_id;
+  SELECT commercial_mode, territory INTO v_tax_mode, v_tax_territory
+    FROM private.supplier_tax_rule_versions WHERE id = NEW.tax_rule_version_id;
+
+  IF v_offer_product IS NULL OR v_offer_product <> NEW.canonical_product_id THEN
+    RAISE EXCEPTION 'pricing canonical product must match supplier offer';
+  END IF;
+  IF v_landed_offer IS NULL OR v_landed_offer <> NEW.supplier_offer_id THEN
+    RAISE EXCEPTION 'pricing landed cost must belong to supplier offer';
+  END IF;
+  IF v_landed_currency <> NEW.currency THEN
+    RAISE EXCEPTION 'pricing and landed-cost currencies must match';
+  END IF;
+  IF v_tax_mode IS NULL OR v_tax_mode <> NEW.commercial_mode OR v_tax_territory <> 'GB' THEN
+    RAISE EXCEPTION 'pricing tax rule must match commercial mode and GB territory';
+  END IF;
+  IF NEW.status = 'approved' AND NEW.valid_from > now() THEN
+    RAISE EXCEPTION 'approved pricing cannot start in the future';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_pricing_consistency_v1 ON private.supplier_pricing_snapshots;
+CREATE TRIGGER trg_guard_supplier_pricing_consistency_v1
+BEFORE INSERT OR UPDATE ON private.supplier_pricing_snapshots
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_pricing_consistency_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_verified_economics_history_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    RAISE EXCEPTION 'verified commercial evidence is historical truth and cannot be deleted';
+  END IF;
+  IF OLD.status IN ('verified','approved') AND (
+    to_jsonb(NEW) - ARRAY['status','valid_to','effective_to']::text[]
+    IS DISTINCT FROM
+    to_jsonb(OLD) - ARRAY['status','valid_to','effective_to']::text[]
+  ) THEN
+    RAISE EXCEPTION 'verified commercial evidence is immutable; create a new version/snapshot';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_guard_tax_rule_history_v1 ON private.supplier_tax_rule_versions;
+CREATE TRIGGER trg_guard_tax_rule_history_v1 BEFORE UPDATE OR DELETE ON private.supplier_tax_rule_versions
+FOR EACH ROW EXECUTE FUNCTION private.guard_verified_economics_history_v1();
+DROP TRIGGER IF EXISTS trg_guard_landed_cost_history_v1 ON private.supplier_landed_cost_snapshots;
+CREATE TRIGGER trg_guard_landed_cost_history_v1 BEFORE UPDATE OR DELETE ON private.supplier_landed_cost_snapshots
+FOR EACH ROW EXECUTE FUNCTION private.guard_verified_economics_history_v1();
+DROP TRIGGER IF EXISTS trg_guard_pricing_history_v1 ON private.supplier_pricing_snapshots;
+CREATE TRIGGER trg_guard_pricing_history_v1 BEFORE UPDATE OR DELETE ON private.supplier_pricing_snapshots
+FOR EACH ROW EXECUTE FUNCTION private.guard_verified_economics_history_v1();
+
+CREATE OR REPLACE FUNCTION public.server_admin_supplier_economics_v1(
+  p_actor_id uuid,
+  p_action text,
+  p_payload jsonb
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_action text := lower(BTRIM(COALESCE(p_action, '')));
+  v_payload jsonb := COALESCE(p_payload, '{}'::jsonb);
+  v_id uuid;
+  v_status text;
+  v_now timestamptz := now();
+BEGIN
+  IF NOT private.phase_g_actor_is_active_admin(p_actor_id) THEN
+    RAISE EXCEPTION 'active admin authority is required';
+  END IF;
+  IF jsonb_typeof(v_payload) <> 'object' THEN RAISE EXCEPTION 'payload must be an object'; END IF;
+
+  IF v_action = 'record_tax_rule' THEN
+    v_status := lower(BTRIM(COALESCE(v_payload->>'status','draft')));
+    INSERT INTO private.supplier_tax_rule_versions(
+      rule_key, version, territory, commercial_mode, status, effective_from, effective_to,
+      rule_payload, evidence_refs, evidence_hash, verified_by, verified_at
+    ) VALUES (
+      lower(BTRIM(v_payload->>'ruleKey')), NULLIF(v_payload->>'version','')::integer,
+      upper(BTRIM(COALESCE(v_payload->>'territory','GB'))), lower(BTRIM(v_payload->>'commercialMode')),
+      v_status, COALESCE(NULLIF(v_payload->>'effectiveFrom','')::timestamptz,v_now),
+      NULLIF(v_payload->>'effectiveTo','')::timestamptz, COALESCE(v_payload->'rulePayload','{}'::jsonb),
+      COALESCE(v_payload->'evidenceRefs','[]'::jsonb), NULLIF(BTRIM(v_payload->>'evidenceHash'),''),
+      CASE WHEN v_status='verified' THEN p_actor_id ELSE NULL END,
+      CASE WHEN v_status='verified' THEN v_now ELSE NULL END
+    ) RETURNING id INTO v_id;
+    RETURN jsonb_build_object('ok',true,'taxRuleVersionId',v_id);
+  END IF;
+
+  IF v_action = 'record_landed_cost' THEN
+    v_status := lower(BTRIM(COALESCE(v_payload->>'status','draft')));
+    INSERT INTO private.supplier_landed_cost_snapshots(
+      supplier_offer_id, import_item_id, currency, supplier_product_cost, supplier_shipping_cost,
+      carrier_cost, customs_duty, import_vat, fx_cost, other_cost, ship_from_country,
+      destination_territory, importer_of_record, source_refs, evidence_hash, status,
+      valid_from, valid_to, reviewed_by, reviewed_at
+    ) VALUES (
+      NULLIF(v_payload->>'supplierOfferId','')::uuid, NULLIF(v_payload->>'importItemId','')::uuid,
+      upper(BTRIM(v_payload->>'currency')), COALESCE(NULLIF(v_payload->>'supplierProductCost','')::numeric,0),
+      COALESCE(NULLIF(v_payload->>'supplierShippingCost','')::numeric,0), COALESCE(NULLIF(v_payload->>'carrierCost','')::numeric,0),
+      COALESCE(NULLIF(v_payload->>'customsDuty','')::numeric,0), COALESCE(NULLIF(v_payload->>'importVat','')::numeric,0),
+      COALESCE(NULLIF(v_payload->>'fxCost','')::numeric,0), COALESCE(NULLIF(v_payload->>'otherCost','')::numeric,0),
+      NULLIF(upper(BTRIM(v_payload->>'shipFromCountry')),''), upper(BTRIM(COALESCE(v_payload->>'destinationTerritory','GB'))),
+      NULLIF(BTRIM(v_payload->>'importerOfRecord'),''), COALESCE(v_payload->'sourceRefs','[]'::jsonb),
+      BTRIM(v_payload->>'evidenceHash'), v_status, COALESCE(NULLIF(v_payload->>'validFrom','')::timestamptz,v_now),
+      NULLIF(v_payload->>'validTo','')::timestamptz, CASE WHEN v_status='verified' THEN p_actor_id ELSE NULL END,
+      CASE WHEN v_status='verified' THEN v_now ELSE NULL END
+    ) RETURNING id INTO v_id;
+    RETURN jsonb_build_object('ok',true,'landedCostSnapshotId',v_id);
+  END IF;
+
+  IF v_action = 'record_pricing' THEN
+    v_status := lower(BTRIM(COALESCE(v_payload->>'status','candidate')));
+    INSERT INTO private.supplier_pricing_snapshots(
+      supplier_offer_id, canonical_product_id, landed_cost_snapshot_id, tax_rule_version_id,
+      commercial_mode, currency, merchandise_amount, mandatory_fee_amount, customer_shipping_charge,
+      tax_amount, gross_customer_price, expected_contribution, minimum_contribution,
+      pricing_policy_version, status, valid_from, valid_to, evidence, approved_by, approved_at
+    ) VALUES (
+      NULLIF(v_payload->>'supplierOfferId','')::uuid, NULLIF(v_payload->>'canonicalProductId','')::uuid,
+      NULLIF(v_payload->>'landedCostSnapshotId','')::uuid, NULLIF(v_payload->>'taxRuleVersionId','')::uuid,
+      lower(BTRIM(v_payload->>'commercialMode')), upper(BTRIM(v_payload->>'currency')),
+      COALESCE(NULLIF(v_payload->>'merchandiseAmount','')::numeric,0), COALESCE(NULLIF(v_payload->>'mandatoryFeeAmount','')::numeric,0),
+      COALESCE(NULLIF(v_payload->>'customerShippingCharge','')::numeric,0), COALESCE(NULLIF(v_payload->>'taxAmount','')::numeric,0),
+      NULLIF(v_payload->>'grossCustomerPrice','')::numeric, NULLIF(v_payload->>'expectedContribution','')::numeric,
+      COALESCE(NULLIF(v_payload->>'minimumContribution','')::numeric,0), NULLIF(v_payload->>'pricingPolicyVersion','')::integer,
+      v_status, COALESCE(NULLIF(v_payload->>'validFrom','')::timestamptz,v_now), NULLIF(v_payload->>'validTo','')::timestamptz,
+      COALESCE(v_payload->'evidence','{}'::jsonb), CASE WHEN v_status='approved' THEN p_actor_id ELSE NULL END,
+      CASE WHEN v_status='approved' THEN v_now ELSE NULL END
+    ) RETURNING id INTO v_id;
+    RETURN jsonb_build_object('ok',true,'pricingSnapshotId',v_id);
+  END IF;
+
+  RAISE EXCEPTION 'unsupported supplier economics action';
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_supplier_economics_v1(uuid,text,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_supplier_economics_v1(uuid,text,jsonb) TO service_role;
+
+-- No control is enabled by Phase G.


### PR DESCRIPTION
Implements canonical Phase G Commercial Economics foundations: landed cost, evidence-driven tax rule versions, transparent pricing/margin guard, append-only financial ledger, active-admin mutation boundary, fail-closed server decision helper and dedicated contract tests. Supplier Commerce controls remain OFF. PowerShell validation: Phase G 12/12 PASS; upstream C-F 50/50 PASS; typecheck PASS; lint PASS; build PASS. Full suite retains the known baseline 27 failures and adds no new Phase G failure family.