### PR TITLE
Phase I: order orchestrator, commerce risk and reservation

### DIFF
--- a/netlify/functions/__tests__/supplier-order-orchestrator.test.ts
+++ b/netlify/functions/__tests__/supplier-order-orchestrator.test.ts
@@ -1,0 +1,188 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  SUPPLIER_ORDER_ORCHESTRATOR_INTERFACE_VERSION,
+  reserveSupplierOffer,
+  releaseSupplierReservation,
+} from '../_shared/supplierOrderOrchestrator';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const foundation = repo('supabase/634_supplier_order_orchestrator_risk_reservation.sql');
+const runtime = repo('supabase/635_supplier_order_orchestrator_runtime_guards.sql');
+const governance = repo('supabase/636_supplier_order_risk_admin_governance.sql');
+const helper = repo('netlify/functions/_shared/supplierOrderOrchestrator.ts');
+const adminApi = repo('netlify/functions/admin-supplier-order-orchestration.ts');
+
+const ORDER = '11111111-1111-4111-8111-111111111111';
+const ITEM = '22222222-2222-4222-8222-222222222222';
+const OFFER = '33333333-3333-4333-8333-333333333333';
+const CORRELATION = '44444444-4444-4444-8444-444444444444';
+
+describe('Phase I Order Orchestrator + Commerce Risk + Reservation', () => {
+  it('keeps the existing public order as the single customer-order truth', () => {
+    expect(foundation).toContain('order_id uuid NOT NULL UNIQUE REFERENCES public.orders(id)');
+    expect(foundation).toContain('order_item_id uuid NOT NULL UNIQUE REFERENCES public.order_items(id)');
+    expect(foundation).toContain('not a parallel buyer order');
+    expect(foundation).not.toContain('CREATE TABLE IF NOT EXISTS public.supplier_orders');
+  });
+
+  it('models multiple internal fulfilment legs under one customer order', () => {
+    expect(foundation).toContain('private.supplier_fulfilment_legs');
+    expect(foundation).toContain("fulfiller_type IN ('marketplace_seller','loadify_direct','supplier')");
+    expect(foundation).toContain("commercial_mode IN ('marketplace_seller','loadify_supplier_fulfilled','loadify_direct')");
+    expect(runtime).toContain('fulfilment leg item must belong to the same canonical customer order');
+  });
+
+  it('keeps supplier fulfilment identity tied to canonical supplier offers and products', () => {
+    expect(foundation).toContain('supplier_offer_id uuid REFERENCES private.supplier_offers(id)');
+    expect(runtime).toContain('fulfilment item canonical product must match supplier offer');
+    expect(runtime).toContain('supplier_offer_id<>p_supplier_offer_id');
+  });
+
+  it('implements a separate commerce risk layer with the five canonical actions', () => {
+    expect(foundation).toContain("action IN ('ALLOW','REVIEW','HOLD','RESTRICT','BLOCK')");
+    expect(runtime).toContain("WHEN v_score>=v_policy.block_score THEN 'BLOCK'");
+    expect(runtime).toContain("WHEN v_score>=v_policy.restrict_score THEN 'RESTRICT'");
+    expect(runtime).toContain("WHEN v_score>=v_policy.hold_score THEN 'HOLD'");
+    expect(runtime).toContain("WHEN v_score>=v_policy.review_score THEN 'REVIEW'");
+    expect(runtime).toContain("ELSE 'ALLOW'");
+  });
+
+  it('does not automatically ban accounts as a side effect of a risk decision', () => {
+    expect(foundation).toContain('Risk action does not itself ban an account');
+    expect(runtime).toContain('It never bans accounts by itself');
+    expect(runtime).not.toContain("UPDATE public.users SET");
+    expect(runtime).not.toContain("lifecycle_status='banned'");
+  });
+
+  it('makes risk history append-only and policy driven', () => {
+    expect(foundation).toContain('private.supplier_commerce_risk_policy_versions');
+    expect(foundation).toContain('private.supplier_commerce_risk_assessments');
+    expect(runtime).toContain('commerce risk assessments are append-only');
+    expect(governance).toContain('approved risk policy is immutable; retire and create a new version');
+  });
+
+  it('rejects secret-bearing risk signals and governance payloads', () => {
+    expect(runtime).toContain('secret_bearing_risk_payload_rejected');
+    expect(governance).toContain('secret-bearing risk policy payload rejected');
+    expect(adminApi).toContain('password|secret|access[_-]?token');
+  });
+
+  it('uses the Phase C reservation kill switch before creating supplier reservations', () => {
+    expect(runtime).toContain("server_supplier_commerce_control_decision_v1('reservation'");
+    expect(runtime).toContain("'reservation_control_disabled'");
+    expect(foundation).toContain('This migration enables no control');
+  });
+
+  it('requires fresh Phase H stock/price evidence before reservation', () => {
+    expect(runtime).toContain('server_supplier_stock_price_decision_v1');
+    expect(runtime).toContain("'stock_price_not_ready'");
+    expect(runtime).toContain("'sellable_quantity_unknown'");
+    expect(foundation).toContain('stock_observation_id uuid NOT NULL REFERENCES private.supplier_stock_observations');
+    expect(foundation).toContain('price_observation_id uuid NOT NULL REFERENCES private.supplier_price_observations');
+    expect(foundation).toContain('pricing_snapshot_id uuid NOT NULL REFERENCES private.supplier_pricing_snapshots');
+  });
+
+  it('subtracts active reservations from Phase H sellable stock and serialises by offer lock', () => {
+    expect(runtime).toContain('FOR UPDATE');
+    expect(runtime).toContain('SUM(r.quantity)');
+    expect(runtime).toContain("r.status='active'");
+    expect(runtime).toContain('v_available:=GREATEST(v_sellable-v_already_reserved,0)');
+    expect(runtime).toContain("'reservation_capacity_exhausted'");
+  });
+
+  it('requires idempotency and protects duplicate order, risk and reservation creation', () => {
+    expect(foundation).toContain('idempotency_key text NOT NULL UNIQUE');
+    expect(foundation).toContain('reservation_key text NOT NULL UNIQUE');
+    expect(runtime).toContain('risk idempotency key collision with different evidence');
+    expect(runtime).toContain('reservation idempotency key collision with different request');
+    expect(runtime).toContain('order orchestration idempotency mismatch');
+  });
+
+  it('supports reservation release and expiry without rewriting public order history', () => {
+    expect(runtime).toContain('server_release_supplier_reservation_v1');
+    expect(governance).toContain('server_expire_supplier_reservations_v1');
+    expect(governance).toContain('does not modify public customer order history');
+    expect(governance).not.toContain('UPDATE public.orders');
+  });
+
+  it('keeps Phase I private storage server-only and admin governance active-admin-only', () => {
+    for (const table of [
+      'supplier_order_orchestrations',
+      'supplier_fulfilment_legs',
+      'supplier_fulfilment_leg_items',
+      'supplier_commerce_risk_policy_versions',
+      'supplier_commerce_risk_assessments',
+      'supplier_stock_reservations',
+    ]) {
+      expect(foundation).toContain(`REVOKE ALL ON TABLE private.${table} FROM PUBLIC, anon, authenticated, service_role`);
+    }
+    expect(governance).toContain("u.role='admin'");
+    expect(governance).toContain('u."isActive"=true');
+    expect(adminApi).toContain("authenticateActiveAccount(event, admin, ['admin'])");
+  });
+
+  it('fails closed when reservation RPC evidence is unavailable or malformed', async () => {
+    const rpc = vi.fn(async () => ({ data: { eligible: true }, error: null }));
+    const client = { rpc } as unknown as SupabaseClient;
+    await expect(reserveSupplierOffer(client, {
+      orderId: ORDER,
+      orderItemId: ITEM,
+      supplierOfferId: OFFER,
+      commercialMode: 'loadify_supplier_fulfilled',
+      quantity: 1,
+      reservationKey: 'res-1',
+      orchestrationIdempotencyKey: 'orch-1',
+      correlationId: CORRELATION,
+    })).resolves.toEqual({
+      eligible: false,
+      reason: 'supplier_reservation_unavailable',
+      interfaceVersion: SUPPLIER_ORDER_ORCHESTRATOR_INTERFACE_VERSION,
+    });
+  });
+
+  it('accepts structurally complete reservation evidence from the server boundary', async () => {
+    const expected = {
+      eligible: true,
+      reason: 'supplier_stock_reserved',
+      orchestrationId: '55555555-5555-4555-8555-555555555555',
+      fulfilmentLegId: '66666666-6666-4666-8666-666666666666',
+      reservationId: '77777777-7777-4777-8777-777777777777',
+      expiresAt: '2026-08-21T10:00:00.000Z',
+      reservedQuantity: 1,
+      availableBeforeReservation: 5,
+      interfaceVersion: 1 as const,
+    };
+    const rpc = vi.fn(async () => ({ data: expected, error: null }));
+    const client = { rpc } as unknown as SupabaseClient;
+    await expect(reserveSupplierOffer(client, {
+      orderId: ORDER,
+      orderItemId: ITEM,
+      supplierOfferId: OFFER,
+      commercialMode: 'loadify_supplier_fulfilled',
+      quantity: 1,
+      reservationKey: 'res-1',
+      orchestrationIdempotencyKey: 'orch-1',
+      correlationId: CORRELATION,
+    })).resolves.toEqual(expected);
+  });
+
+  it('fails closed when reservation release evidence is unavailable', async () => {
+    const rpc = vi.fn(async () => ({ data: null, error: new Error('db unavailable') }));
+    const client = { rpc } as unknown as SupabaseClient;
+    await expect(releaseSupplierReservation(client, 'res-1', 'checkout cancelled')).resolves.toEqual({
+      ok: false,
+      reason: 'supplier_reservation_release_unavailable',
+      interfaceVersion: 1,
+    });
+  });
+
+  it('keeps the payment-to-supplier handshake deferred to Phase J', () => {
+    expect(foundation).not.toContain('stripePaymentIntent');
+    expect(runtime).not.toContain('supplier acknowledgement');
+    expect(runtime).not.toContain('external supplier order ID');
+    expect(helper).not.toContain('submitOrder');
+  });
+});

--- a/netlify/functions/__tests__/supplier-order-orchestrator.test.ts
+++ b/netlify/functions/__tests__/supplier-order-orchestrator.test.ts
@@ -4,6 +4,7 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 import { describe, expect, it, vi } from 'vitest';
 import {
   SUPPLIER_ORDER_ORCHESTRATOR_INTERFACE_VERSION,
+  assessSupplierCommerceRisk,
   reserveSupplierOffer,
   releaseSupplierReservation,
 } from '../_shared/supplierOrderOrchestrator';
@@ -12,6 +13,7 @@ const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8'
 const foundation = repo('supabase/634_supplier_order_orchestrator_risk_reservation.sql');
 const runtime = repo('supabase/635_supplier_order_orchestrator_runtime_guards.sql');
 const governance = repo('supabase/636_supplier_order_risk_admin_governance.sql');
+const audit = repo('supabase/637_supplier_order_orchestration_audit_closure.sql');
 const helper = repo('netlify/functions/_shared/supplierOrderOrchestrator.ts');
 const adminApi = repo('netlify/functions/admin-supplier-order-orchestration.ts');
 
@@ -50,10 +52,16 @@ describe('Phase I Order Orchestrator + Commerce Risk + Reservation', () => {
     expect(runtime).toContain("ELSE 'ALLOW'");
   });
 
+  it('supports buyer, supplier, order and platform risk subjects independently from compliance', () => {
+    expect(foundation).toContain("subject_type IN ('buyer','supplier','order','platform')");
+    expect(helper).toContain("export type CommerceRiskSubject = 'buyer' | 'supplier' | 'order' | 'platform'");
+    expect(helper).toContain('server_supplier_commerce_risk_decision_v1');
+  });
+
   it('does not automatically ban accounts as a side effect of a risk decision', () => {
     expect(foundation).toContain('Risk action does not itself ban an account');
     expect(runtime).toContain('It never bans accounts by itself');
-    expect(runtime).not.toContain("UPDATE public.users SET");
+    expect(runtime).not.toContain('UPDATE public.users SET');
     expect(runtime).not.toContain("lifecycle_status='banned'");
   });
 
@@ -108,6 +116,15 @@ describe('Phase I Order Orchestrator + Commerce Risk + Reservation', () => {
     expect(governance).not.toContain('UPDATE public.orders');
   });
 
+  it('records append-only orchestration and reservation lifecycle audit evidence', () => {
+    expect(audit).toContain('private.supplier_order_orchestration_events');
+    expect(audit).toContain('supplier order orchestration events are append-only');
+    expect(audit).toContain("'reservation_created'");
+    expect(audit).toContain("'reservation_released'");
+    expect(audit).toContain("'reservation_expired'");
+    expect(audit).toContain("'orchestration_state_changed'");
+  });
+
   it('keeps Phase I private storage server-only and admin governance active-admin-only', () => {
     for (const table of [
       'supplier_order_orchestrations',
@@ -119,9 +136,48 @@ describe('Phase I Order Orchestrator + Commerce Risk + Reservation', () => {
     ]) {
       expect(foundation).toContain(`REVOKE ALL ON TABLE private.${table} FROM PUBLIC, anon, authenticated, service_role`);
     }
+    expect(audit).toContain('REVOKE ALL ON TABLE private.supplier_order_orchestration_events FROM PUBLIC, anon, authenticated, service_role');
     expect(governance).toContain("u.role='admin'");
     expect(governance).toContain('u."isActive"=true');
     expect(adminApi).toContain("authenticateActiveAccount(event, admin, ['admin'])");
+  });
+
+  it('fails closed when generic commerce-risk evidence is unavailable', async () => {
+    const rpc = vi.fn(async () => ({ data: { eligible: true }, error: null }));
+    const client = { rpc } as unknown as SupabaseClient;
+    await expect(assessSupplierCommerceRisk(client, {
+      orderId: ORDER,
+      subjectType: 'buyer',
+      subjectRef: 'buyer-1',
+      signals: { paymentFraudScore: 50 },
+      idempotencyKey: 'risk-1',
+    })).resolves.toEqual({
+      eligible: false,
+      reason: 'commerce_risk_unavailable',
+      interfaceVersion: 1,
+    });
+  });
+
+  it('accepts a structurally complete ALLOW risk decision from the server boundary', async () => {
+    const expected = {
+      eligible: true,
+      reason: 'policy_score_allow',
+      action: 'ALLOW' as const,
+      riskScore: 12,
+      assessmentId: '88888888-8888-4888-8888-888888888888',
+      policyId: '99999999-9999-4999-8999-999999999999',
+      policyVersion: 3,
+      interfaceVersion: 1 as const,
+    };
+    const rpc = vi.fn(async () => ({ data: expected, error: null }));
+    const client = { rpc } as unknown as SupabaseClient;
+    await expect(assessSupplierCommerceRisk(client, {
+      orderId: ORDER,
+      subjectType: 'platform',
+      subjectRef: 'checkout:1',
+      signals: { duplicateOrder: false, reconciliationMismatch: false, anomalyScore: 12 },
+      idempotencyKey: 'risk-2',
+    })).resolves.toEqual(expected);
   });
 
   it('fails closed when reservation RPC evidence is unavailable or malformed', async () => {

--- a/netlify/functions/__tests__/supplier-order-route-integrity.test.ts
+++ b/netlify/functions/__tests__/supplier-order-route-integrity.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const mixedLeg = repo('supabase/638_supplier_order_mixed_leg_and_release_closure.sql');
+const integrity = repo('supabase/639_supplier_order_route_integrity_closure.sql');
+
+describe('Phase I fulfilment route integrity closure', () => {
+  it('supports marketplace-seller and Loadify-direct legs while supplier legs remain reservation-driven', () => {
+    expect(mixedLeg).toContain('server_plan_order_fulfilment_leg_v1');
+    expect(integrity).toContain("v_fulfiller NOT IN ('marketplace_seller','loadify_direct')");
+    expect(integrity).toContain("'supplier_leg_requires_supplier_reservation_rpc'");
+  });
+
+  it('keeps route identities mutually exclusive', () => {
+    expect(integrity).toContain("fulfiller_type='supplier' AND supplier_offer_id IS NOT NULL AND seller_id IS NULL");
+    expect(integrity).toContain("fulfiller_type='loadify_direct' AND supplier_offer_id IS NULL AND seller_id IS NULL");
+    expect(integrity).toContain("fulfiller_type='marketplace_seller' AND supplier_offer_id IS NULL AND seller_id IS NOT NULL");
+  });
+
+  it('binds marketplace seller legs to the product seller and rejects seller identity on Loadify Direct', () => {
+    expect(integrity).toContain("v_product.\"sellerId\"<>p_seller_id");
+    expect(integrity).toContain("'marketplace_seller_identity_mismatch'");
+    expect(integrity).toContain("'loadify_direct_does_not_accept_marketplace_seller_identity'");
+  });
+
+  it('requires supplier leg items to use the exact leg supplier offer and canonical product', () => {
+    expect(integrity).toContain('NEW.supplier_offer_id<>v_leg.supplier_offer_id');
+    expect(integrity).toContain('supplier fulfilment item must use the leg supplier offer and canonical product');
+    expect(integrity).toContain('fulfilment item canonical product must match supplier offer');
+  });
+
+  it('prevents supplier-offer identity from leaking into non-supplier legs', () => {
+    expect(integrity).toContain('non-supplier fulfilment item cannot carry supplier offer identity');
+  });
+
+  it('uses checkout control without mislabelling marketplace seller identity as supplierRef', () => {
+    const plannerStart = integrity.indexOf('CREATE OR REPLACE FUNCTION public.server_plan_order_fulfilment_leg_v1');
+    const planner = integrity.slice(plannerStart);
+    expect(planner).toContain("server_supplier_commerce_control_decision_v1('checkout'");
+    expect(planner).not.toContain("'supplierRef'");
+  });
+
+  it('keeps supplier submission and acknowledgement deferred to Phase J', () => {
+    expect(mixedLeg).not.toContain('submitOrder');
+    expect(integrity).not.toContain('submitOrder');
+    expect(integrity).not.toContain('external supplier order ID');
+    expect(integrity).not.toContain('supplier acknowledgement');
+  });
+});

--- a/netlify/functions/_shared/supplierOrderOrchestrator.ts
+++ b/netlify/functions/_shared/supplierOrderOrchestrator.ts
@@ -3,6 +3,60 @@ import type { SupabaseClient } from '@supabase/supabase-js';
 export const SUPPLIER_ORDER_ORCHESTRATOR_INTERFACE_VERSION = 1 as const;
 
 export type CommerceRiskAction = 'ALLOW' | 'REVIEW' | 'HOLD' | 'RESTRICT' | 'BLOCK';
+export type CommerceRiskSubject = 'buyer' | 'supplier' | 'order' | 'platform';
+
+export interface CommerceRiskDecision {
+  eligible: boolean;
+  reason: string;
+  interfaceVersion: 1;
+  action?: CommerceRiskAction;
+  riskScore?: number;
+  assessmentId?: string | null;
+  policyId?: string;
+  policyVersion?: number;
+}
+
+function isRiskDecision(value: unknown): value is CommerceRiskDecision {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  if (typeof row.eligible !== 'boolean' || typeof row.reason !== 'string' || row.interfaceVersion !== 1) return false;
+  if (row.action !== undefined && !['ALLOW', 'REVIEW', 'HOLD', 'RESTRICT', 'BLOCK'].includes(String(row.action))) return false;
+  if (row.riskScore !== undefined && typeof row.riskScore !== 'number') return false;
+  return true;
+}
+
+export async function assessSupplierCommerceRisk(
+  client: SupabaseClient,
+  input: {
+    orderId: string;
+    subjectType: CommerceRiskSubject;
+    subjectRef: string;
+    signals: Record<string, unknown>;
+    policyKey?: string;
+    idempotencyKey?: string;
+    orchestrationId?: string | null;
+  },
+): Promise<CommerceRiskDecision> {
+  try {
+    const { data, error } = await client.rpc('server_supplier_commerce_risk_decision_v1', {
+      p_order_id: input.orderId,
+      p_subject_type: input.subjectType,
+      p_subject_ref: input.subjectRef,
+      p_signals: input.signals,
+      p_policy_key: input.policyKey || 'supplier_commerce_default',
+      p_idempotency_key: input.idempotencyKey || null,
+      p_orchestration_id: input.orchestrationId || null,
+    });
+    if (error || !isRiskDecision(data)) throw error || new Error('invalid commerce risk evidence');
+    return data;
+  } catch {
+    return {
+      eligible: false,
+      reason: 'commerce_risk_unavailable',
+      interfaceVersion: SUPPLIER_ORDER_ORCHESTRATOR_INTERFACE_VERSION,
+    };
+  }
+}
 
 export interface SupplierReservationInput {
   orderId: string;

--- a/netlify/functions/_shared/supplierOrderOrchestrator.ts
+++ b/netlify/functions/_shared/supplierOrderOrchestrator.ts
@@ -1,0 +1,156 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export const SUPPLIER_ORDER_ORCHESTRATOR_INTERFACE_VERSION = 1 as const;
+
+export type CommerceRiskAction = 'ALLOW' | 'REVIEW' | 'HOLD' | 'RESTRICT' | 'BLOCK';
+
+export interface SupplierReservationInput {
+  orderId: string;
+  orderItemId: string;
+  supplierOfferId: string;
+  commercialMode: 'loadify_supplier_fulfilled';
+  quantity: number;
+  territory?: string;
+  externalVariantRef?: string;
+  reservationKey: string;
+  orchestrationIdempotencyKey: string;
+  correlationId: string;
+  riskSignals?: Record<string, unknown>;
+  riskPolicyKey?: string;
+  reservationMinutes?: number;
+}
+
+export interface SupplierReservationDecision {
+  eligible: boolean;
+  reason: string;
+  interfaceVersion: 1;
+  orchestrationId?: string;
+  fulfilmentLegId?: string;
+  reservationId?: string;
+  status?: string;
+  expiresAt?: string;
+  reservedQuantity?: number;
+  availableBeforeReservation?: number;
+  risk?: {
+    eligible?: boolean;
+    action?: CommerceRiskAction;
+    riskScore?: number;
+    reason?: string;
+  };
+}
+
+function isReservationDecision(value: unknown): value is SupplierReservationDecision {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  if (typeof row.eligible !== 'boolean' || typeof row.reason !== 'string' || row.interfaceVersion !== 1) return false;
+  if (!row.eligible) return true;
+  return typeof row.orchestrationId === 'string'
+    && typeof row.fulfilmentLegId === 'string'
+    && typeof row.reservationId === 'string'
+    && typeof row.expiresAt === 'string'
+    && typeof row.reservedQuantity === 'number';
+}
+
+export async function reserveSupplierOffer(
+  client: SupabaseClient,
+  input: SupplierReservationInput,
+): Promise<SupplierReservationDecision> {
+  try {
+    const { data, error } = await client.rpc('server_reserve_supplier_offer_v1', {
+      p_order_id: input.orderId,
+      p_order_item_id: input.orderItemId,
+      p_supplier_offer_id: input.supplierOfferId,
+      p_commercial_mode: input.commercialMode,
+      p_quantity: input.quantity,
+      p_territory: input.territory || 'GB',
+      p_external_variant_ref: input.externalVariantRef || '',
+      p_reservation_key: input.reservationKey,
+      p_orchestration_idempotency_key: input.orchestrationIdempotencyKey,
+      p_correlation_id: input.correlationId,
+      p_risk_signals: input.riskSignals || {},
+      p_risk_policy_key: input.riskPolicyKey || 'supplier_commerce_default',
+      p_reservation_minutes: input.reservationMinutes ?? 30,
+    });
+    if (error || !isReservationDecision(data)) throw error || new Error('invalid reservation evidence');
+    return data;
+  } catch {
+    return {
+      eligible: false,
+      reason: 'supplier_reservation_unavailable',
+      interfaceVersion: SUPPLIER_ORDER_ORCHESTRATOR_INTERFACE_VERSION,
+    };
+  }
+}
+
+export async function releaseSupplierReservation(
+  client: SupabaseClient,
+  reservationKey: string,
+  reason: string,
+): Promise<{ ok: boolean; reason: string; interfaceVersion: 1; reservationId?: string; status?: string }> {
+  try {
+    const { data, error } = await client.rpc('server_release_supplier_reservation_v1', {
+      p_reservation_key: reservationKey,
+      p_reason: reason,
+    });
+    if (error || !data || typeof data !== 'object') throw error || new Error('invalid release evidence');
+    const row = data as Record<string, unknown>;
+    if (typeof row.ok !== 'boolean' || typeof row.reason !== 'string' || row.interfaceVersion !== 1) throw new Error('invalid release evidence');
+    return data as { ok: boolean; reason: string; interfaceVersion: 1; reservationId?: string; status?: string };
+  } catch {
+    return { ok: false, reason: 'supplier_reservation_release_unavailable', interfaceVersion: 1 };
+  }
+}
+
+export interface RiskPolicyInput {
+  policyKey: string;
+  version: number;
+  status: 'draft' | 'approved';
+  reviewScore: number;
+  holdScore: number;
+  restrictScore: number;
+  blockScore: number;
+  evidence: Record<string, unknown>;
+  effectiveFrom?: string;
+}
+
+export async function mutateSupplierRiskPolicy(
+  client: SupabaseClient,
+  actorId: string,
+  input: RiskPolicyInput,
+): Promise<{ ok: true; data: unknown } | { ok: false; error: string }> {
+  try {
+    const { data, error } = await client.rpc('server_admin_supplier_risk_policy_v1', {
+      p_actor_id: actorId,
+      p_policy_key: input.policyKey,
+      p_version: input.version,
+      p_status: input.status,
+      p_review_score: input.reviewScore,
+      p_hold_score: input.holdScore,
+      p_restrict_score: input.restrictScore,
+      p_block_score: input.blockScore,
+      p_evidence: input.evidence,
+      p_effective_from: input.effectiveFrom || null,
+    });
+    if (error) return { ok: false, error: error.message || 'risk policy mutation failed' };
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : 'risk policy mutation failed' };
+  }
+}
+
+export async function readSupplierOrderOrchestrationStatus(
+  client: SupabaseClient,
+  actorId: string,
+  orderId: string,
+): Promise<{ ok: true; data: unknown } | { ok: false; error: string }> {
+  try {
+    const { data, error } = await client.rpc('server_admin_supplier_order_orchestration_status_v1', {
+      p_actor_id: actorId,
+      p_order_id: orderId,
+    });
+    if (error || !data || typeof data !== 'object') return { ok: false, error: error?.message || 'orchestration status unavailable' };
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: error instanceof Error ? error.message : 'orchestration status unavailable' };
+  }
+}

--- a/netlify/functions/admin-supplier-order-orchestration.ts
+++ b/netlify/functions/admin-supplier-order-orchestration.ts
@@ -1,0 +1,74 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { jsonResponse, optionsResponse } from './_shared/http';
+import {
+  mutateSupplierRiskPolicy,
+  readSupplierOrderOrchestrationStatus,
+  type RiskPolicyInput,
+} from './_shared/supplierOrderOrchestrator';
+
+const METHODS = 'POST, OPTIONS';
+
+type AdminAction =
+  | { action: 'risk_policy'; policy: RiskPolicyInput }
+  | { action: 'status'; orderId: string };
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return optionsResponse(METHODS);
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' }, METHODS);
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) return jsonResponse(500, { error: 'Server configuration error' }, METHODS);
+
+  const admin = createClient(supabaseUrl, serviceRoleKey, { auth: { autoRefreshToken: false, persistSession: false } });
+  const auth = await authenticateActiveAccount(event, admin, ['admin']);
+  if (!auth.ok) return jsonResponse(auth.status, { error: 'Unauthorized' }, METHODS);
+
+  let body: AdminAction;
+  try { body = JSON.parse(event.body || '{}') as AdminAction; }
+  catch { return jsonResponse(400, { error: 'Invalid JSON body' }, METHODS); }
+
+  if (!body || typeof body !== 'object' || Array.isArray(body) || !('action' in body)) {
+    return jsonResponse(400, { error: 'A valid Phase I admin action is required' }, METHODS);
+  }
+
+  const serialized = JSON.stringify(body);
+  if (/password|secret|access[_-]?token|refresh[_-]?token|api[_-]?key|card(number)?/i.test(serialized)) {
+    return jsonResponse(400, { error: 'Secrets or payment credentials are not accepted in order-risk governance payloads' }, METHODS);
+  }
+
+  if (body.action === 'status') {
+    if (typeof body.orderId !== 'string' || !body.orderId.trim()) return jsonResponse(400, { error: 'orderId is required' }, METHODS);
+    const result = await readSupplierOrderOrchestrationStatus(admin, auth.actor.id, body.orderId.trim());
+    if (!result.ok) return jsonResponse(500, { error: 'Unable to read supplier order orchestration status' }, METHODS);
+    return jsonResponse(200, { ok: true, result: result.data }, METHODS);
+  }
+
+  if (body.action === 'risk_policy') {
+    const p = body.policy;
+    if (!p || typeof p !== 'object' || Array.isArray(p)
+      || typeof p.policyKey !== 'string' || !p.policyKey.trim()
+      || !Number.isInteger(p.version) || p.version <= 0
+      || !['draft', 'approved'].includes(p.status)
+      || !Number.isInteger(p.reviewScore) || !Number.isInteger(p.holdScore)
+      || !Number.isInteger(p.restrictScore) || !Number.isInteger(p.blockScore)
+      || p.reviewScore < 0 || p.blockScore > 100
+      || p.reviewScore > p.holdScore || p.holdScore > p.restrictScore || p.restrictScore > p.blockScore
+      || !p.evidence || typeof p.evidence !== 'object' || Array.isArray(p.evidence)) {
+      return jsonResponse(400, { error: 'A complete, ordered risk policy is required' }, METHODS);
+    }
+    const result = await mutateSupplierRiskPolicy(admin, auth.actor.id, p);
+    if (!result.ok) {
+      const forbidden = /authority|admin|permission/i.test(result.error);
+      const validation = /required|invalid|policy|threshold|evidence|retire|version|secret/i.test(result.error);
+      return jsonResponse(forbidden ? 403 : validation ? 400 : 500, {
+        error: forbidden ? 'Unauthorized' : validation ? result.error : 'Unable to update commerce risk policy',
+      }, METHODS);
+    }
+    return jsonResponse(200, { ok: true, result: result.data }, METHODS);
+  }
+
+  return jsonResponse(400, { error: 'Unsupported Phase I admin action' }, METHODS);
+};

--- a/supabase/634_supplier_order_orchestrator_risk_reservation.sql
+++ b/supabase/634_supplier_order_orchestrator_risk_reservation.sql
@@ -1,0 +1,168 @@
+-- 634_supplier_order_orchestrator_risk_reservation.sql
+-- Phase I — canonical order orchestration + commerce risk + supplier reservation foundations.
+-- Public orders remain the ONE CUSTOMER ORDER. Internal fulfilment legs do not create a parallel buyer order system.
+-- Supplier Commerce remains fail-closed. This migration enables no control.
+
+CREATE SCHEMA IF NOT EXISTS private;
+
+CREATE TABLE IF NOT EXISTS private.supplier_order_orchestrations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id uuid NOT NULL UNIQUE REFERENCES public.orders(id) ON DELETE RESTRICT,
+  buyer_id uuid NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  state text NOT NULL DEFAULT 'planning',
+  correlation_id uuid NOT NULL,
+  idempotency_key text NOT NULL UNIQUE,
+  risk_state text NOT NULL DEFAULT 'not_assessed',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_order_orchestration_state_check CHECK (
+    state IN ('planning','review','hold','reserved','ready_for_payment','released','cancelled')
+  ),
+  CONSTRAINT supplier_order_orchestration_risk_state_check CHECK (
+    risk_state IN ('not_assessed','allow','review','hold','restrict','block')
+  ),
+  CONSTRAINT supplier_order_orchestration_idempotency_check CHECK (NULLIF(BTRIM(idempotency_key),'') IS NOT NULL)
+);
+
+CREATE TABLE IF NOT EXISTS private.supplier_fulfilment_legs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  orchestration_id uuid NOT NULL REFERENCES private.supplier_order_orchestrations(id) ON DELETE RESTRICT,
+  leg_key text NOT NULL,
+  fulfiller_type text NOT NULL,
+  commercial_mode text NOT NULL,
+  supplier_offer_id uuid REFERENCES private.supplier_offers(id) ON DELETE RESTRICT,
+  seller_id uuid REFERENCES public.users(id) ON DELETE RESTRICT,
+  status text NOT NULL DEFAULT 'planned',
+  currency text,
+  expected_cost numeric(14,2),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_fulfilment_leg_key_unique UNIQUE(orchestration_id, leg_key),
+  CONSTRAINT supplier_fulfilment_leg_key_check CHECK (NULLIF(BTRIM(leg_key),'') IS NOT NULL),
+  CONSTRAINT supplier_fulfilment_leg_fulfiller_check CHECK (fulfiller_type IN ('marketplace_seller','loadify_direct','supplier')),
+  CONSTRAINT supplier_fulfilment_leg_mode_check CHECK (commercial_mode IN ('marketplace_seller','loadify_supplier_fulfilled','loadify_direct')),
+  CONSTRAINT supplier_fulfilment_leg_status_check CHECK (status IN ('planned','review','hold','reserved','ready_for_payment','released','cancelled')),
+  CONSTRAINT supplier_fulfilment_leg_currency_check CHECK (currency IS NULL OR (currency = upper(BTRIM(currency)) AND currency ~ '^[A-Z]{3}$')),
+  CONSTRAINT supplier_fulfilment_leg_cost_check CHECK (expected_cost IS NULL OR expected_cost >= 0),
+  CONSTRAINT supplier_fulfilment_leg_route_check CHECK (
+    (fulfiller_type='supplier' AND supplier_offer_id IS NOT NULL AND commercial_mode='loadify_supplier_fulfilled')
+    OR (fulfiller_type='loadify_direct' AND commercial_mode='loadify_direct')
+    OR (fulfiller_type='marketplace_seller' AND seller_id IS NOT NULL AND commercial_mode='marketplace_seller')
+  )
+);
+
+CREATE TABLE IF NOT EXISTS private.supplier_fulfilment_leg_items (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  leg_id uuid NOT NULL REFERENCES private.supplier_fulfilment_legs(id) ON DELETE RESTRICT,
+  order_item_id uuid NOT NULL UNIQUE REFERENCES public.order_items(id) ON DELETE RESTRICT,
+  canonical_product_id uuid,
+  supplier_offer_id uuid REFERENCES private.supplier_offers(id) ON DELETE RESTRICT,
+  quantity integer NOT NULL CHECK (quantity > 0),
+  external_variant_ref text NOT NULL DEFAULT '',
+  pricing_snapshot_id uuid REFERENCES private.supplier_pricing_snapshots(id) ON DELETE RESTRICT,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_fulfilment_item_variant_check CHECK (external_variant_ref=BTRIM(external_variant_ref))
+);
+
+CREATE TABLE IF NOT EXISTS private.supplier_commerce_risk_policy_versions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  policy_key text NOT NULL,
+  version integer NOT NULL CHECK (version > 0),
+  status text NOT NULL DEFAULT 'draft',
+  review_score integer NOT NULL CHECK (review_score BETWEEN 0 AND 100),
+  hold_score integer NOT NULL CHECK (hold_score BETWEEN 0 AND 100),
+  restrict_score integer NOT NULL CHECK (restrict_score BETWEEN 0 AND 100),
+  block_score integer NOT NULL CHECK (block_score BETWEEN 0 AND 100),
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  approved_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  approved_at timestamptz,
+  effective_from timestamptz NOT NULL DEFAULT now(),
+  effective_to timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_commerce_risk_policy_unique UNIQUE(policy_key,version),
+  CONSTRAINT supplier_commerce_risk_policy_key_check CHECK (NULLIF(BTRIM(policy_key),'') IS NOT NULL),
+  CONSTRAINT supplier_commerce_risk_policy_status_check CHECK (status IN ('draft','approved','retired')),
+  CONSTRAINT supplier_commerce_risk_policy_threshold_check CHECK (
+    review_score <= hold_score AND hold_score <= restrict_score AND restrict_score <= block_score
+  ),
+  CONSTRAINT supplier_commerce_risk_policy_evidence_check CHECK (jsonb_typeof(evidence)='object'),
+  CONSTRAINT supplier_commerce_risk_policy_approval_check CHECK (
+    status <> 'approved' OR (approved_by IS NOT NULL AND approved_at IS NOT NULL AND evidence <> '{}'::jsonb)
+  ),
+  CONSTRAINT supplier_commerce_risk_policy_effective_check CHECK (effective_to IS NULL OR effective_to > effective_from)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_commerce_risk_one_active_policy_idx
+  ON private.supplier_commerce_risk_policy_versions(policy_key)
+  WHERE status='approved' AND effective_to IS NULL;
+
+CREATE TABLE IF NOT EXISTS private.supplier_commerce_risk_assessments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id uuid NOT NULL REFERENCES public.orders(id) ON DELETE RESTRICT,
+  orchestration_id uuid REFERENCES private.supplier_order_orchestrations(id) ON DELETE RESTRICT,
+  subject_type text NOT NULL,
+  subject_ref text NOT NULL,
+  risk_score integer NOT NULL CHECK (risk_score BETWEEN 0 AND 100),
+  action text NOT NULL,
+  policy_id uuid NOT NULL REFERENCES private.supplier_commerce_risk_policy_versions(id) ON DELETE RESTRICT,
+  signals jsonb NOT NULL,
+  reason text NOT NULL,
+  idempotency_key text NOT NULL UNIQUE,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_commerce_risk_subject_check CHECK (subject_type IN ('buyer','supplier','order','platform')),
+  CONSTRAINT supplier_commerce_risk_action_check CHECK (action IN ('ALLOW','REVIEW','HOLD','RESTRICT','BLOCK')),
+  CONSTRAINT supplier_commerce_risk_subject_ref_check CHECK (NULLIF(BTRIM(subject_ref),'') IS NOT NULL),
+  CONSTRAINT supplier_commerce_risk_signals_check CHECK (jsonb_typeof(signals)='object'),
+  CONSTRAINT supplier_commerce_risk_reason_check CHECK (NULLIF(BTRIM(reason),'') IS NOT NULL),
+  CONSTRAINT supplier_commerce_risk_idempotency_check CHECK (NULLIF(BTRIM(idempotency_key),'') IS NOT NULL)
+);
+CREATE INDEX IF NOT EXISTS supplier_commerce_risk_order_idx
+  ON private.supplier_commerce_risk_assessments(order_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS private.supplier_stock_reservations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  orchestration_id uuid NOT NULL REFERENCES private.supplier_order_orchestrations(id) ON DELETE RESTRICT,
+  leg_item_id uuid NOT NULL REFERENCES private.supplier_fulfilment_leg_items(id) ON DELETE RESTRICT,
+  order_id uuid NOT NULL REFERENCES public.orders(id) ON DELETE RESTRICT,
+  order_item_id uuid NOT NULL REFERENCES public.order_items(id) ON DELETE RESTRICT,
+  supplier_offer_id uuid NOT NULL REFERENCES private.supplier_offers(id) ON DELETE RESTRICT,
+  canonical_product_id uuid NOT NULL,
+  external_variant_ref text NOT NULL DEFAULT '',
+  quantity integer NOT NULL CHECK (quantity > 0),
+  status text NOT NULL DEFAULT 'active',
+  reservation_key text NOT NULL UNIQUE,
+  stock_observation_id uuid NOT NULL REFERENCES private.supplier_stock_observations(id) ON DELETE RESTRICT,
+  price_observation_id uuid NOT NULL REFERENCES private.supplier_price_observations(id) ON DELETE RESTRICT,
+  pricing_snapshot_id uuid NOT NULL REFERENCES private.supplier_pricing_snapshots(id) ON DELETE RESTRICT,
+  sync_policy_version integer NOT NULL CHECK (sync_policy_version > 0),
+  expires_at timestamptz NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  released_at timestamptz,
+  consumed_at timestamptz,
+  CONSTRAINT supplier_stock_reservation_status_check CHECK (status IN ('active','released','expired','consumed')),
+  CONSTRAINT supplier_stock_reservation_variant_check CHECK (external_variant_ref=BTRIM(external_variant_ref)),
+  CONSTRAINT supplier_stock_reservation_key_check CHECK (NULLIF(BTRIM(reservation_key),'') IS NOT NULL),
+  CONSTRAINT supplier_stock_reservation_expiry_check CHECK (expires_at > created_at),
+  CONSTRAINT supplier_stock_reservation_terminal_check CHECK (
+    (status='active' AND released_at IS NULL AND consumed_at IS NULL)
+    OR (status IN ('released','expired') AND released_at IS NOT NULL AND consumed_at IS NULL)
+    OR (status='consumed' AND consumed_at IS NOT NULL)
+  )
+);
+CREATE INDEX IF NOT EXISTS supplier_stock_reservation_active_offer_idx
+  ON private.supplier_stock_reservations(supplier_offer_id, external_variant_ref, expires_at)
+  WHERE status='active';
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_stock_reservation_one_active_item_idx
+  ON private.supplier_stock_reservations(order_item_id)
+  WHERE status='active';
+
+REVOKE ALL ON TABLE private.supplier_order_orchestrations FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_fulfilment_legs FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_fulfilment_leg_items FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_commerce_risk_policy_versions FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_commerce_risk_assessments FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_stock_reservations FROM PUBLIC, anon, authenticated, service_role;
+
+COMMENT ON TABLE private.supplier_order_orchestrations IS 'Phase I internal orchestration attached to the existing public customer order. It is not a parallel buyer order.';
+COMMENT ON TABLE private.supplier_fulfilment_legs IS 'Internal fulfilment legs for one canonical customer order; supports seller, Loadify direct and supplier-fulfilled routes.';
+COMMENT ON TABLE private.supplier_commerce_risk_assessments IS 'Append-only commerce risk decisions. Risk action does not itself ban an account.';
+COMMENT ON TABLE private.supplier_stock_reservations IS 'Canonical supplier-stock reservations backed by fresh Phase H stock/price evidence and scoped to one existing public order item.';

--- a/supabase/635_supplier_order_orchestrator_runtime_guards.sql
+++ b/supabase/635_supplier_order_orchestrator_runtime_guards.sql
@@ -1,0 +1,337 @@
+-- 635_supplier_order_orchestrator_runtime_guards.sql
+-- Phase I runtime: risk decision, atomic supplier reservation and orchestration state.
+-- Uses existing public.orders/public.order_items as customer order truth and Phase H stock/price readiness.
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_commerce_risk_immutable_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+BEGIN
+  RAISE EXCEPTION 'commerce risk assessments are append-only';
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_commerce_risk_immutable_v1 ON private.supplier_commerce_risk_assessments;
+CREATE TRIGGER trg_guard_supplier_commerce_risk_immutable_v1
+BEFORE UPDATE OR DELETE ON private.supplier_commerce_risk_assessments
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_commerce_risk_immutable_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_fulfilment_item_identity_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+DECLARE
+  v_order_id uuid;
+  v_leg_order_id uuid;
+  v_item_product_id uuid;
+  v_offer private.supplier_offers%ROWTYPE;
+BEGIN
+  SELECT oi."orderId", oi."productId" INTO v_order_id, v_item_product_id
+    FROM public.order_items oi WHERE oi.id=NEW.order_item_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'canonical order item required'; END IF;
+
+  SELECT o.order_id INTO v_leg_order_id
+    FROM private.supplier_fulfilment_legs l
+    JOIN private.supplier_order_orchestrations o ON o.id=l.orchestration_id
+   WHERE l.id=NEW.leg_id;
+  IF NOT FOUND OR v_leg_order_id<>v_order_id THEN
+    RAISE EXCEPTION 'fulfilment leg item must belong to the same canonical customer order';
+  END IF;
+
+  IF NEW.supplier_offer_id IS NOT NULL THEN
+    SELECT * INTO v_offer FROM private.supplier_offers WHERE id=NEW.supplier_offer_id;
+    IF NOT FOUND THEN RAISE EXCEPTION 'supplier offer not found'; END IF;
+    IF NEW.canonical_product_id IS DISTINCT FROM v_offer.canonical_product_id THEN
+      RAISE EXCEPTION 'fulfilment item canonical product must match supplier offer';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_fulfilment_item_identity_v1 ON private.supplier_fulfilment_leg_items;
+CREATE TRIGGER trg_guard_supplier_fulfilment_item_identity_v1
+BEFORE INSERT OR UPDATE ON private.supplier_fulfilment_leg_items
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_fulfilment_item_identity_v1();
+
+CREATE OR REPLACE FUNCTION public.server_supplier_commerce_risk_decision_v1(
+  p_order_id uuid,
+  p_subject_type text,
+  p_subject_ref text,
+  p_signals jsonb,
+  p_policy_key text DEFAULT 'supplier_commerce_default',
+  p_idempotency_key text DEFAULT NULL,
+  p_orchestration_id uuid DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_subject text:=lower(BTRIM(COALESCE(p_subject_type,'')));
+  v_ref text:=NULLIF(BTRIM(p_subject_ref),'');
+  v_policy private.supplier_commerce_risk_policy_versions%ROWTYPE;
+  v_existing private.supplier_commerce_risk_assessments%ROWTYPE;
+  v_score integer:=0;
+  v_action text;
+  v_reason text;
+  v_idem text:=NULLIF(BTRIM(p_idempotency_key),'');
+  v_value jsonb;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.orders o WHERE o.id=p_order_id) THEN
+    RETURN jsonb_build_object('eligible',false,'reason','order_not_found','interfaceVersion',1);
+  END IF;
+  IF v_subject NOT IN ('buyer','supplier','order','platform') OR v_ref IS NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','invalid_risk_subject','interfaceVersion',1);
+  END IF;
+  IF p_signals IS NULL OR jsonb_typeof(p_signals)<>'object' THEN
+    RETURN jsonb_build_object('eligible',false,'reason','invalid_risk_signals','interfaceVersion',1);
+  END IF;
+  IF p_signals::text ~* '(password|secret|access[_-]?token|refresh[_-]?token|api[_-]?key|card(number)?)' THEN
+    RETURN jsonb_build_object('eligible',false,'reason','secret_bearing_risk_payload_rejected','interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_policy
+    FROM private.supplier_commerce_risk_policy_versions p
+   WHERE p.policy_key=BTRIM(COALESCE(p_policy_key,'supplier_commerce_default'))
+     AND p.status='approved'
+     AND p.effective_from<=now()
+     AND (p.effective_to IS NULL OR p.effective_to>now())
+   ORDER BY p.version DESC LIMIT 1;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('eligible',false,'reason','risk_policy_missing','interfaceVersion',1);
+  END IF;
+
+  -- Score only explicit server-provided 0..100 numeric signals. Booleans true are treated as 100.
+  FOR v_value IN SELECT value FROM jsonb_each(p_signals) LOOP
+    IF jsonb_typeof(v_value)='number' THEN
+      v_score:=GREATEST(v_score,LEAST(100,GREATEST(0,(v_value::text)::numeric::integer)));
+    ELSIF jsonb_typeof(v_value)='boolean' AND (v_value::text)::boolean THEN
+      v_score:=100;
+    END IF;
+  END LOOP;
+
+  v_action:=CASE
+    WHEN v_score>=v_policy.block_score THEN 'BLOCK'
+    WHEN v_score>=v_policy.restrict_score THEN 'RESTRICT'
+    WHEN v_score>=v_policy.hold_score THEN 'HOLD'
+    WHEN v_score>=v_policy.review_score THEN 'REVIEW'
+    ELSE 'ALLOW'
+  END;
+  v_reason:='policy_score_'||lower(v_action);
+
+  IF v_idem IS NOT NULL THEN
+    SELECT * INTO v_existing FROM private.supplier_commerce_risk_assessments WHERE idempotency_key=v_idem;
+    IF FOUND THEN
+      IF v_existing.order_id<>p_order_id OR v_existing.subject_type<>v_subject OR v_existing.subject_ref<>v_ref
+         OR v_existing.policy_id<>v_policy.id OR v_existing.signals<>p_signals THEN
+        RAISE EXCEPTION 'risk idempotency key collision with different evidence';
+      END IF;
+      RETURN jsonb_build_object('eligible',v_existing.action='ALLOW','reason',v_existing.reason,'action',v_existing.action,
+        'riskScore',v_existing.risk_score,'assessmentId',v_existing.id,'policyId',v_existing.policy_id,'policyVersion',v_policy.version,'interfaceVersion',1);
+    END IF;
+
+    INSERT INTO private.supplier_commerce_risk_assessments(
+      order_id,orchestration_id,subject_type,subject_ref,risk_score,action,policy_id,signals,reason,idempotency_key
+    ) VALUES(p_order_id,p_orchestration_id,v_subject,v_ref,v_score,v_action,v_policy.id,p_signals,v_reason,v_idem)
+    RETURNING * INTO v_existing;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'eligible',v_action='ALLOW','reason',v_reason,'action',v_action,'riskScore',v_score,
+    'assessmentId',CASE WHEN v_existing.id IS NULL THEN NULL ELSE v_existing.id END,
+    'policyId',v_policy.id,'policyVersion',v_policy.version,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_supplier_commerce_risk_decision_v1(uuid,text,text,jsonb,text,text,uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_commerce_risk_decision_v1(uuid,text,text,jsonb,text,text,uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_reserve_supplier_offer_v1(
+  p_order_id uuid,
+  p_order_item_id uuid,
+  p_supplier_offer_id uuid,
+  p_commercial_mode text,
+  p_quantity integer,
+  p_territory text,
+  p_external_variant_ref text,
+  p_reservation_key text,
+  p_orchestration_idempotency_key text,
+  p_correlation_id uuid,
+  p_risk_signals jsonb DEFAULT '{}'::jsonb,
+  p_risk_policy_key text DEFAULT 'supplier_commerce_default',
+  p_reservation_minutes integer DEFAULT 30
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_order public.orders%ROWTYPE;
+  v_item public.order_items%ROWTYPE;
+  v_offer private.supplier_offers%ROWTYPE;
+  v_orch private.supplier_order_orchestrations%ROWTYPE;
+  v_leg private.supplier_fulfilment_legs%ROWTYPE;
+  v_leg_item private.supplier_fulfilment_leg_items%ROWTYPE;
+  v_existing private.supplier_stock_reservations%ROWTYPE;
+  v_control jsonb;
+  v_sync jsonb;
+  v_risk jsonb;
+  v_sellable integer;
+  v_already_reserved integer:=0;
+  v_available integer;
+  v_reservation private.supplier_stock_reservations%ROWTYPE;
+  v_leg_key text;
+  v_variant text:=BTRIM(COALESCE(p_external_variant_ref,''));
+BEGIN
+  IF p_quantity IS NULL OR p_quantity<=0 OR p_reservation_minutes NOT BETWEEN 1 AND 60 THEN
+    RETURN jsonb_build_object('eligible',false,'reason','invalid_reservation_request','interfaceVersion',1);
+  END IF;
+  IF NULLIF(BTRIM(p_reservation_key),'') IS NULL OR NULLIF(BTRIM(p_orchestration_idempotency_key),'') IS NULL OR p_correlation_id IS NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','idempotency_and_correlation_required','interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_order FROM public.orders WHERE id=p_order_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','order_not_found','interfaceVersion',1); END IF;
+  SELECT * INTO v_item FROM public.order_items WHERE id=p_order_item_id AND "orderId"=p_order_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','order_item_not_found','interfaceVersion',1); END IF;
+  IF p_quantity>v_item.quantity THEN RETURN jsonb_build_object('eligible',false,'reason','reservation_exceeds_order_quantity','interfaceVersion',1); END IF;
+
+  SELECT * INTO v_offer FROM private.supplier_offers WHERE id=p_supplier_offer_id AND status='approved' FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','supplier_offer_not_ready','interfaceVersion',1); END IF;
+  IF p_commercial_mode<>'loadify_supplier_fulfilled' THEN
+    RETURN jsonb_build_object('eligible',false,'reason','supplier_reservation_requires_supplier_fulfilled_mode','interfaceVersion',1);
+  END IF;
+
+  v_control:=public.server_supplier_commerce_control_decision_v1('reservation',jsonb_build_object(
+    'offerRef',v_offer.offer_key,'productRef',v_offer.canonical_product_id::text,'territory',upper(BTRIM(COALESCE(p_territory,'GB')))
+  ));
+  IF COALESCE((v_control->>'enabled')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('eligible',false,'reason','reservation_control_disabled','control',v_control,'interfaceVersion',1);
+  END IF;
+
+  INSERT INTO private.supplier_order_orchestrations(order_id,buyer_id,correlation_id,idempotency_key)
+  VALUES(p_order_id,v_order."buyerId",p_correlation_id,BTRIM(p_orchestration_idempotency_key))
+  ON CONFLICT (order_id) DO NOTHING;
+  SELECT * INTO v_orch FROM private.supplier_order_orchestrations WHERE order_id=p_order_id FOR UPDATE;
+  IF v_orch.idempotency_key<>BTRIM(p_orchestration_idempotency_key) THEN
+    RAISE EXCEPTION 'order orchestration idempotency mismatch';
+  END IF;
+
+  v_risk:=public.server_supplier_commerce_risk_decision_v1(
+    p_order_id,'order',p_order_id::text,COALESCE(p_risk_signals,'{}'::jsonb),p_risk_policy_key,
+    'risk:'||BTRIM(p_reservation_key),v_orch.id
+  );
+  UPDATE private.supplier_order_orchestrations
+     SET risk_state=lower(COALESCE(v_risk->>'action','block')),
+         state=CASE COALESCE(v_risk->>'action','BLOCK') WHEN 'REVIEW' THEN 'review' WHEN 'HOLD' THEN 'hold' WHEN 'RESTRICT' THEN 'hold' WHEN 'BLOCK' THEN 'hold' ELSE state END,
+         updated_at=now()
+   WHERE id=v_orch.id;
+  IF COALESCE((v_risk->>'eligible')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('eligible',false,'reason','commerce_risk_not_allowed','risk',v_risk,'orchestrationId',v_orch.id,'interfaceVersion',1);
+  END IF;
+
+  v_sync:=public.server_supplier_stock_price_decision_v1(
+    p_supplier_offer_id,v_offer.canonical_product_id,p_commercial_mode,p_territory,v_variant
+  );
+  IF COALESCE((v_sync->>'eligible')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('eligible',false,'reason','stock_price_not_ready','sync',v_sync,'orchestrationId',v_orch.id,'interfaceVersion',1);
+  END IF;
+  IF v_sync->>'sellableQuantity' IS NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','sellable_quantity_unknown','sync',v_sync,'orchestrationId',v_orch.id,'interfaceVersion',1);
+  END IF;
+  v_sellable:=(v_sync->>'sellableQuantity')::integer;
+
+  SELECT * INTO v_existing FROM private.supplier_stock_reservations WHERE reservation_key=BTRIM(p_reservation_key);
+  IF FOUND THEN
+    IF v_existing.order_id<>p_order_id OR v_existing.order_item_id<>p_order_item_id OR v_existing.supplier_offer_id<>p_supplier_offer_id
+       OR v_existing.quantity<>p_quantity OR v_existing.external_variant_ref<>v_variant THEN
+      RAISE EXCEPTION 'reservation idempotency key collision with different request';
+    END IF;
+    RETURN jsonb_build_object('eligible',v_existing.status='active','reason','reservation_replayed','reservationId',v_existing.id,
+      'orchestrationId',v_existing.orchestration_id,'status',v_existing.status,'expiresAt',v_existing.expires_at,'interfaceVersion',1);
+  END IF;
+
+  -- Offer row is locked above; this serialises reservations for the offer so parallel requests cannot oversell sellable stock.
+  SELECT COALESCE(SUM(r.quantity),0)::integer INTO v_already_reserved
+    FROM private.supplier_stock_reservations r
+   WHERE r.supplier_offer_id=p_supplier_offer_id
+     AND r.external_variant_ref=v_variant
+     AND r.status='active'
+     AND r.expires_at>now();
+  v_available:=GREATEST(v_sellable-v_already_reserved,0);
+  IF p_quantity>v_available THEN
+    RETURN jsonb_build_object('eligible',false,'reason','reservation_capacity_exhausted','sellableQuantity',v_sellable,
+      'alreadyReserved',v_already_reserved,'availableToReserve',v_available,'orchestrationId',v_orch.id,'interfaceVersion',1);
+  END IF;
+
+  v_leg_key:='supplier:'||p_supplier_offer_id::text;
+  INSERT INTO private.supplier_fulfilment_legs(
+    orchestration_id,leg_key,fulfiller_type,commercial_mode,supplier_offer_id,status,currency
+  ) VALUES(v_orch.id,v_leg_key,'supplier','loadify_supplier_fulfilled',p_supplier_offer_id,'planned',v_sync->>'currency')
+  ON CONFLICT (orchestration_id,leg_key) DO NOTHING;
+  SELECT * INTO v_leg FROM private.supplier_fulfilment_legs WHERE orchestration_id=v_orch.id AND leg_key=v_leg_key FOR UPDATE;
+
+  INSERT INTO private.supplier_fulfilment_leg_items(
+    leg_id,order_item_id,canonical_product_id,supplier_offer_id,quantity,external_variant_ref,pricing_snapshot_id
+  ) VALUES(v_leg.id,p_order_item_id,v_offer.canonical_product_id,p_supplier_offer_id,p_quantity,v_variant,NULLIF(v_sync->>'pricingSnapshotId','')::uuid)
+  ON CONFLICT (order_item_id) DO NOTHING;
+  SELECT * INTO v_leg_item FROM private.supplier_fulfilment_leg_items WHERE order_item_id=p_order_item_id;
+  IF v_leg_item.leg_id<>v_leg.id OR v_leg_item.supplier_offer_id<>p_supplier_offer_id OR v_leg_item.quantity<>p_quantity THEN
+    RAISE EXCEPTION 'order item is already routed to a different fulfilment leg';
+  END IF;
+
+  INSERT INTO private.supplier_stock_reservations(
+    orchestration_id,leg_item_id,order_id,order_item_id,supplier_offer_id,canonical_product_id,external_variant_ref,quantity,status,reservation_key,
+    stock_observation_id,price_observation_id,pricing_snapshot_id,sync_policy_version,expires_at
+  ) VALUES(
+    v_orch.id,v_leg_item.id,p_order_id,p_order_item_id,p_supplier_offer_id,v_offer.canonical_product_id,v_variant,p_quantity,'active',BTRIM(p_reservation_key),
+    (v_sync->>'stockObservationId')::uuid,(v_sync->>'priceObservationId')::uuid,(v_sync->>'pricingSnapshotId')::uuid,(v_sync->>'policyVersion')::integer,
+    now()+make_interval(mins=>p_reservation_minutes)
+  ) RETURNING * INTO v_reservation;
+
+  UPDATE private.supplier_fulfilment_legs SET status='reserved',updated_at=now() WHERE id=v_leg.id;
+  UPDATE private.supplier_order_orchestrations SET state='reserved',risk_state='allow',updated_at=now() WHERE id=v_orch.id;
+
+  RETURN jsonb_build_object(
+    'eligible',true,'reason','supplier_stock_reserved','orchestrationId',v_orch.id,'fulfilmentLegId',v_leg.id,'reservationId',v_reservation.id,
+    'availableBeforeReservation',v_available,'reservedQuantity',p_quantity,'expiresAt',v_reservation.expires_at,
+    'stockObservationId',v_reservation.stock_observation_id,'priceObservationId',v_reservation.price_observation_id,
+    'pricingSnapshotId',v_reservation.pricing_snapshot_id,'risk',v_risk,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_reserve_supplier_offer_v1(uuid,uuid,uuid,text,integer,text,text,text,text,uuid,jsonb,text,integer) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_reserve_supplier_offer_v1(uuid,uuid,uuid,text,integer,text,text,text,text,uuid,jsonb,text,integer) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_release_supplier_reservation_v1(
+  p_reservation_key text,
+  p_reason text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE v_res private.supplier_stock_reservations%ROWTYPE; v_reason text:=NULLIF(BTRIM(p_reason),'');
+BEGIN
+  IF v_reason IS NULL THEN RAISE EXCEPTION 'reservation release reason required'; END IF;
+  SELECT * INTO v_res FROM private.supplier_stock_reservations WHERE reservation_key=BTRIM(COALESCE(p_reservation_key,'')) FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','reservation_not_found','interfaceVersion',1); END IF;
+  IF v_res.status IN ('released','expired') THEN
+    RETURN jsonb_build_object('ok',true,'reason','reservation_already_released','reservationId',v_res.id,'status',v_res.status,'interfaceVersion',1);
+  END IF;
+  IF v_res.status='consumed' THEN RETURN jsonb_build_object('ok',false,'reason','consumed_reservation_cannot_release','interfaceVersion',1); END IF;
+  UPDATE private.supplier_stock_reservations SET status='released',released_at=now() WHERE id=v_res.id RETURNING * INTO v_res;
+  UPDATE private.supplier_fulfilment_legs l SET status='released',updated_at=now()
+   WHERE l.id=(SELECT i.leg_id FROM private.supplier_fulfilment_leg_items i WHERE i.id=v_res.leg_item_id);
+  RETURN jsonb_build_object('ok',true,'reason','reservation_released','reservationId',v_res.id,'status',v_res.status,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_release_supplier_reservation_v1(text,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_release_supplier_reservation_v1(text,text) TO service_role;
+
+COMMENT ON FUNCTION public.server_supplier_commerce_risk_decision_v1(uuid,text,text,jsonb,text,text,uuid) IS 'Phase I policy-driven ALLOW/REVIEW/HOLD/RESTRICT/BLOCK commerce-risk decision. It never bans accounts by itself.';
+COMMENT ON FUNCTION public.server_reserve_supplier_offer_v1(uuid,uuid,uuid,text,integer,text,text,text,text,uuid,jsonb,text,integer) IS 'Phase I atomic supplier reservation attached to one existing public customer order and backed by Phase H stock/price evidence.';

--- a/supabase/636_supplier_order_risk_admin_governance.sql
+++ b/supabase/636_supplier_order_risk_admin_governance.sql
@@ -1,0 +1,214 @@
+-- 636_supplier_order_risk_admin_governance.sql
+-- Phase I governance: active-admin-only risk policy lifecycle, factual order-orchestrator status and safe reservation expiry.
+
+CREATE TABLE IF NOT EXISTS private.supplier_commerce_risk_policy_audit (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  policy_id uuid NOT NULL REFERENCES private.supplier_commerce_risk_policy_versions(id) ON DELETE RESTRICT,
+  actor_id uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  action text NOT NULL,
+  reason text NOT NULL,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_commerce_risk_policy_audit_action_check CHECK (action IN ('created','approved','retired')),
+  CONSTRAINT supplier_commerce_risk_policy_audit_reason_check CHECK (NULLIF(BTRIM(reason),'') IS NOT NULL),
+  CONSTRAINT supplier_commerce_risk_policy_audit_evidence_check CHECK (jsonb_typeof(evidence)='object')
+);
+REVOKE ALL ON TABLE private.supplier_commerce_risk_policy_audit FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_risk_policy_history_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+BEGIN
+  IF TG_OP='DELETE' THEN RAISE EXCEPTION 'risk policy history cannot be deleted'; END IF;
+  IF OLD.status='approved' AND (
+    NEW.policy_key IS DISTINCT FROM OLD.policy_key OR NEW.version IS DISTINCT FROM OLD.version OR
+    NEW.review_score IS DISTINCT FROM OLD.review_score OR NEW.hold_score IS DISTINCT FROM OLD.hold_score OR
+    NEW.restrict_score IS DISTINCT FROM OLD.restrict_score OR NEW.block_score IS DISTINCT FROM OLD.block_score OR
+    NEW.evidence IS DISTINCT FROM OLD.evidence OR NEW.approved_by IS DISTINCT FROM OLD.approved_by OR NEW.approved_at IS DISTINCT FROM OLD.approved_at OR
+    NEW.effective_from IS DISTINCT FROM OLD.effective_from
+  ) THEN
+    RAISE EXCEPTION 'approved risk policy is immutable; retire and create a new version';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_risk_policy_history_v1 ON private.supplier_commerce_risk_policy_versions;
+CREATE TRIGGER trg_guard_supplier_risk_policy_history_v1
+BEFORE UPDATE OR DELETE ON private.supplier_commerce_risk_policy_versions
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_risk_policy_history_v1();
+
+CREATE OR REPLACE FUNCTION public.server_admin_supplier_risk_policy_v1(
+  p_actor_id uuid,
+  p_policy_key text,
+  p_version integer,
+  p_status text,
+  p_review_score integer,
+  p_hold_score integer,
+  p_restrict_score integer,
+  p_block_score integer,
+  p_evidence jsonb,
+  p_effective_from timestamptz DEFAULT NULL
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_status text:=lower(BTRIM(COALESCE(p_status,'draft')));
+  v_key text:=NULLIF(BTRIM(p_policy_key),'');
+  v_saved private.supplier_commerce_risk_policy_versions%ROWTYPE;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id=p_actor_id AND u.role='admin' AND u."isActive"=true) THEN
+    RAISE EXCEPTION 'active admin authority is required' USING ERRCODE='42501';
+  END IF;
+  IF v_key IS NULL OR p_version IS NULL OR p_version<=0 THEN RAISE EXCEPTION 'risk policy key/version required'; END IF;
+  IF v_status NOT IN ('draft','approved') THEN RAISE EXCEPTION 'risk policy status must be draft or approved'; END IF;
+  IF p_review_score IS NULL OR p_hold_score IS NULL OR p_restrict_score IS NULL OR p_block_score IS NULL
+     OR p_review_score<0 OR p_block_score>100 OR p_review_score>p_hold_score OR p_hold_score>p_restrict_score OR p_restrict_score>p_block_score THEN
+    RAISE EXCEPTION 'invalid risk policy thresholds';
+  END IF;
+  IF p_evidence IS NULL OR jsonb_typeof(p_evidence)<>'object' OR (v_status='approved' AND p_evidence='{}'::jsonb) THEN
+    RAISE EXCEPTION 'risk policy evidence required';
+  END IF;
+  IF p_evidence::text ~* '(password|secret|access[_-]?token|refresh[_-]?token|api[_-]?key|card(number)?)' THEN
+    RAISE EXCEPTION 'secret-bearing risk policy payload rejected';
+  END IF;
+  IF v_status='approved' AND EXISTS (
+    SELECT 1 FROM private.supplier_commerce_risk_policy_versions p
+     WHERE p.policy_key=v_key AND p.status='approved' AND p.effective_to IS NULL
+  ) THEN RAISE EXCEPTION 'retire current approved risk policy before approving another'; END IF;
+
+  INSERT INTO private.supplier_commerce_risk_policy_versions(
+    policy_key,version,status,review_score,hold_score,restrict_score,block_score,evidence,approved_by,approved_at,effective_from
+  ) VALUES(
+    v_key,p_version,v_status,p_review_score,p_hold_score,p_restrict_score,p_block_score,p_evidence,
+    CASE WHEN v_status='approved' THEN p_actor_id ELSE NULL END,
+    CASE WHEN v_status='approved' THEN now() ELSE NULL END,
+    COALESCE(p_effective_from,now())
+  ) RETURNING * INTO v_saved;
+
+  INSERT INTO private.supplier_commerce_risk_policy_audit(policy_id,actor_id,action,reason,evidence)
+  VALUES(v_saved.id,p_actor_id,CASE WHEN v_status='approved' THEN 'approved' ELSE 'created' END,
+    CASE WHEN v_status='approved' THEN 'Approved Phase I commerce risk policy' ELSE 'Created Phase I commerce risk draft' END,p_evidence);
+
+  RETURN jsonb_build_object('ok',true,'policyId',v_saved.id,'policyKey',v_saved.policy_key,'version',v_saved.version,'status',v_saved.status,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_supplier_risk_policy_v1(uuid,text,integer,text,integer,integer,integer,integer,jsonb,timestamptz) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_supplier_risk_policy_v1(uuid,text,integer,text,integer,integer,integer,integer,jsonb,timestamptz) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_retire_supplier_risk_policy_v1(
+  p_actor_id uuid,
+  p_policy_key text,
+  p_reason text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_policy private.supplier_commerce_risk_policy_versions%ROWTYPE;
+  v_reason text:=NULLIF(BTRIM(p_reason),'');
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id=p_actor_id AND u.role='admin' AND u."isActive"=true) THEN
+    RAISE EXCEPTION 'active admin authority is required' USING ERRCODE='42501';
+  END IF;
+  IF v_reason IS NULL THEN RAISE EXCEPTION 'risk policy retirement reason required'; END IF;
+  SELECT * INTO v_policy FROM private.supplier_commerce_risk_policy_versions
+   WHERE policy_key=BTRIM(COALESCE(p_policy_key,'')) AND status='approved' AND effective_to IS NULL
+   ORDER BY version DESC LIMIT 1 FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'approved risk policy not found'; END IF;
+  UPDATE private.supplier_commerce_risk_policy_versions
+     SET status='retired',effective_to=now()
+   WHERE id=v_policy.id RETURNING * INTO v_policy;
+  INSERT INTO private.supplier_commerce_risk_policy_audit(policy_id,actor_id,action,reason,evidence)
+  VALUES(v_policy.id,p_actor_id,'retired',v_reason,v_policy.evidence);
+  RETURN jsonb_build_object('ok',true,'policyId',v_policy.id,'status',v_policy.status,'effectiveTo',v_policy.effective_to,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_retire_supplier_risk_policy_v1(uuid,text,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_retire_supplier_risk_policy_v1(uuid,text,text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_expire_supplier_reservations_v1()
+RETURNS integer
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE v_count integer:=0;
+BEGIN
+  WITH expired AS (
+    UPDATE private.supplier_stock_reservations r
+       SET status='expired',released_at=now()
+     WHERE r.status='active' AND r.expires_at<=now()
+     RETURNING r.id,r.leg_item_id,r.orchestration_id
+  ), updated_legs AS (
+    UPDATE private.supplier_fulfilment_legs l SET status='released',updated_at=now()
+     WHERE l.id IN (
+       SELECT DISTINCT i.leg_id FROM private.supplier_fulfilment_leg_items i
+       JOIN expired e ON e.leg_item_id=i.id
+     )
+     RETURNING l.id
+  ), updated_orchestrations AS (
+    UPDATE private.supplier_order_orchestrations o SET state='released',updated_at=now()
+     WHERE o.id IN (SELECT DISTINCT orchestration_id FROM expired)
+       AND NOT EXISTS (
+         SELECT 1 FROM private.supplier_stock_reservations active
+          WHERE active.orchestration_id=o.id AND active.status='active' AND active.expires_at>now()
+       )
+     RETURNING o.id
+  )
+  SELECT count(*)::integer INTO v_count FROM expired;
+  RETURN v_count;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_expire_supplier_reservations_v1() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_expire_supplier_reservations_v1() TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_supplier_order_orchestration_status_v1(
+  p_actor_id uuid,
+  p_order_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE v_orch private.supplier_order_orchestrations%ROWTYPE;
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id=p_actor_id AND u.role='admin' AND u."isActive"=true) THEN
+    RAISE EXCEPTION 'active admin authority is required' USING ERRCODE='42501';
+  END IF;
+  SELECT * INTO v_orch FROM private.supplier_order_orchestrations WHERE order_id=p_order_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('found',false,'orderId',p_order_id,'interfaceVersion',1); END IF;
+  RETURN jsonb_build_object(
+    'found',true,'orderId',v_orch.order_id,'orchestrationId',v_orch.id,'state',v_orch.state,'riskState',v_orch.risk_state,
+    'correlationId',v_orch.correlation_id,'legs',(
+      SELECT COALESCE(jsonb_agg(jsonb_build_object(
+        'id',l.id,'legKey',l.leg_key,'fulfillerType',l.fulfiller_type,'commercialMode',l.commercial_mode,'status',l.status,
+        'supplierOfferId',l.supplier_offer_id,'sellerId',l.seller_id,
+        'items',(SELECT COALESCE(jsonb_agg(jsonb_build_object('orderItemId',i.order_item_id,'quantity',i.quantity,'canonicalProductId',i.canonical_product_id,'supplierOfferId',i.supplier_offer_id)),'[]'::jsonb)
+                   FROM private.supplier_fulfilment_leg_items i WHERE i.leg_id=l.id)
+      ) ORDER BY l.created_at),'[]'::jsonb)
+      FROM private.supplier_fulfilment_legs l WHERE l.orchestration_id=v_orch.id
+    ),
+    'riskAssessments',(
+      SELECT COALESCE(jsonb_agg(jsonb_build_object('id',r.id,'subjectType',r.subject_type,'riskScore',r.risk_score,'action',r.action,'reason',r.reason,'createdAt',r.created_at) ORDER BY r.created_at),'[]'::jsonb)
+      FROM private.supplier_commerce_risk_assessments r WHERE r.orchestration_id=v_orch.id
+    ),
+    'reservations',(
+      SELECT COALESCE(jsonb_agg(jsonb_build_object('id',r.id,'orderItemId',r.order_item_id,'quantity',r.quantity,'status',r.status,'expiresAt',r.expires_at) ORDER BY r.created_at),'[]'::jsonb)
+      FROM private.supplier_stock_reservations r WHERE r.orchestration_id=v_orch.id
+    ),
+    'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_supplier_order_orchestration_status_v1(uuid,uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_supplier_order_orchestration_status_v1(uuid,uuid) TO service_role;
+
+COMMENT ON FUNCTION public.server_expire_supplier_reservations_v1() IS 'Expires only elapsed active Phase I supplier reservations; does not modify public customer order history.';

--- a/supabase/637_supplier_order_orchestration_audit_closure.sql
+++ b/supabase/637_supplier_order_orchestration_audit_closure.sql
@@ -1,0 +1,86 @@
+-- 637_supplier_order_orchestration_audit_closure.sql
+-- Phase I audit closure: state/reservation transitions are durable append-only evidence.
+
+CREATE TABLE IF NOT EXISTS private.supplier_order_orchestration_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  orchestration_id uuid NOT NULL REFERENCES private.supplier_order_orchestrations(id) ON DELETE RESTRICT,
+  fulfilment_leg_id uuid REFERENCES private.supplier_fulfilment_legs(id) ON DELETE RESTRICT,
+  reservation_id uuid REFERENCES private.supplier_stock_reservations(id) ON DELETE RESTRICT,
+  event text NOT NULL,
+  previous_state text,
+  new_state text,
+  reason text NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_order_orchestration_event_check CHECK (
+    event IN ('orchestration_created','orchestration_state_changed','reservation_created','reservation_released','reservation_expired','reservation_consumed')
+  ),
+  CONSTRAINT supplier_order_orchestration_event_reason_check CHECK (NULLIF(BTRIM(reason),'') IS NOT NULL),
+  CONSTRAINT supplier_order_orchestration_event_metadata_check CHECK (jsonb_typeof(metadata)='object')
+);
+CREATE INDEX IF NOT EXISTS supplier_order_orchestration_event_idx
+  ON private.supplier_order_orchestration_events(orchestration_id,created_at);
+REVOKE ALL ON TABLE private.supplier_order_orchestration_events FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_order_orchestration_event_immutable_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  RAISE EXCEPTION 'supplier order orchestration events are append-only';
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_order_orchestration_event_immutable_v1 ON private.supplier_order_orchestration_events;
+CREATE TRIGGER trg_guard_supplier_order_orchestration_event_immutable_v1
+BEFORE UPDATE OR DELETE ON private.supplier_order_orchestration_events
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_order_orchestration_event_immutable_v1();
+
+CREATE OR REPLACE FUNCTION private.audit_supplier_order_orchestration_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  IF TG_OP='INSERT' THEN
+    INSERT INTO private.supplier_order_orchestration_events(orchestration_id,event,new_state,reason,metadata)
+    VALUES(NEW.id,'orchestration_created',NEW.state,'canonical_order_orchestration_created',jsonb_build_object('orderId',NEW.order_id,'riskState',NEW.risk_state));
+  ELSIF NEW.state IS DISTINCT FROM OLD.state OR NEW.risk_state IS DISTINCT FROM OLD.risk_state THEN
+    INSERT INTO private.supplier_order_orchestration_events(orchestration_id,event,previous_state,new_state,reason,metadata)
+    VALUES(NEW.id,'orchestration_state_changed',OLD.state,NEW.state,'orchestration_state_transition',
+      jsonb_build_object('previousRiskState',OLD.risk_state,'newRiskState',NEW.risk_state));
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_audit_supplier_order_orchestration_v1 ON private.supplier_order_orchestrations;
+CREATE TRIGGER trg_audit_supplier_order_orchestration_v1
+AFTER INSERT OR UPDATE ON private.supplier_order_orchestrations
+FOR EACH ROW EXECUTE FUNCTION private.audit_supplier_order_orchestration_v1();
+
+CREATE OR REPLACE FUNCTION private.audit_supplier_stock_reservation_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+DECLARE v_leg_id uuid;
+BEGIN
+  SELECT i.leg_id INTO v_leg_id FROM private.supplier_fulfilment_leg_items i WHERE i.id=NEW.leg_item_id;
+  IF TG_OP='INSERT' THEN
+    INSERT INTO private.supplier_order_orchestration_events(
+      orchestration_id,fulfilment_leg_id,reservation_id,event,new_state,reason,metadata
+    ) VALUES(
+      NEW.orchestration_id,v_leg_id,NEW.id,'reservation_created',NEW.status,'supplier_stock_reserved',
+      jsonb_build_object('orderItemId',NEW.order_item_id,'supplierOfferId',NEW.supplier_offer_id,'quantity',NEW.quantity,'expiresAt',NEW.expires_at)
+    );
+  ELSIF NEW.status IS DISTINCT FROM OLD.status THEN
+    INSERT INTO private.supplier_order_orchestration_events(
+      orchestration_id,fulfilment_leg_id,reservation_id,event,previous_state,new_state,reason,metadata
+    ) VALUES(
+      NEW.orchestration_id,v_leg_id,NEW.id,
+      CASE NEW.status WHEN 'released' THEN 'reservation_released' WHEN 'expired' THEN 'reservation_expired' WHEN 'consumed' THEN 'reservation_consumed' ELSE 'orchestration_state_changed' END,
+      OLD.status,NEW.status,
+      CASE NEW.status WHEN 'released' THEN 'reservation_released' WHEN 'expired' THEN 'reservation_expired' WHEN 'consumed' THEN 'reservation_consumed' ELSE 'reservation_state_transition' END,
+      jsonb_build_object('orderItemId',NEW.order_item_id,'quantity',NEW.quantity)
+    );
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_audit_supplier_stock_reservation_v1 ON private.supplier_stock_reservations;
+CREATE TRIGGER trg_audit_supplier_stock_reservation_v1
+AFTER INSERT OR UPDATE ON private.supplier_stock_reservations
+FOR EACH ROW EXECUTE FUNCTION private.audit_supplier_stock_reservation_v1();
+
+COMMENT ON TABLE private.supplier_order_orchestration_events IS 'Append-only Phase I orchestration and reservation lifecycle evidence; customer order history remains in public.orders/order_events.';

--- a/supabase/638_supplier_order_mixed_leg_and_release_closure.sql
+++ b/supabase/638_supplier_order_mixed_leg_and_release_closure.sql
@@ -1,0 +1,144 @@
+-- 638_supplier_order_mixed_leg_and_release_closure.sql
+-- Branch Guard closure: explicitly support non-supplier internal legs under the same public order,
+-- and keep orchestration state accurate when a supplier reservation is released.
+
+CREATE OR REPLACE FUNCTION public.server_plan_order_fulfilment_leg_v1(
+  p_order_id uuid,
+  p_order_item_id uuid,
+  p_fulfiller_type text,
+  p_commercial_mode text,
+  p_seller_id uuid,
+  p_orchestration_idempotency_key text,
+  p_correlation_id uuid,
+  p_risk_signals jsonb DEFAULT '{}'::jsonb,
+  p_risk_policy_key text DEFAULT 'supplier_commerce_default'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_order public.orders%ROWTYPE;
+  v_item public.order_items%ROWTYPE;
+  v_product public.products%ROWTYPE;
+  v_orch private.supplier_order_orchestrations%ROWTYPE;
+  v_leg private.supplier_fulfilment_legs%ROWTYPE;
+  v_leg_item private.supplier_fulfilment_leg_items%ROWTYPE;
+  v_control jsonb;
+  v_risk jsonb;
+  v_fulfiller text:=lower(BTRIM(COALESCE(p_fulfiller_type,'')));
+  v_mode text:=lower(BTRIM(COALESCE(p_commercial_mode,'')));
+  v_leg_key text;
+BEGIN
+  IF v_fulfiller NOT IN ('marketplace_seller','loadify_direct') THEN
+    RETURN jsonb_build_object('eligible',false,'reason','supplier_leg_requires_supplier_reservation_rpc','interfaceVersion',1);
+  END IF;
+  IF (v_fulfiller='marketplace_seller' AND v_mode<>'marketplace_seller') OR (v_fulfiller='loadify_direct' AND v_mode<>'loadify_direct') THEN
+    RETURN jsonb_build_object('eligible',false,'reason','fulfiller_commercial_mode_mismatch','interfaceVersion',1);
+  END IF;
+  IF NULLIF(BTRIM(p_orchestration_idempotency_key),'') IS NULL OR p_correlation_id IS NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','idempotency_and_correlation_required','interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_order FROM public.orders WHERE id=p_order_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','order_not_found','interfaceVersion',1); END IF;
+  SELECT * INTO v_item FROM public.order_items WHERE id=p_order_item_id AND "orderId"=p_order_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','order_item_not_found','interfaceVersion',1); END IF;
+  SELECT * INTO v_product FROM public.products WHERE id=v_item."productId";
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','product_not_found','interfaceVersion',1); END IF;
+
+  IF v_fulfiller='marketplace_seller' AND (p_seller_id IS NULL OR v_product."sellerId"<>p_seller_id) THEN
+    RETURN jsonb_build_object('eligible',false,'reason','marketplace_seller_identity_mismatch','interfaceVersion',1);
+  END IF;
+
+  v_control:=public.server_supplier_commerce_control_decision_v1('checkout',jsonb_build_object(
+    'productRef',v_item."productId"::text,'territory','GB',
+    'supplierRef',CASE WHEN v_fulfiller='marketplace_seller' THEN p_seller_id::text ELSE NULL END
+  ));
+  IF COALESCE((v_control->>'enabled')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('eligible',false,'reason','checkout_control_disabled','control',v_control,'interfaceVersion',1);
+  END IF;
+
+  INSERT INTO private.supplier_order_orchestrations(order_id,buyer_id,correlation_id,idempotency_key)
+  VALUES(p_order_id,v_order."buyerId",p_correlation_id,BTRIM(p_orchestration_idempotency_key))
+  ON CONFLICT(order_id) DO NOTHING;
+  SELECT * INTO v_orch FROM private.supplier_order_orchestrations WHERE order_id=p_order_id FOR UPDATE;
+  IF v_orch.idempotency_key<>BTRIM(p_orchestration_idempotency_key) THEN RAISE EXCEPTION 'order orchestration idempotency mismatch'; END IF;
+
+  v_risk:=public.server_supplier_commerce_risk_decision_v1(
+    p_order_id,'order',p_order_id::text,COALESCE(p_risk_signals,'{}'::jsonb),p_risk_policy_key,
+    'risk:plan:'||p_order_item_id::text,v_orch.id
+  );
+  UPDATE private.supplier_order_orchestrations SET
+    risk_state=lower(COALESCE(v_risk->>'action','block')),
+    state=CASE COALESCE(v_risk->>'action','BLOCK') WHEN 'REVIEW' THEN 'review' WHEN 'HOLD' THEN 'hold' WHEN 'RESTRICT' THEN 'hold' WHEN 'BLOCK' THEN 'hold' ELSE state END,
+    updated_at=now()
+  WHERE id=v_orch.id;
+  IF COALESCE((v_risk->>'eligible')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('eligible',false,'reason','commerce_risk_not_allowed','risk',v_risk,'orchestrationId',v_orch.id,'interfaceVersion',1);
+  END IF;
+
+  v_leg_key:=v_fulfiller||':'||COALESCE(p_seller_id::text,'loadify');
+  INSERT INTO private.supplier_fulfilment_legs(
+    orchestration_id,leg_key,fulfiller_type,commercial_mode,seller_id,status
+  ) VALUES(v_orch.id,v_leg_key,v_fulfiller,v_mode,CASE WHEN v_fulfiller='marketplace_seller' THEN p_seller_id ELSE NULL END,'planned')
+  ON CONFLICT(orchestration_id,leg_key) DO NOTHING;
+  SELECT * INTO v_leg FROM private.supplier_fulfilment_legs WHERE orchestration_id=v_orch.id AND leg_key=v_leg_key FOR UPDATE;
+
+  INSERT INTO private.supplier_fulfilment_leg_items(leg_id,order_item_id,quantity,external_variant_ref)
+  VALUES(v_leg.id,p_order_item_id,v_item.quantity,'')
+  ON CONFLICT(order_item_id) DO NOTHING;
+  SELECT * INTO v_leg_item FROM private.supplier_fulfilment_leg_items WHERE order_item_id=p_order_item_id;
+  IF v_leg_item.leg_id<>v_leg.id THEN RAISE EXCEPTION 'order item is already routed to a different fulfilment leg'; END IF;
+
+  UPDATE private.supplier_fulfilment_legs SET status='ready_for_payment',updated_at=now() WHERE id=v_leg.id;
+  UPDATE private.supplier_order_orchestrations SET state='ready_for_payment',risk_state='allow',updated_at=now() WHERE id=v_orch.id;
+
+  RETURN jsonb_build_object('eligible',true,'reason','fulfilment_leg_ready','orchestrationId',v_orch.id,'fulfilmentLegId',v_leg.id,
+    'orderItemId',p_order_item_id,'fulfillerType',v_fulfiller,'commercialMode',v_mode,'risk',v_risk,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_plan_order_fulfilment_leg_v1(uuid,uuid,text,text,uuid,text,uuid,jsonb,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_plan_order_fulfilment_leg_v1(uuid,uuid,text,text,uuid,text,uuid,jsonb,text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_release_supplier_reservation_v1(
+  p_reservation_key text,
+  p_reason text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_res private.supplier_stock_reservations%ROWTYPE;
+  v_reason text:=NULLIF(BTRIM(p_reason),'');
+  v_leg_id uuid;
+BEGIN
+  IF v_reason IS NULL THEN RAISE EXCEPTION 'reservation release reason required'; END IF;
+  SELECT * INTO v_res FROM private.supplier_stock_reservations WHERE reservation_key=BTRIM(COALESCE(p_reservation_key,'')) FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','reservation_not_found','interfaceVersion',1); END IF;
+  IF v_res.status IN ('released','expired') THEN
+    RETURN jsonb_build_object('ok',true,'reason','reservation_already_released','reservationId',v_res.id,'status',v_res.status,'interfaceVersion',1);
+  END IF;
+  IF v_res.status='consumed' THEN RETURN jsonb_build_object('ok',false,'reason','consumed_reservation_cannot_release','interfaceVersion',1); END IF;
+
+  UPDATE private.supplier_stock_reservations SET status='released',released_at=now() WHERE id=v_res.id RETURNING * INTO v_res;
+  SELECT i.leg_id INTO v_leg_id FROM private.supplier_fulfilment_leg_items i WHERE i.id=v_res.leg_item_id;
+  UPDATE private.supplier_fulfilment_legs SET status='released',updated_at=now() WHERE id=v_leg_id;
+  UPDATE private.supplier_order_orchestrations o SET state='released',updated_at=now()
+   WHERE o.id=v_res.orchestration_id
+     AND NOT EXISTS (
+       SELECT 1 FROM private.supplier_stock_reservations active
+        WHERE active.orchestration_id=o.id AND active.status='active' AND active.expires_at>now()
+     );
+
+  RETURN jsonb_build_object('ok',true,'reason','reservation_released','reservationId',v_res.id,'status',v_res.status,
+    'orchestrationId',v_res.orchestration_id,'releaseReason',v_reason,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_release_supplier_reservation_v1(text,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_release_supplier_reservation_v1(text,text) TO service_role;
+
+COMMENT ON FUNCTION public.server_plan_order_fulfilment_leg_v1(uuid,uuid,text,text,uuid,text,uuid,jsonb,text) IS 'Phase I plans Marketplace Seller or Loadify Direct internal fulfilment legs under the existing public customer order. Supplier legs use the reservation RPC.';

--- a/supabase/639_supplier_order_route_integrity_closure.sql
+++ b/supabase/639_supplier_order_route_integrity_closure.sql
@@ -1,0 +1,150 @@
+-- 639_supplier_order_route_integrity_closure.sql
+-- Branch Guard closure: prevent mixed-mode identity contamination inside fulfilment legs/items.
+
+ALTER TABLE private.supplier_fulfilment_legs
+  DROP CONSTRAINT IF EXISTS supplier_fulfilment_leg_route_check;
+ALTER TABLE private.supplier_fulfilment_legs
+  ADD CONSTRAINT supplier_fulfilment_leg_route_check CHECK (
+    (fulfiller_type='supplier' AND supplier_offer_id IS NOT NULL AND seller_id IS NULL AND commercial_mode='loadify_supplier_fulfilled')
+    OR (fulfiller_type='loadify_direct' AND supplier_offer_id IS NULL AND seller_id IS NULL AND commercial_mode='loadify_direct')
+    OR (fulfiller_type='marketplace_seller' AND supplier_offer_id IS NULL AND seller_id IS NOT NULL AND commercial_mode='marketplace_seller')
+  );
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_fulfilment_item_identity_v1()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path TO ''
+AS $$
+DECLARE
+  v_order_id uuid;
+  v_leg_order_id uuid;
+  v_leg private.supplier_fulfilment_legs%ROWTYPE;
+  v_offer private.supplier_offers%ROWTYPE;
+BEGIN
+  SELECT oi."orderId" INTO v_order_id FROM public.order_items oi WHERE oi.id=NEW.order_item_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'canonical order item required'; END IF;
+
+  SELECT l.* INTO v_leg FROM private.supplier_fulfilment_legs l WHERE l.id=NEW.leg_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'fulfilment leg required'; END IF;
+  SELECT o.order_id INTO v_leg_order_id FROM private.supplier_order_orchestrations o WHERE o.id=v_leg.orchestration_id;
+  IF NOT FOUND OR v_leg_order_id<>v_order_id THEN
+    RAISE EXCEPTION 'fulfilment leg item must belong to the same canonical customer order';
+  END IF;
+
+  IF v_leg.fulfiller_type='supplier' THEN
+    IF NEW.supplier_offer_id IS NULL OR NEW.supplier_offer_id<>v_leg.supplier_offer_id OR NEW.canonical_product_id IS NULL THEN
+      RAISE EXCEPTION 'supplier fulfilment item must use the leg supplier offer and canonical product';
+    END IF;
+    SELECT * INTO v_offer FROM private.supplier_offers WHERE id=NEW.supplier_offer_id;
+    IF NOT FOUND OR NEW.canonical_product_id IS DISTINCT FROM v_offer.canonical_product_id THEN
+      RAISE EXCEPTION 'fulfilment item canonical product must match supplier offer';
+    END IF;
+  ELSE
+    IF NEW.supplier_offer_id IS NOT NULL THEN
+      RAISE EXCEPTION 'non-supplier fulfilment item cannot carry supplier offer identity';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.server_plan_order_fulfilment_leg_v1(
+  p_order_id uuid,
+  p_order_item_id uuid,
+  p_fulfiller_type text,
+  p_commercial_mode text,
+  p_seller_id uuid,
+  p_orchestration_idempotency_key text,
+  p_correlation_id uuid,
+  p_risk_signals jsonb DEFAULT '{}'::jsonb,
+  p_risk_policy_key text DEFAULT 'supplier_commerce_default'
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_order public.orders%ROWTYPE;
+  v_item public.order_items%ROWTYPE;
+  v_product public.products%ROWTYPE;
+  v_orch private.supplier_order_orchestrations%ROWTYPE;
+  v_leg private.supplier_fulfilment_legs%ROWTYPE;
+  v_leg_item private.supplier_fulfilment_leg_items%ROWTYPE;
+  v_control jsonb;
+  v_risk jsonb;
+  v_fulfiller text:=lower(BTRIM(COALESCE(p_fulfiller_type,'')));
+  v_mode text:=lower(BTRIM(COALESCE(p_commercial_mode,'')));
+  v_leg_key text;
+BEGIN
+  IF v_fulfiller NOT IN ('marketplace_seller','loadify_direct') THEN
+    RETURN jsonb_build_object('eligible',false,'reason','supplier_leg_requires_supplier_reservation_rpc','interfaceVersion',1);
+  END IF;
+  IF (v_fulfiller='marketplace_seller' AND v_mode<>'marketplace_seller') OR (v_fulfiller='loadify_direct' AND v_mode<>'loadify_direct') THEN
+    RETURN jsonb_build_object('eligible',false,'reason','fulfiller_commercial_mode_mismatch','interfaceVersion',1);
+  END IF;
+  IF NULLIF(BTRIM(p_orchestration_idempotency_key),'') IS NULL OR p_correlation_id IS NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','idempotency_and_correlation_required','interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_order FROM public.orders WHERE id=p_order_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','order_not_found','interfaceVersion',1); END IF;
+  SELECT * INTO v_item FROM public.order_items WHERE id=p_order_item_id AND "orderId"=p_order_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','order_item_not_found','interfaceVersion',1); END IF;
+  SELECT * INTO v_product FROM public.products WHERE id=v_item."productId";
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','product_not_found','interfaceVersion',1); END IF;
+  IF v_fulfiller='marketplace_seller' AND (p_seller_id IS NULL OR v_product."sellerId"<>p_seller_id) THEN
+    RETURN jsonb_build_object('eligible',false,'reason','marketplace_seller_identity_mismatch','interfaceVersion',1);
+  END IF;
+  IF v_fulfiller='loadify_direct' AND p_seller_id IS NOT NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','loadify_direct_does_not_accept_marketplace_seller_identity','interfaceVersion',1);
+  END IF;
+
+  v_control:=public.server_supplier_commerce_control_decision_v1('checkout',jsonb_build_object(
+    'productRef',v_item."productId"::text,'territory','GB'
+  ));
+  IF COALESCE((v_control->>'enabled')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('eligible',false,'reason','checkout_control_disabled','control',v_control,'interfaceVersion',1);
+  END IF;
+
+  INSERT INTO private.supplier_order_orchestrations(order_id,buyer_id,correlation_id,idempotency_key)
+  VALUES(p_order_id,v_order."buyerId",p_correlation_id,BTRIM(p_orchestration_idempotency_key))
+  ON CONFLICT(order_id) DO NOTHING;
+  SELECT * INTO v_orch FROM private.supplier_order_orchestrations WHERE order_id=p_order_id FOR UPDATE;
+  IF v_orch.idempotency_key<>BTRIM(p_orchestration_idempotency_key) THEN RAISE EXCEPTION 'order orchestration idempotency mismatch'; END IF;
+
+  v_risk:=public.server_supplier_commerce_risk_decision_v1(
+    p_order_id,'order',p_order_id::text,COALESCE(p_risk_signals,'{}'::jsonb),p_risk_policy_key,
+    'risk:plan:'||p_order_item_id::text,v_orch.id
+  );
+  UPDATE private.supplier_order_orchestrations SET
+    risk_state=lower(COALESCE(v_risk->>'action','block')),
+    state=CASE COALESCE(v_risk->>'action','BLOCK') WHEN 'REVIEW' THEN 'review' WHEN 'HOLD' THEN 'hold' WHEN 'RESTRICT' THEN 'hold' WHEN 'BLOCK' THEN 'hold' ELSE state END,
+    updated_at=now()
+  WHERE id=v_orch.id;
+  IF COALESCE((v_risk->>'eligible')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('eligible',false,'reason','commerce_risk_not_allowed','risk',v_risk,'orchestrationId',v_orch.id,'interfaceVersion',1);
+  END IF;
+
+  v_leg_key:=v_fulfiller||':'||CASE WHEN v_fulfiller='marketplace_seller' THEN p_seller_id::text ELSE 'loadify' END;
+  INSERT INTO private.supplier_fulfilment_legs(orchestration_id,leg_key,fulfiller_type,commercial_mode,seller_id,status)
+  VALUES(v_orch.id,v_leg_key,v_fulfiller,v_mode,CASE WHEN v_fulfiller='marketplace_seller' THEN p_seller_id ELSE NULL END,'planned')
+  ON CONFLICT(orchestration_id,leg_key) DO NOTHING;
+  SELECT * INTO v_leg FROM private.supplier_fulfilment_legs WHERE orchestration_id=v_orch.id AND leg_key=v_leg_key FOR UPDATE;
+
+  INSERT INTO private.supplier_fulfilment_leg_items(leg_id,order_item_id,quantity,external_variant_ref)
+  VALUES(v_leg.id,p_order_item_id,v_item.quantity,'')
+  ON CONFLICT(order_item_id) DO NOTHING;
+  SELECT * INTO v_leg_item FROM private.supplier_fulfilment_leg_items WHERE order_item_id=p_order_item_id;
+  IF v_leg_item.leg_id<>v_leg.id THEN RAISE EXCEPTION 'order item is already routed to a different fulfilment leg'; END IF;
+
+  UPDATE private.supplier_fulfilment_legs SET status='ready_for_payment',updated_at=now() WHERE id=v_leg.id;
+  UPDATE private.supplier_order_orchestrations SET state='ready_for_payment',risk_state='allow',updated_at=now() WHERE id=v_orch.id;
+  RETURN jsonb_build_object('eligible',true,'reason','fulfilment_leg_ready','orchestrationId',v_orch.id,'fulfilmentLegId',v_leg.id,
+    'orderItemId',p_order_item_id,'fulfillerType',v_fulfiller,'commercialMode',v_mode,'risk',v_risk,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_plan_order_fulfilment_leg_v1(uuid,uuid,text,text,uuid,text,uuid,jsonb,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_plan_order_fulfilment_leg_v1(uuid,uuid,text,text,uuid,text,uuid,jsonb,text) TO service_role;
+
+COMMENT ON CONSTRAINT supplier_fulfilment_leg_route_check ON private.supplier_fulfilment_legs IS 'Phase I route identity is exclusive by fulfiller mode; supplier/seller identities cannot leak across leg types.';


### PR DESCRIPTION
Phase I canonical Supplier Commerce implementation.

Scope:
- keeps one public customer order truth with internal fulfilment legs;
- adds policy-driven Commerce Risk actions ALLOW / REVIEW / HOLD / RESTRICT / BLOCK without automatic account bans;
- adds supplier stock reservation backed by Phase H stock/price evidence;
- enforces reservation kill switch fail-closed;
- adds idempotency, route-integrity, release/expiry and append-only audit closures;
- keeps payment→supplier submission/acknowledgement deferred to Phase J;
- no unrelated visual Workspace/Super Admin redesign.

PowerShell Branch Guard on exact head 5796fbaa4ade9cf249c7e1d011da3dbc0ee7da1d:
- Phase I dedicated tests PASS;
- upstream C-H Supplier Commerce tests PASS;
- TypeScript PASS;
- ESLint PASS;
- production build PASS;
- clean isolated worktree.