### PR TITLE
Phase J — payment to supplier handshake, acknowledgement, idempotency and reconciliation

### DIFF
--- a/netlify/functions/__tests__/supplier-order-handshake-recovery.test.ts
+++ b/netlify/functions/__tests__/supplier-order-handshake-recovery.test.ts
@@ -1,0 +1,93 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+import type { SupplierAdapterV1 } from '../_shared/supplierAdapter';
+import { recoverSupplierOrderLostResponse } from '../_shared/supplierOrderRecovery';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const closure = repo('supabase/643_supplier_payment_handshake_terminal_closure.sql');
+const adapterContract = repo('netlify/functions/_shared/supplierAdapter.ts');
+const recovery = repo('netlify/functions/_shared/supplierOrderRecovery.ts');
+
+const HANDSHAKE = '33333333-3333-4333-8333-333333333333';
+const CORRELATION = '77777777-7777-4777-8777-777777777777';
+
+describe('Phase J lost-response and terminal closure', () => {
+  it('adds provider lookup by the original idempotency key without changing adapter interface version', () => {
+    expect(adapterContract).toContain('findOrderByIdempotencyKey?');
+    expect(adapterContract).toContain('same idempotency key used for submitOrder');
+    expect(adapterContract).toContain('SUPPLIER_ADAPTER_INTERFACE_VERSION = 1');
+  });
+
+  it('never calls submitOrder during lost-response recovery', () => {
+    expect(recovery).toContain('This function never calls submitOrder');
+    expect(recovery).toContain('adapter.findOrderByIdempotencyKey(context)');
+    expect(recovery).not.toContain('adapter.submitOrder(');
+  });
+
+  it('fails to manual review when provider cannot lookup a lost response safely', async () => {
+    const client = { rpc: vi.fn() } as unknown as SupabaseClient;
+    const adapter: SupplierAdapterV1 = {
+      interfaceVersion: 1,
+      providerKey: 'provider-a',
+      adapterVersion: 'v1',
+      capabilities: ['order_submission', 'acknowledgement'],
+    };
+    await expect(recoverSupplierOrderLostResponse(client, adapter, {
+      handshakeId: HANDSHAKE,
+      supplierKey: 'supplier-a',
+      territory: 'GB',
+      correlationId: CORRELATION,
+      idempotencyKey: 'idem-1',
+    })).resolves.toEqual({ ok: false, state: 'manual_review', errorClass: 'CAPABILITY_UNAVAILABLE' });
+  });
+
+  it('recovers accepted supplier order by idempotency lookup and reconciles once', async () => {
+    const rpc = vi.fn(async (name: string) => {
+      if (name === 'server_record_supplier_order_acknowledgement_v1') return { data: { ok: true }, error: null };
+      if (name === 'server_reconcile_supplier_order_handshake_v1') return { data: { reconciled: true }, error: null };
+      return { data: null, error: new Error(`unexpected rpc ${name}`) };
+    });
+    const client = { rpc } as unknown as SupabaseClient;
+    const adapter: SupplierAdapterV1 = {
+      interfaceVersion: 1,
+      providerKey: 'provider-a',
+      adapterVersion: 'v1',
+      capabilities: ['order_submission', 'acknowledgement'],
+      findOrderByIdempotencyKey: vi.fn(async () => ({
+        ok: true as const,
+        data: { supplierOrderRef: 'SUP-LOST-1', state: 'accepted' as const, acknowledgedAt: '2026-08-21T09:30:00Z' },
+      })),
+    };
+    const result = await recoverSupplierOrderLostResponse(client, adapter, {
+      handshakeId: HANDSHAKE,
+      supplierKey: 'supplier-a',
+      territory: 'GB',
+      correlationId: CORRELATION,
+      idempotencyKey: 'idem-1',
+    });
+    expect(result).toEqual({ ok: true, state: 'reconciled', externalSupplierOrderRef: 'SUP-LOST-1' });
+    expect(adapter.findOrderByIdempotencyKey).toHaveBeenCalledTimes(1);
+  });
+
+  it('prevents accepted, rejected and reconciled terminal truth from regressing', () => {
+    expect(closure).toContain('reconciled supplier handshake cannot regress');
+    expect(closure).toContain('accepted supplier acknowledgement cannot regress');
+    expect(closure).toContain('rejected supplier acknowledgement cannot regress');
+    expect(closure).toContain('external supplier order reference is immutable once known');
+  });
+
+  it('treats weaker duplicate acknowledgement after accepted as replay, not downgrade', () => {
+    expect(closure).toContain("IF v_h.acknowledgement_state='accepted' THEN");
+    expect(closure).toContain("'accepted_acknowledgement_replayed'");
+    expect(closure).toContain("'conflicting_terminal_acknowledgement'");
+  });
+
+  it('explicitly checks both payment and reservation evidence during reconciliation', () => {
+    expect(closure).toContain('IF v_payment.id IS NULL');
+    expect(closure).toContain('IF v_res.id IS NULL');
+    expect(closure).toContain("v_payment.payment_status<>'completed'");
+    expect(closure).toContain("v_res.status='consumed'");
+  });
+});

--- a/netlify/functions/__tests__/supplier-order-handshake.test.ts
+++ b/netlify/functions/__tests__/supplier-order-handshake.test.ts
@@ -1,0 +1,246 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+import type { SupplierAdapterV1 } from '../_shared/supplierAdapter';
+import {
+  SUPPLIER_ORDER_HANDSHAKE_INTERFACE_VERSION,
+  recoverSupplierOrderAcknowledgement,
+  submitPaidSupplierOrder,
+} from '../_shared/supplierOrderHandshake';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const foundation = repo('supabase/640_supplier_payment_handshake_foundation.sql');
+const runtime = repo('supabase/641_supplier_payment_handshake_runtime_guards.sql');
+const reconciliation = repo('supabase/642_supplier_payment_handshake_reconciliation.sql');
+const helper = repo('netlify/functions/_shared/supplierOrderHandshake.ts');
+const adminApi = repo('netlify/functions/admin-supplier-order-handshake.ts');
+
+const UUID = '11111111-1111-4111-8111-111111111111';
+const LEG = '22222222-2222-4222-8222-222222222222';
+const HANDSHAKE = '33333333-3333-4333-8333-333333333333';
+const RESERVATION = '44444444-4444-4444-8444-444444444444';
+const PAYMENT = '55555555-5555-4555-8555-555555555555';
+
+function prepared() {
+  return {
+    eligible: true,
+    reason: 'supplier_order_handshake_ready',
+    handshakeId: HANDSHAKE,
+    orderId: UUID,
+    fulfilmentLegId: LEG,
+    reservationId: RESERVATION,
+    paymentEvidenceId: PAYMENT,
+    supplierKey: 'supplier-a',
+    supplierOfferId: '66666666-6666-4666-8666-666666666666',
+    externalOfferRef: 'offer-42',
+    providerKey: 'provider-a',
+    adapterVersion: '2026-08-21',
+    quantity: 2,
+    destinationCountry: 'GB',
+    idempotencyKey: 'idem-1',
+    correlationId: '77777777-7777-4777-8777-777777777777',
+    state: 'prepared',
+    externalSupplierOrderRef: null,
+    interfaceVersion: 1,
+  } as const;
+}
+
+function adapter(overrides: Partial<SupplierAdapterV1> = {}): SupplierAdapterV1 {
+  return {
+    interfaceVersion: 1,
+    providerKey: 'provider-a',
+    adapterVersion: '2026-08-21',
+    capabilities: ['order_submission', 'acknowledgement'],
+    submitOrder: vi.fn(async () => ({
+      ok: true as const,
+      data: { supplierOrderRef: 'SUP-1', state: 'accepted' as const, acknowledgedAt: '2026-08-21T09:00:00Z' },
+    })),
+    getOrderAcknowledgement: vi.fn(async () => ({
+      ok: true as const,
+      data: { supplierOrderRef: 'SUP-1', state: 'accepted' as const, acknowledgedAt: '2026-08-21T09:00:10Z' },
+    })),
+    ...overrides,
+  };
+}
+
+describe('Phase J payment → supplier handshake', () => {
+  it('keeps payment success distinct from supplier-order success', () => {
+    expect(foundation).toContain('PAYMENT SUCCESS != SUPPLIER ORDER SUCCESS');
+    expect(foundation).toContain('private.supplier_payment_evidence_snapshots');
+    expect(foundation).toContain('private.supplier_order_handshakes');
+    expect(runtime).toContain("reason','canonical_payment_not_proven'");
+  });
+
+  it('requires canonical completed payment evidence and matching Stripe PaymentIntent', () => {
+    expect(runtime).toContain("ps.status='completed'");
+    expect(runtime).toContain('ps."stripePaymentIntent"=v_order."stripePaymentIntentId"');
+    expect(runtime).toContain('v_payment.amount<>v_order.total');
+    expect(foundation).toContain("payment_status='completed'");
+  });
+
+  it('rechecks supplier stock and price after payment before submission', () => {
+    expect(runtime).toContain('server_supplier_stock_price_decision_v1');
+    expect(runtime).toContain("'supplier_stock_price_recheck_failed'");
+    expect(runtime).toContain("'supplier_price_changed_since_reservation'");
+    expect(runtime).toContain("'supplier_stock_changed_since_reservation'");
+  });
+
+  it('requires the supplier_order kill switch and does not enable it', () => {
+    expect(runtime).toContain("server_supplier_commerce_control_decision_v1('supplier_order'");
+    expect(runtime).toContain("'supplier_order_control_disabled'");
+    expect(foundation).toContain('No Supplier Commerce control is enabled here');
+    expect(foundation).not.toContain("enabled = true");
+  });
+
+  it('requires an active adapter with order submission and acknowledgement capabilities', () => {
+    expect(runtime).toContain("a.status='active'");
+    expect(runtime).toContain("ARRAY['order_submission','acknowledgement']::text[]");
+    expect(helper).toContain("adapterSupports(adapter, 'order_submission')");
+    expect(helper).toContain("adapterSupports(adapter, 'acknowledgement')");
+  });
+
+  it('makes payment evidence immutable and handshake events append-only', () => {
+    expect(runtime).toContain('supplier payment evidence snapshots are immutable');
+    expect(runtime).toContain('supplier order handshake events are append-only');
+    expect(foundation).toContain('REVOKE ALL ON TABLE private.supplier_payment_evidence_snapshots');
+    expect(foundation).toContain('REVOKE ALL ON TABLE private.supplier_order_handshake_events');
+  });
+
+  it('prevents duplicate supplier submissions with stable idempotency and immutable request identity', () => {
+    expect(foundation).toContain('idempotency_key text NOT NULL UNIQUE');
+    expect(foundation).toContain('request_fingerprint text NOT NULL');
+    expect(runtime).toContain('supplier order handshake idempotency collision with different request');
+    expect(runtime).toContain('supplier submission idempotency mismatch');
+  });
+
+  it('never blindly retries unknown or pending outcomes', () => {
+    expect(runtime).toContain("IF v_h.state IN ('unknown','reconciliation_required','pending')");
+    expect(runtime).toContain("'query_before_retry_required'");
+    expect(reconciliation).toContain("reason','query_before_retry_required'");
+    expect(helper).toContain('never calls submitOrder itself');
+  });
+
+  it('marks timed-out submissions UNKNOWN_OUTCOME for acknowledgement recovery', () => {
+    expect(reconciliation).toContain('server_mark_supplier_order_handshake_timeout_v1');
+    expect(reconciliation).toContain("state='unknown'");
+    expect(reconciliation).toContain("last_error_class='UNKNOWN_OUTCOME'");
+    expect(reconciliation).toContain("recovery_state='query_before_retry'");
+  });
+
+  it('protects external supplier order identity from duplicate acknowledgement drift', () => {
+    expect(runtime).toContain('external supplier order reference cannot change');
+    expect(reconciliation).toContain('duplicate acknowledgement references a different supplier order');
+    expect(foundation).toContain('supplier_order_handshake_external_ref_unique');
+  });
+
+  it('consumes reservation only after accepted supplier acknowledgement', () => {
+    expect(runtime).toContain("IF v_new_state='accepted' THEN");
+    expect(runtime).toContain("SET status='consumed',consumed_at=now()");
+    expect(reconciliation).toContain("IF v_ack='accepted' THEN");
+  });
+
+  it('releases reservation after supplier rejection without rewriting customer payment history', () => {
+    expect(runtime).toContain("ELSIF v_new_state='rejected' THEN");
+    expect(runtime).toContain("SET status='released',released_at=now()");
+    expect(runtime).not.toContain('UPDATE public.payment_sessions');
+    expect(reconciliation).not.toContain('UPDATE public.orders');
+  });
+
+  it('reconciles only accepted acknowledgement + external ref + consumed reservation', () => {
+    expect(reconciliation).toContain("v_h.acknowledgement_state='accepted'");
+    expect(reconciliation).toContain('v_h.external_supplier_order_ref IS NOT NULL');
+    expect(reconciliation).toContain("v_res.status='consumed'");
+    expect(reconciliation).toContain("state='reconciled'");
+  });
+
+  it('does not confuse Phase J handshake reconciliation with Phase L financial reconciliation', () => {
+    expect(reconciliation).toContain('full financial reconciliation remains Phase L');
+    expect(reconciliation).toContain('Full financial reconciliation is intentionally deferred to Phase L');
+  });
+
+  it('keeps Phase J admin visibility active-admin-only', () => {
+    expect(reconciliation).toContain("u.role='admin'");
+    expect(reconciliation).toContain('u."isActive"=true');
+    expect(adminApi).toContain("authenticateActiveAccount(event, admin, ['admin'])");
+  });
+
+  it('submits through SupplierAdapterV1 and reconciles an accepted acknowledgement', async () => {
+    const rpc = vi.fn(async (name: string) => {
+      if (name === 'server_prepare_supplier_order_handshake_v1') return { data: prepared(), error: null };
+      if (name === 'server_mark_supplier_order_submission_started_v1') return { data: { ok: true, reason: 'submission_started', interfaceVersion: 1 }, error: null };
+      if (name === 'server_record_supplier_order_submission_result_v1') return { data: { ok: true, state: 'accepted', recoveryState: 'reconcile' }, error: null };
+      if (name === 'server_record_supplier_order_acknowledgement_v1') return { data: { ok: true }, error: null };
+      if (name === 'server_reconcile_supplier_order_handshake_v1') return { data: { reconciled: true }, error: null };
+      if (name === 'server_record_supplier_commerce_operation_v1') return { data: UUID, error: null };
+      return { data: null, error: new Error(`unexpected rpc ${name}`) };
+    });
+    const client = { rpc } as unknown as SupabaseClient;
+    const a = adapter();
+    const result = await submitPaidSupplierOrder(client, a, {
+      orderId: UUID,
+      fulfilmentLegId: LEG,
+      idempotencyKey: 'idem-1',
+      correlationId: '77777777-7777-4777-8777-777777777777',
+    });
+    expect(result).toMatchObject({ ok: true, state: 'reconciled', handshakeId: HANDSHAKE, externalSupplierOrderRef: 'SUP-1' });
+    expect(a.submitOrder).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed on adapter identity mismatch before provider submission', async () => {
+    const rpc = vi.fn(async (name: string) => {
+      if (name === 'server_prepare_supplier_order_handshake_v1') return { data: prepared(), error: null };
+      if (name === 'server_record_supplier_order_submission_result_v1') return { data: { ok: true, state: 'reconciliation_required' }, error: null };
+      return { data: null, error: null };
+    });
+    const client = { rpc } as unknown as SupabaseClient;
+    const a = adapter({ providerKey: 'wrong-provider' });
+    const result = await submitPaidSupplierOrder(client, a, {
+      orderId: UUID, fulfilmentLegId: LEG, idempotencyKey: 'idem-1', correlationId: '77777777-7777-4777-8777-777777777777',
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errorClass).toBe('CAPABILITY_UNAVAILABLE');
+    expect(a.submitOrder).not.toHaveBeenCalled();
+  });
+
+  it('classifies thrown provider submission as UNKNOWN_OUTCOME instead of blind retry', async () => {
+    const rpc = vi.fn(async (name: string) => {
+      if (name === 'server_prepare_supplier_order_handshake_v1') return { data: prepared(), error: null };
+      if (name === 'server_mark_supplier_order_submission_started_v1') return { data: { ok: true }, error: null };
+      if (name === 'server_record_supplier_order_submission_result_v1') return { data: { ok: true, state: 'unknown', recoveryState: 'query_before_retry' }, error: null };
+      if (name === 'server_record_supplier_commerce_operation_v1') return { data: UUID, error: null };
+      return { data: null, error: null };
+    });
+    const client = { rpc } as unknown as SupabaseClient;
+    const a = adapter({ submitOrder: vi.fn(async () => { throw new Error('socket closed after write'); }) });
+    const result = await submitPaidSupplierOrder(client, a, {
+      orderId: UUID, fulfilmentLegId: LEG, idempotencyKey: 'idem-1', correlationId: '77777777-7777-4777-8777-777777777777',
+    });
+    expect(result).toMatchObject({ ok: false, state: 'unknown', recoveryState: 'query_before_retry', errorClass: 'UNKNOWN_OUTCOME' });
+  });
+
+  it('recovers a lost acknowledgement by querying provider, never resubmitting', async () => {
+    const rpc = vi.fn(async (name: string) => {
+      if (name === 'server_record_supplier_order_acknowledgement_v1') return { data: { ok: true }, error: null };
+      if (name === 'server_reconcile_supplier_order_handshake_v1') return { data: { reconciled: true }, error: null };
+      return { data: null, error: null };
+    });
+    const client = { rpc } as unknown as SupabaseClient;
+    const a = adapter();
+    const result = await recoverSupplierOrderAcknowledgement(client, a, {
+      handshakeId: HANDSHAKE,
+      supplierOrderRef: 'SUP-1',
+      supplierKey: 'supplier-a',
+      territory: 'GB',
+      correlationId: '77777777-7777-4777-8777-777777777777',
+      idempotencyKey: 'idem-1',
+    });
+    expect(result).toMatchObject({ ok: true, state: 'reconciled', externalSupplierOrderRef: 'SUP-1' });
+    expect(a.getOrderAcknowledgement).toHaveBeenCalledTimes(1);
+    expect(a.submitOrder).not.toHaveBeenCalled();
+  });
+
+  it('exposes the expected interface version', () => {
+    expect(SUPPLIER_ORDER_HANDSHAKE_INTERFACE_VERSION).toBe(1);
+  });
+});

--- a/netlify/functions/_shared/supplierAdapter.ts
+++ b/netlify/functions/_shared/supplierAdapter.ts
@@ -68,8 +68,8 @@ export interface SupplierOrderRequest {
   shippingServiceRef?: string;
   destinationCountry: string;
   // Customer PII is intentionally not part of the generic adapter contract here.
-  // A later order-orchestrator phase must define the minimum provider-specific
-  // disclosure envelope under the privacy/retention contract.
+  // Provider implementations may translate the minimum lawful server-side
+  // disclosure envelope without leaking credentials or PII into the core model.
 }
 
 export interface SupplierOrderAcknowledgement {
@@ -106,6 +106,12 @@ export interface SupplierAdapterV1 {
   quoteShipping?(context: SupplierAdapterContext, input: { externalOfferRef: string; quantity: number; destinationCountry: string }): Promise<SupplierAdapterResult<SupplierShippingQuote[]>>;
   submitOrder?(context: SupplierAdapterContext, input: SupplierOrderRequest): Promise<SupplierAdapterResult<SupplierOrderAcknowledgement>>;
   getOrderAcknowledgement?(context: SupplierAdapterContext, supplierOrderRef: string): Promise<SupplierAdapterResult<SupplierOrderAcknowledgement>>;
+  /**
+   * Optional lost-response recovery hook. Providers that can query by the same
+   * idempotency key used for submitOrder should implement this so an UNKNOWN
+   * outcome can be resolved without a blind duplicate submit.
+   */
+  findOrderByIdempotencyKey?(context: SupplierAdapterContext): Promise<SupplierAdapterResult<SupplierOrderAcknowledgement>>;
   getTracking?(context: SupplierAdapterContext, supplierOrderRef: string): Promise<SupplierAdapterResult<SupplierTrackingEvent[]>>;
   cancelOrder?(context: SupplierAdapterContext, supplierOrderRef: string): Promise<SupplierAdapterResult<{ cancelled: boolean }>>;
   requestReturn?(context: SupplierAdapterContext, supplierOrderRef: string, reasonCode: string): Promise<SupplierAdapterResult<{ returnRef: string }>>;

--- a/netlify/functions/_shared/supplierAdapter.ts
+++ b/netlify/functions/_shared/supplierAdapter.ts
@@ -109,7 +109,8 @@ export interface SupplierAdapterV1 {
   /**
    * Optional lost-response recovery hook. Providers that can query by the same
    * idempotency key used for submitOrder should implement this so an UNKNOWN
-   * outcome can be resolved without a blind duplicate submit.
+   * outcome can be resolved without a blind duplicate submit. Recovery must use
+   * the same idempotency key used for submitOrder.
    */
   findOrderByIdempotencyKey?(context: SupplierAdapterContext): Promise<SupplierAdapterResult<SupplierOrderAcknowledgement>>;
   getTracking?(context: SupplierAdapterContext, supplierOrderRef: string): Promise<SupplierAdapterResult<SupplierTrackingEvent[]>>;

--- a/netlify/functions/_shared/supplierOrderHandshake.ts
+++ b/netlify/functions/_shared/supplierOrderHandshake.ts
@@ -1,0 +1,347 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  SupplierAdapterContext,
+  SupplierAdapterErrorClass,
+  SupplierAdapterResult,
+  SupplierAdapterV1,
+  SupplierOrderAcknowledgement,
+} from './supplierAdapter';
+import { adapterSupports } from './supplierAdapter';
+import { recordSupplierCommerceOperation } from './supplierCommerceControl';
+
+export const SUPPLIER_ORDER_HANDSHAKE_INTERFACE_VERSION = 1 as const;
+
+export interface SupplierHandshakePrepareInput {
+  orderId: string;
+  fulfilmentLegId: string;
+  idempotencyKey: string;
+  correlationId: string;
+}
+
+export interface SupplierHandshakePrepared {
+  eligible: true;
+  reason: 'supplier_order_handshake_ready';
+  handshakeId: string;
+  orderId: string;
+  fulfilmentLegId: string;
+  reservationId: string;
+  paymentEvidenceId: string;
+  supplierKey: string;
+  supplierOfferId: string;
+  externalOfferRef: string;
+  providerKey: string;
+  adapterVersion: string;
+  quantity: number;
+  destinationCountry: string;
+  idempotencyKey: string;
+  correlationId: string;
+  state: string;
+  externalSupplierOrderRef?: string | null;
+  interfaceVersion: 1;
+}
+
+export interface SupplierHandshakeBlocked {
+  eligible: false;
+  reason: string;
+  interfaceVersion: 1;
+  [key: string]: unknown;
+}
+
+export type SupplierHandshakePreparation = SupplierHandshakePrepared | SupplierHandshakeBlocked;
+
+export interface SupplierHandshakeRuntimeResult {
+  ok: boolean;
+  state: string;
+  handshakeId?: string;
+  externalSupplierOrderRef?: string | null;
+  recoveryState?: string;
+  errorClass?: string;
+  reason?: string;
+}
+
+function isPrepared(value: unknown): value is SupplierHandshakePrepared {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  return row.eligible === true
+    && row.reason === 'supplier_order_handshake_ready'
+    && typeof row.handshakeId === 'string'
+    && typeof row.externalOfferRef === 'string'
+    && typeof row.providerKey === 'string'
+    && typeof row.adapterVersion === 'string'
+    && typeof row.quantity === 'number'
+    && typeof row.destinationCountry === 'string'
+    && typeof row.supplierKey === 'string'
+    && typeof row.idempotencyKey === 'string'
+    && typeof row.correlationId === 'string'
+    && row.interfaceVersion === SUPPLIER_ORDER_HANDSHAKE_INTERFACE_VERSION;
+}
+
+function classifyAdapterFailure(errorClass: SupplierAdapterErrorClass): string {
+  switch (errorClass) {
+    case 'AUTH_CONFIGURATION_FAILURE': return 'AUTH_CONFIGURATION_FAILURE';
+    case 'RATE_LIMITED': return 'RATE_LIMITED';
+    case 'PERMANENT_REJECTION': return 'PERMANENT_REJECTION';
+    case 'UNKNOWN_OUTCOME':
+    case 'MALFORMED_RESPONSE': return 'UNKNOWN_OUTCOME';
+    case 'CAPABILITY_UNAVAILABLE': return 'MANUAL_REVIEW_REQUIRED';
+    default: return 'RETRYABLE_FAILURE';
+  }
+}
+
+function acknowledgementResultClass(ack: SupplierOrderAcknowledgement): 'SUCCESS' | 'ACCEPTED_PENDING' | 'PERMANENT_REJECTION' | 'UNKNOWN_OUTCOME' {
+  if (ack.state === 'accepted') return 'SUCCESS';
+  if (ack.state === 'pending') return 'ACCEPTED_PENDING';
+  if (ack.state === 'rejected') return 'PERMANENT_REJECTION';
+  return 'UNKNOWN_OUTCOME';
+}
+
+async function recordSubmissionResult(
+  client: SupabaseClient,
+  handshakeId: string,
+  resultClass: string,
+  ackState: SupplierOrderAcknowledgement['state'],
+  externalRef: string | undefined,
+  errorClass?: string,
+  errorMessage?: string,
+): Promise<Record<string, unknown> | null> {
+  const { data, error } = await client.rpc('server_record_supplier_order_submission_result_v1', {
+    p_handshake_id: handshakeId,
+    p_result_class: resultClass,
+    p_ack_state: ackState,
+    p_external_supplier_order_ref: externalRef ?? null,
+    p_error_class: errorClass ?? null,
+    p_error_message: errorMessage ?? null,
+  });
+  if (error || !data || typeof data !== 'object') return null;
+  return data as Record<string, unknown>;
+}
+
+async function recordAcknowledgement(
+  client: SupabaseClient,
+  handshakeId: string,
+  ack: SupplierOrderAcknowledgement,
+  source: string,
+): Promise<boolean> {
+  const { data, error } = await client.rpc('server_record_supplier_order_acknowledgement_v1', {
+    p_handshake_id: handshakeId,
+    p_ack_state: ack.state,
+    p_external_supplier_order_ref: ack.supplierOrderRef || null,
+    p_acknowledged_at: ack.acknowledgedAt,
+    p_source: source,
+  });
+  return !error && !!data && typeof data === 'object' && (data as { ok?: unknown }).ok === true;
+}
+
+async function reconcile(client: SupabaseClient, handshakeId: string): Promise<Record<string, unknown> | null> {
+  const { data, error } = await client.rpc('server_reconcile_supplier_order_handshake_v1', { p_handshake_id: handshakeId });
+  if (error || !data || typeof data !== 'object') return null;
+  return data as Record<string, unknown>;
+}
+
+/**
+ * Executes one provider-neutral Phase J submission attempt.
+ * Unknown/pending outcomes are never blindly retried. The caller must recover
+ * acknowledgement first, using the same external supplier order reference and
+ * idempotency key.
+ */
+export async function submitPaidSupplierOrder(
+  client: SupabaseClient,
+  adapter: SupplierAdapterV1,
+  input: SupplierHandshakePrepareInput,
+): Promise<SupplierHandshakeRuntimeResult> {
+  const startedAt = new Date().toISOString();
+  const { data: rawPrepared, error: prepareError } = await client.rpc('server_prepare_supplier_order_handshake_v1', {
+    p_order_id: input.orderId,
+    p_fulfilment_leg_id: input.fulfilmentLegId,
+    p_idempotency_key: input.idempotencyKey,
+    p_correlation_id: input.correlationId,
+  });
+
+  if (prepareError || !isPrepared(rawPrepared)) {
+    const reason = rawPrepared && typeof rawPrepared === 'object' && typeof (rawPrepared as { reason?: unknown }).reason === 'string'
+      ? String((rawPrepared as { reason: string }).reason)
+      : 'supplier_order_handshake_not_ready';
+    return { ok: false, state: 'blocked', reason };
+  }
+  const prepared = rawPrepared;
+
+  if (
+    adapter.interfaceVersion !== SUPPLIER_ORDER_HANDSHAKE_INTERFACE_VERSION
+    || adapter.providerKey !== prepared.providerKey
+    || adapter.adapterVersion !== prepared.adapterVersion
+    || !adapterSupports(adapter, 'order_submission')
+    || !adapterSupports(adapter, 'acknowledgement')
+    || !adapter.submitOrder
+    || !adapter.getOrderAcknowledgement
+  ) {
+    await recordSubmissionResult(client, prepared.handshakeId, 'MANUAL_REVIEW_REQUIRED', 'unknown', undefined, 'CAPABILITY_UNAVAILABLE', 'adapter identity/capability mismatch');
+    return { ok: false, state: 'reconciliation_required', handshakeId: prepared.handshakeId, errorClass: 'CAPABILITY_UNAVAILABLE' };
+  }
+
+  const { data: startData, error: startError } = await client.rpc('server_mark_supplier_order_submission_started_v1', {
+    p_handshake_id: prepared.handshakeId,
+    p_idempotency_key: prepared.idempotencyKey,
+  });
+  if (startError || !startData || typeof startData !== 'object' || (startData as { ok?: unknown }).ok !== true) {
+    const reason = startData && typeof startData === 'object' && typeof (startData as { reason?: unknown }).reason === 'string'
+      ? String((startData as { reason: string }).reason)
+      : 'supplier_submission_start_blocked';
+    return { ok: false, state: 'blocked', handshakeId: prepared.handshakeId, reason };
+  }
+
+  const context: SupplierAdapterContext = {
+    correlationId: prepared.correlationId,
+    idempotencyKey: prepared.idempotencyKey,
+    supplierKey: prepared.supplierKey,
+    territory: prepared.destinationCountry,
+  };
+
+  let result: SupplierAdapterResult<SupplierOrderAcknowledgement>;
+  try {
+    result = await adapter.submitOrder(context, {
+      externalOfferRef: prepared.externalOfferRef,
+      quantity: prepared.quantity,
+      destinationCountry: prepared.destinationCountry,
+    });
+  } catch (error) {
+    result = {
+      ok: false,
+      errorClass: 'UNKNOWN_OUTCOME',
+      message: error instanceof Error ? error.message : 'supplier submission threw before acknowledgement',
+    };
+  }
+
+  if (!result.ok) {
+    const resultClass = classifyAdapterFailure(result.errorClass);
+    const persisted = await recordSubmissionResult(
+      client,
+      prepared.handshakeId,
+      resultClass,
+      'unknown',
+      result.externalRef,
+      result.errorClass,
+      result.message,
+    );
+    await recordSupplierCommerceOperation(client, {
+      correlationId: prepared.correlationId,
+      requestId: prepared.idempotencyKey,
+      operation: 'supplier_order',
+      providerRef: adapter.providerKey,
+      supplierRef: prepared.supplierKey,
+      entityType: 'supplier_order_handshake',
+      entityRef: prepared.handshakeId,
+      resultClass: resultClass as 'RETRYABLE_FAILURE' | 'PERMANENT_REJECTION' | 'AUTH_CONFIGURATION_FAILURE' | 'RATE_LIMITED' | 'UNKNOWN_OUTCOME' | 'MANUAL_REVIEW_REQUIRED',
+      errorClass: result.errorClass,
+      recoveryState: resultClass === 'UNKNOWN_OUTCOME' ? 'query_before_retry' : resultClass === 'RETRYABLE_FAILURE' || resultClass === 'RATE_LIMITED' ? 'retry_pending' : 'manual_review',
+      externalRef: result.externalRef,
+      customerImpact: 'customer_payment_already_succeeded_supplier_order_not_confirmed',
+      financialImpact: 'supplier_commitment_unconfirmed',
+      startedAt,
+      finishedAt: new Date().toISOString(),
+    });
+    return {
+      ok: false,
+      state: typeof persisted?.state === 'string' ? persisted.state : 'unknown',
+      handshakeId: prepared.handshakeId,
+      externalSupplierOrderRef: result.externalRef ?? null,
+      recoveryState: typeof persisted?.recoveryState === 'string' ? persisted.recoveryState : undefined,
+      errorClass: result.errorClass,
+    };
+  }
+
+  const ack = result.data;
+  const resultClass = acknowledgementResultClass(ack);
+  const persisted = await recordSubmissionResult(client, prepared.handshakeId, resultClass, ack.state, ack.supplierOrderRef || result.externalRef);
+  if (!persisted) {
+    return { ok: false, state: 'reconciliation_required', handshakeId: prepared.handshakeId, externalSupplierOrderRef: ack.supplierOrderRef };
+  }
+
+  await recordAcknowledgement(client, prepared.handshakeId, ack, 'submitOrder');
+  const reconciled = ack.state === 'accepted' ? await reconcile(client, prepared.handshakeId) : null;
+
+  await recordSupplierCommerceOperation(client, {
+    correlationId: prepared.correlationId,
+    requestId: prepared.idempotencyKey,
+    operation: 'supplier_order',
+    providerRef: adapter.providerKey,
+    supplierRef: prepared.supplierKey,
+    entityType: 'supplier_order_handshake',
+    entityRef: prepared.handshakeId,
+    resultClass: ack.state === 'accepted' ? 'SUCCESS' : ack.state === 'pending' ? 'ACCEPTED_PENDING' : ack.state === 'rejected' ? 'PERMANENT_REJECTION' : 'UNKNOWN_OUTCOME',
+    recoveryState: ack.state === 'accepted' ? 'resolved' : ack.state === 'pending' || ack.state === 'unknown' ? 'query_before_retry' : 'manual_review',
+    externalRef: ack.supplierOrderRef,
+    customerImpact: ack.state === 'accepted' ? 'none' : 'customer_payment_succeeded_supplier_order_not_final',
+    financialImpact: ack.state === 'accepted' ? 'supplier_commitment_confirmed' : 'supplier_commitment_unresolved',
+    startedAt,
+    finishedAt: new Date().toISOString(),
+  });
+
+  return {
+    ok: ack.state === 'accepted' && reconciled?.reconciled === true,
+    state: ack.state === 'accepted' && reconciled?.reconciled === true ? 'reconciled' : ack.state,
+    handshakeId: prepared.handshakeId,
+    externalSupplierOrderRef: ack.supplierOrderRef,
+    recoveryState: typeof persisted.recoveryState === 'string' ? persisted.recoveryState : undefined,
+  };
+}
+
+/**
+ * Lost-response / pending-ack recovery. This method queries acknowledgement
+ * before any retry and never calls submitOrder itself.
+ */
+export async function recoverSupplierOrderAcknowledgement(
+  client: SupabaseClient,
+  adapter: SupplierAdapterV1,
+  input: {
+    handshakeId: string;
+    supplierOrderRef: string;
+    supplierKey: string;
+    territory: string;
+    correlationId: string;
+    idempotencyKey: string;
+  },
+): Promise<SupplierHandshakeRuntimeResult> {
+  if (!adapterSupports(adapter, 'acknowledgement') || !adapter.getOrderAcknowledgement || !input.supplierOrderRef) {
+    return { ok: false, state: 'manual_review', handshakeId: input.handshakeId, errorClass: 'CAPABILITY_UNAVAILABLE' };
+  }
+
+  const context: SupplierAdapterContext = {
+    correlationId: input.correlationId,
+    idempotencyKey: input.idempotencyKey,
+    supplierKey: input.supplierKey,
+    territory: input.territory,
+  };
+
+  let result: SupplierAdapterResult<SupplierOrderAcknowledgement>;
+  try {
+    result = await adapter.getOrderAcknowledgement(context, input.supplierOrderRef);
+  } catch (error) {
+    result = {
+      ok: false,
+      errorClass: 'UNKNOWN_OUTCOME',
+      message: error instanceof Error ? error.message : 'acknowledgement recovery failed',
+      externalRef: input.supplierOrderRef,
+    };
+  }
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      state: result.errorClass === 'PERMANENT_REJECTION' ? 'manual_review' : 'query_before_retry',
+      handshakeId: input.handshakeId,
+      externalSupplierOrderRef: input.supplierOrderRef,
+      errorClass: result.errorClass,
+    };
+  }
+
+  const ack = result.data;
+  const recorded = await recordAcknowledgement(client, input.handshakeId, ack, 'getOrderAcknowledgement');
+  if (!recorded) return { ok: false, state: 'reconciliation_required', handshakeId: input.handshakeId };
+  const reconciled = ack.state === 'accepted' ? await reconcile(client, input.handshakeId) : null;
+  return {
+    ok: ack.state === 'accepted' && reconciled?.reconciled === true,
+    state: ack.state === 'accepted' && reconciled?.reconciled === true ? 'reconciled' : ack.state,
+    handshakeId: input.handshakeId,
+    externalSupplierOrderRef: ack.supplierOrderRef,
+  };
+}

--- a/netlify/functions/_shared/supplierOrderRecovery.ts
+++ b/netlify/functions/_shared/supplierOrderRecovery.ts
@@ -1,0 +1,81 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { SupplierAdapterContext, SupplierAdapterV1 } from './supplierAdapter';
+
+export interface LostResponseRecoveryInput {
+  handshakeId: string;
+  supplierKey: string;
+  territory: string;
+  correlationId: string;
+  idempotencyKey: string;
+}
+
+export interface LostResponseRecoveryResult {
+  ok: boolean;
+  state: 'reconciled' | 'pending' | 'rejected' | 'unknown' | 'manual_review' | 'reconciliation_required';
+  externalSupplierOrderRef?: string | null;
+  errorClass?: string;
+}
+
+/**
+ * Resolves the hardest Phase J case: the provider may have accepted submitOrder
+ * but the response (and therefore supplierOrderRef) was lost. The adapter is
+ * queried by the SAME idempotency key. This function never calls submitOrder.
+ */
+export async function recoverSupplierOrderLostResponse(
+  client: SupabaseClient,
+  adapter: SupplierAdapterV1,
+  input: LostResponseRecoveryInput,
+): Promise<LostResponseRecoveryResult> {
+  if (!adapter.capabilities.includes('acknowledgement') || !adapter.findOrderByIdempotencyKey) {
+    return { ok: false, state: 'manual_review', errorClass: 'CAPABILITY_UNAVAILABLE' };
+  }
+
+  const context: SupplierAdapterContext = {
+    correlationId: input.correlationId,
+    idempotencyKey: input.idempotencyKey,
+    supplierKey: input.supplierKey,
+    territory: input.territory,
+  };
+
+  let result;
+  try {
+    result = await adapter.findOrderByIdempotencyKey(context);
+  } catch {
+    return { ok: false, state: 'unknown', errorClass: 'UNKNOWN_OUTCOME' };
+  }
+
+  if (!result.ok) {
+    return {
+      ok: false,
+      state: result.errorClass === 'PERMANENT_REJECTION' ? 'manual_review' : 'unknown',
+      externalSupplierOrderRef: result.externalRef ?? null,
+      errorClass: result.errorClass,
+    };
+  }
+
+  const ack = result.data;
+  const { data: recorded, error: recordError } = await client.rpc('server_record_supplier_order_acknowledgement_v1', {
+    p_handshake_id: input.handshakeId,
+    p_ack_state: ack.state,
+    p_external_supplier_order_ref: ack.supplierOrderRef || null,
+    p_acknowledged_at: ack.acknowledgedAt,
+    p_source: 'findOrderByIdempotencyKey',
+  });
+  if (recordError || !recorded || typeof recorded !== 'object' || (recorded as { ok?: unknown }).ok !== true) {
+    return { ok: false, state: 'reconciliation_required', externalSupplierOrderRef: ack.supplierOrderRef };
+  }
+
+  if (ack.state !== 'accepted') {
+    return { ok: false, state: ack.state, externalSupplierOrderRef: ack.supplierOrderRef };
+  }
+
+  const { data: reconciled, error: reconcileError } = await client.rpc('server_reconcile_supplier_order_handshake_v1', {
+    p_handshake_id: input.handshakeId,
+  });
+  const ok = !reconcileError && !!reconciled && typeof reconciled === 'object' && (reconciled as { reconciled?: unknown }).reconciled === true;
+  return {
+    ok,
+    state: ok ? 'reconciled' : 'reconciliation_required',
+    externalSupplierOrderRef: ack.supplierOrderRef,
+  };
+}

--- a/netlify/functions/admin-supplier-order-handshake.ts
+++ b/netlify/functions/admin-supplier-order-handshake.ts
@@ -1,0 +1,37 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { jsonResponse, optionsResponse } from './_shared/http';
+
+const METHODS = 'POST, OPTIONS';
+
+type AdminAction = { action: 'status'; orderId?: string };
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return optionsResponse(METHODS);
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' }, METHODS);
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) return jsonResponse(500, { error: 'Server configuration error' }, METHODS);
+
+  const admin = createClient(supabaseUrl, serviceRoleKey, { auth: { autoRefreshToken: false, persistSession: false } });
+  const auth = await authenticateActiveAccount(event, admin, ['admin']);
+  if (!auth.ok) return jsonResponse(auth.status, { error: 'Unauthorized' }, METHODS);
+
+  let body: AdminAction;
+  try { body = JSON.parse(event.body || '{}') as AdminAction; }
+  catch { return jsonResponse(400, { error: 'Invalid JSON body' }, METHODS); }
+
+  if (!body || body.action !== 'status') return jsonResponse(400, { error: 'Unsupported Phase J admin action' }, METHODS);
+  if (body.orderId !== undefined && (typeof body.orderId !== 'string' || !body.orderId.trim())) {
+    return jsonResponse(400, { error: 'orderId must be a non-empty string when supplied' }, METHODS);
+  }
+
+  const { data, error } = await admin.rpc('server_admin_supplier_order_handshake_status_v1', {
+    p_actor_id: auth.actor.id,
+    p_order_id: body.orderId?.trim() || null,
+  });
+  if (error) return jsonResponse(500, { error: 'Unable to read supplier order handshake status' }, METHODS);
+  return jsonResponse(200, { ok: true, result: data }, METHODS);
+};

--- a/supabase/640_supplier_payment_handshake_foundation.sql
+++ b/supabase/640_supplier_payment_handshake_foundation.sql
@@ -1,0 +1,117 @@
+-- 640_supplier_payment_handshake_foundation.sql
+-- Phase J — payment evidence → supplier submission → acknowledgement foundation.
+-- PAYMENT SUCCESS != SUPPLIER ORDER SUCCESS. No Supplier Commerce control is enabled here.
+
+ALTER TABLE private.supplier_fulfilment_legs
+  DROP CONSTRAINT IF EXISTS supplier_fulfilment_leg_status_check;
+ALTER TABLE private.supplier_fulfilment_legs
+  ADD CONSTRAINT supplier_fulfilment_leg_status_check CHECK (
+    status IN (
+      'planned','review','hold','reserved','ready_for_payment','released','cancelled',
+      'supplier_submitting','supplier_pending','supplier_accepted','supplier_rejected','reconciliation_required'
+    )
+  );
+
+ALTER TABLE private.supplier_order_orchestrations
+  DROP CONSTRAINT IF EXISTS supplier_order_orchestration_state_check;
+ALTER TABLE private.supplier_order_orchestrations
+  ADD CONSTRAINT supplier_order_orchestration_state_check CHECK (
+    state IN (
+      'planning','review','hold','reserved','ready_for_payment','released','cancelled',
+      'supplier_submitting','supplier_pending','supplier_accepted','supplier_exception','reconciliation_required'
+    )
+  );
+
+CREATE TABLE IF NOT EXISTS private.supplier_payment_evidence_snapshots (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id uuid NOT NULL UNIQUE REFERENCES public.orders(id) ON DELETE RESTRICT,
+  payment_session_id uuid NOT NULL UNIQUE REFERENCES public.payment_sessions(id) ON DELETE RESTRICT,
+  payment_intent_ref text NOT NULL UNIQUE,
+  payment_status text NOT NULL,
+  order_status text NOT NULL,
+  amount numeric(14,2) NOT NULL CHECK (amount >= 0),
+  currency text NOT NULL,
+  evidence_source text NOT NULL DEFAULT 'canonical_payment_session',
+  captured_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_payment_evidence_intent_check CHECK (NULLIF(BTRIM(payment_intent_ref),'') IS NOT NULL),
+  CONSTRAINT supplier_payment_evidence_status_check CHECK (payment_status='completed'),
+  CONSTRAINT supplier_payment_evidence_currency_check CHECK (currency=upper(BTRIM(currency)) AND currency ~ '^[A-Z]{3}$'),
+  CONSTRAINT supplier_payment_evidence_source_check CHECK (evidence_source='canonical_payment_session')
+);
+
+CREATE TABLE IF NOT EXISTS private.supplier_order_handshakes (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id uuid NOT NULL REFERENCES public.orders(id) ON DELETE RESTRICT,
+  orchestration_id uuid NOT NULL REFERENCES private.supplier_order_orchestrations(id) ON DELETE RESTRICT,
+  fulfilment_leg_id uuid NOT NULL UNIQUE REFERENCES private.supplier_fulfilment_legs(id) ON DELETE RESTRICT,
+  reservation_id uuid NOT NULL UNIQUE REFERENCES private.supplier_stock_reservations(id) ON DELETE RESTRICT,
+  payment_evidence_id uuid NOT NULL REFERENCES private.supplier_payment_evidence_snapshots(id) ON DELETE RESTRICT,
+  supplier_offer_id uuid NOT NULL REFERENCES private.supplier_offers(id) ON DELETE RESTRICT,
+  supplier_id uuid NOT NULL REFERENCES private.supplier_foundation_suppliers(id) ON DELETE RESTRICT,
+  provider_key text NOT NULL,
+  adapter_version text NOT NULL,
+  idempotency_key text NOT NULL UNIQUE,
+  correlation_id uuid NOT NULL,
+  request_fingerprint text NOT NULL,
+  state text NOT NULL DEFAULT 'prepared',
+  acknowledgement_state text NOT NULL DEFAULT 'not_received',
+  recovery_state text NOT NULL DEFAULT 'none',
+  external_supplier_order_ref text,
+  submission_attempts integer NOT NULL DEFAULT 0 CHECK (submission_attempts >= 0),
+  last_error_class text,
+  last_error_message text,
+  submitted_at timestamptz,
+  acknowledged_at timestamptz,
+  last_checked_at timestamptz,
+  reconciled_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_order_handshake_provider_check CHECK (NULLIF(BTRIM(provider_key),'') IS NOT NULL),
+  CONSTRAINT supplier_order_handshake_adapter_check CHECK (NULLIF(BTRIM(adapter_version),'') IS NOT NULL),
+  CONSTRAINT supplier_order_handshake_idem_check CHECK (NULLIF(BTRIM(idempotency_key),'') IS NOT NULL),
+  CONSTRAINT supplier_order_handshake_fingerprint_check CHECK (NULLIF(BTRIM(request_fingerprint),'') IS NOT NULL),
+  CONSTRAINT supplier_order_handshake_state_check CHECK (state IN (
+    'prepared','submitting','pending','accepted','rejected','unknown','retryable_failure','reconciliation_required','reconciled'
+  )),
+  CONSTRAINT supplier_order_handshake_ack_check CHECK (acknowledgement_state IN ('not_received','pending','accepted','rejected','unknown')),
+  CONSTRAINT supplier_order_handshake_recovery_check CHECK (recovery_state IN ('none','retry_pending','query_before_retry','reconcile','manual_review','resolved'))
+);
+CREATE INDEX IF NOT EXISTS supplier_order_handshake_order_idx
+  ON private.supplier_order_handshakes(order_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS supplier_order_handshake_recovery_idx
+  ON private.supplier_order_handshakes(recovery_state, state, updated_at);
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_order_handshake_external_ref_unique
+  ON private.supplier_order_handshakes(provider_key, supplier_id, external_supplier_order_ref)
+  WHERE external_supplier_order_ref IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS private.supplier_order_handshake_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  handshake_id uuid NOT NULL REFERENCES private.supplier_order_handshakes(id) ON DELETE RESTRICT,
+  event_key text NOT NULL UNIQUE,
+  event text NOT NULL,
+  previous_state text,
+  new_state text,
+  result_class text,
+  error_class text,
+  external_supplier_order_ref text,
+  recovery_state text,
+  reason text NOT NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_order_handshake_event_key_check CHECK (NULLIF(BTRIM(event_key),'') IS NOT NULL),
+  CONSTRAINT supplier_order_handshake_event_check CHECK (event IN (
+    'prepared','submission_started','submission_result','acknowledgement','timeout','reconciliation','manual_review'
+  )),
+  CONSTRAINT supplier_order_handshake_event_reason_check CHECK (NULLIF(BTRIM(reason),'') IS NOT NULL),
+  CONSTRAINT supplier_order_handshake_event_metadata_check CHECK (jsonb_typeof(metadata)='object')
+);
+CREATE INDEX IF NOT EXISTS supplier_order_handshake_event_idx
+  ON private.supplier_order_handshake_events(handshake_id, created_at);
+
+REVOKE ALL ON TABLE private.supplier_payment_evidence_snapshots FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_order_handshakes FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_order_handshake_events FROM PUBLIC, anon, authenticated, service_role;
+
+COMMENT ON TABLE private.supplier_payment_evidence_snapshots IS 'Immutable Phase J evidence that canonical customer payment completed; it does not imply supplier-order success.';
+COMMENT ON TABLE private.supplier_order_handshakes IS 'Provider-neutral Phase J supplier submission/acknowledgement state. One handshake per internal supplier fulfilment leg.';
+COMMENT ON TABLE private.supplier_order_handshake_events IS 'Append-only Phase J submission, acknowledgement and recovery evidence.';

--- a/supabase/641_supplier_payment_handshake_runtime_guards.sql
+++ b/supabase/641_supplier_payment_handshake_runtime_guards.sql
@@ -1,0 +1,323 @@
+-- 641_supplier_payment_handshake_runtime_guards.sql
+-- Phase J runtime guards: immutable payment evidence, idempotent preparation/submission state,
+-- payment proof, stock/price recheck and fail-closed supplier_order control.
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_payment_evidence_immutable_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  RAISE EXCEPTION 'supplier payment evidence snapshots are immutable';
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_payment_evidence_immutable_v1 ON private.supplier_payment_evidence_snapshots;
+CREATE TRIGGER trg_guard_supplier_payment_evidence_immutable_v1
+BEFORE UPDATE OR DELETE ON private.supplier_payment_evidence_snapshots
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_payment_evidence_immutable_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_order_handshake_event_immutable_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  RAISE EXCEPTION 'supplier order handshake events are append-only';
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_order_handshake_event_immutable_v1 ON private.supplier_order_handshake_events;
+CREATE TRIGGER trg_guard_supplier_order_handshake_event_immutable_v1
+BEFORE UPDATE OR DELETE ON private.supplier_order_handshake_events
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_order_handshake_event_immutable_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_order_handshake_identity_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  IF TG_OP='UPDATE' AND (
+    NEW.order_id IS DISTINCT FROM OLD.order_id OR
+    NEW.orchestration_id IS DISTINCT FROM OLD.orchestration_id OR
+    NEW.fulfilment_leg_id IS DISTINCT FROM OLD.fulfilment_leg_id OR
+    NEW.reservation_id IS DISTINCT FROM OLD.reservation_id OR
+    NEW.payment_evidence_id IS DISTINCT FROM OLD.payment_evidence_id OR
+    NEW.supplier_offer_id IS DISTINCT FROM OLD.supplier_offer_id OR
+    NEW.supplier_id IS DISTINCT FROM OLD.supplier_id OR
+    NEW.provider_key IS DISTINCT FROM OLD.provider_key OR
+    NEW.adapter_version IS DISTINCT FROM OLD.adapter_version OR
+    NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key OR
+    NEW.correlation_id IS DISTINCT FROM OLD.correlation_id OR
+    NEW.request_fingerprint IS DISTINCT FROM OLD.request_fingerprint
+  ) THEN
+    RAISE EXCEPTION 'supplier order handshake identity is immutable';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_order_handshake_identity_v1 ON private.supplier_order_handshakes;
+CREATE TRIGGER trg_guard_supplier_order_handshake_identity_v1
+BEFORE UPDATE ON private.supplier_order_handshakes
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_order_handshake_identity_v1();
+
+CREATE OR REPLACE FUNCTION public.server_prepare_supplier_order_handshake_v1(
+  p_order_id uuid,
+  p_fulfilment_leg_id uuid,
+  p_idempotency_key text,
+  p_correlation_id uuid
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+DECLARE
+  v_order public.orders%ROWTYPE;
+  v_orch private.supplier_order_orchestrations%ROWTYPE;
+  v_leg private.supplier_fulfilment_legs%ROWTYPE;
+  v_offer private.supplier_offers%ROWTYPE;
+  v_supplier private.supplier_foundation_suppliers%ROWTYPE;
+  v_adapter private.supplier_adapter_registrations%ROWTYPE;
+  v_res private.supplier_stock_reservations%ROWTYPE;
+  v_payment public.payment_sessions%ROWTYPE;
+  v_payment_evidence private.supplier_payment_evidence_snapshots%ROWTYPE;
+  v_handshake private.supplier_order_handshakes%ROWTYPE;
+  v_control jsonb;
+  v_sync jsonb;
+  v_quantity integer;
+  v_destination_country text;
+  v_fingerprint text;
+BEGIN
+  IF NULLIF(BTRIM(p_idempotency_key),'') IS NULL OR p_correlation_id IS NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','idempotency_and_correlation_required','interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_order FROM public.orders WHERE id=p_order_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','order_not_found','interfaceVersion',1); END IF;
+  IF v_order.status NOT IN ('paid','packed','shipped','delivered') OR NULLIF(BTRIM(v_order."stripePaymentIntentId"),'') IS NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','canonical_payment_not_proven','interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_orch FROM private.supplier_order_orchestrations WHERE order_id=p_order_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','order_orchestration_missing','interfaceVersion',1); END IF;
+
+  SELECT * INTO v_leg FROM private.supplier_fulfilment_legs
+   WHERE id=p_fulfilment_leg_id AND orchestration_id=v_orch.id FOR UPDATE;
+  IF NOT FOUND OR v_leg.fulfiller_type<>'supplier' OR v_leg.commercial_mode<>'loadify_supplier_fulfilled' OR v_leg.supplier_offer_id IS NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','supplier_fulfilment_leg_not_ready','interfaceVersion',1);
+  END IF;
+  IF v_leg.status NOT IN ('reserved','supplier_submitting','supplier_pending','reconciliation_required') THEN
+    RETURN jsonb_build_object('eligible',false,'reason','supplier_fulfilment_leg_state_invalid','state',v_leg.status,'interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_offer FROM private.supplier_offers WHERE id=v_leg.supplier_offer_id AND status='approved';
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','supplier_offer_not_ready','interfaceVersion',1); END IF;
+  SELECT * INTO v_supplier FROM private.supplier_foundation_suppliers WHERE id=v_offer.supplier_id AND lifecycle_status='approved';
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','supplier_not_approved','interfaceVersion',1); END IF;
+
+  v_control:=public.server_supplier_commerce_control_decision_v1('supplier_order',jsonb_build_object(
+    'supplierRef',v_supplier.supplier_key,'offerRef',v_offer.offer_key,'productRef',v_offer.canonical_product_id::text,'territory',v_offer.territory
+  ));
+  IF COALESCE((v_control->>'enabled')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('eligible',false,'reason','supplier_order_control_disabled','control',v_control,'interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_res FROM private.supplier_stock_reservations
+   WHERE orchestration_id=v_orch.id AND supplier_offer_id=v_offer.id AND status='active' AND expires_at>now()
+   ORDER BY created_at DESC LIMIT 1 FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','active_supplier_reservation_missing','interfaceVersion',1); END IF;
+
+  SELECT COALESCE(SUM(i.quantity),0)::integer INTO v_quantity
+    FROM private.supplier_fulfilment_leg_items i WHERE i.leg_id=v_leg.id;
+  IF v_quantity<=0 OR v_quantity<>v_res.quantity THEN
+    RETURN jsonb_build_object('eligible',false,'reason','reservation_quantity_mismatch','interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_payment FROM public.payment_sessions ps
+   WHERE ps."orderId"=v_order.id
+     AND ps.status='completed'
+     AND ps."stripePaymentIntent"=v_order."stripePaymentIntentId"
+   ORDER BY ps."updatedAt" DESC LIMIT 1;
+  IF NOT FOUND OR v_payment.amount<>v_order.total OR upper(BTRIM(v_payment.currency))<>'GBP' THEN
+    RETURN jsonb_build_object('eligible',false,'reason','canonical_payment_evidence_mismatch','interfaceVersion',1);
+  END IF;
+
+  v_sync:=public.server_supplier_stock_price_decision_v1(
+    v_offer.id,v_offer.canonical_product_id,'loadify_supplier_fulfilled',v_offer.territory,v_res.external_variant_ref
+  );
+  IF COALESCE((v_sync->>'eligible')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('eligible',false,'reason','supplier_stock_price_recheck_failed','sync',v_sync,'interfaceVersion',1);
+  END IF;
+  IF (v_sync->>'pricingSnapshotId')::uuid IS DISTINCT FROM v_res.pricing_snapshot_id THEN
+    RETURN jsonb_build_object('eligible',false,'reason','supplier_price_changed_since_reservation','sync',v_sync,'interfaceVersion',1);
+  END IF;
+  IF v_sync->>'sellableQuantity' IS NULL OR (v_sync->>'sellableQuantity')::integer < v_quantity THEN
+    RETURN jsonb_build_object('eligible',false,'reason','supplier_stock_changed_since_reservation','sync',v_sync,'interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_adapter FROM private.supplier_adapter_registrations a
+   WHERE a.supplier_id=v_supplier.id AND a.status='active' AND a.interface_version=1
+     AND a.capabilities @> ARRAY['order_submission','acknowledgement']::text[]
+   ORDER BY a.verified_at DESC LIMIT 1;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','supplier_order_adapter_not_ready','interfaceVersion',1); END IF;
+
+  INSERT INTO private.supplier_payment_evidence_snapshots(
+    order_id,payment_session_id,payment_intent_ref,payment_status,order_status,amount,currency
+  ) VALUES(v_order.id,v_payment.id,v_order."stripePaymentIntentId",v_payment.status,v_order.status,v_payment.amount,upper(v_payment.currency))
+  ON CONFLICT(order_id) DO NOTHING;
+  SELECT * INTO v_payment_evidence FROM private.supplier_payment_evidence_snapshots WHERE order_id=v_order.id;
+  IF v_payment_evidence.payment_intent_ref<>v_order."stripePaymentIntentId" OR v_payment_evidence.amount<>v_payment.amount THEN
+    RAISE EXCEPTION 'payment evidence identity mismatch for order';
+  END IF;
+
+  v_destination_country:=upper(BTRIM(COALESCE(
+    v_order."shippingAddress"->>'countryCode',v_order."shippingAddress"->>'country','GB'
+  )));
+  IF v_destination_country='' THEN v_destination_country:='GB'; END IF;
+
+  v_fingerprint:=md5(concat_ws('|',v_order.id::text,v_leg.id::text,v_res.id::text,v_payment_evidence.id::text,
+    v_offer.id::text,v_offer.external_offer_ref,v_quantity::text,v_destination_country));
+
+  SELECT * INTO v_handshake FROM private.supplier_order_handshakes WHERE fulfilment_leg_id=v_leg.id FOR UPDATE;
+  IF FOUND THEN
+    IF v_handshake.idempotency_key<>BTRIM(p_idempotency_key) OR v_handshake.request_fingerprint<>v_fingerprint THEN
+      RAISE EXCEPTION 'supplier order handshake idempotency collision with different request';
+    END IF;
+  ELSE
+    INSERT INTO private.supplier_order_handshakes(
+      order_id,orchestration_id,fulfilment_leg_id,reservation_id,payment_evidence_id,supplier_offer_id,supplier_id,
+      provider_key,adapter_version,idempotency_key,correlation_id,request_fingerprint
+    ) VALUES(
+      v_order.id,v_orch.id,v_leg.id,v_res.id,v_payment_evidence.id,v_offer.id,v_supplier.id,
+      v_adapter.provider_key,v_adapter.adapter_version,BTRIM(p_idempotency_key),p_correlation_id,v_fingerprint
+    ) RETURNING * INTO v_handshake;
+    INSERT INTO private.supplier_order_handshake_events(handshake_id,event_key,event,new_state,reason,metadata)
+    VALUES(v_handshake.id,'prepared:'||v_handshake.id::text,'prepared','prepared','payment_and_supplier_readiness_verified',
+      jsonb_build_object('paymentEvidenceId',v_payment_evidence.id,'reservationId',v_res.id,'pricingSnapshotId',v_res.pricing_snapshot_id));
+  END IF;
+
+  RETURN jsonb_build_object(
+    'eligible',true,'reason','supplier_order_handshake_ready','handshakeId',v_handshake.id,'orderId',v_order.id,
+    'fulfilmentLegId',v_leg.id,'reservationId',v_res.id,'paymentEvidenceId',v_payment_evidence.id,
+    'supplierKey',v_supplier.supplier_key,'supplierOfferId',v_offer.id,'externalOfferRef',v_offer.external_offer_ref,
+    'providerKey',v_adapter.provider_key,'adapterVersion',v_adapter.adapter_version,'quantity',v_quantity,
+    'destinationCountry',v_destination_country,'idempotencyKey',v_handshake.idempotency_key,'correlationId',v_handshake.correlation_id,
+    'state',v_handshake.state,'externalSupplierOrderRef',v_handshake.external_supplier_order_ref,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_prepare_supplier_order_handshake_v1(uuid,uuid,text,uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_prepare_supplier_order_handshake_v1(uuid,uuid,text,uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_mark_supplier_order_submission_started_v1(
+  p_handshake_id uuid,
+  p_idempotency_key text
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_h private.supplier_order_handshakes%ROWTYPE; v_previous text;
+BEGIN
+  SELECT * INTO v_h FROM private.supplier_order_handshakes WHERE id=p_handshake_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','handshake_not_found','interfaceVersion',1); END IF;
+  IF v_h.idempotency_key<>BTRIM(COALESCE(p_idempotency_key,'')) THEN RAISE EXCEPTION 'supplier submission idempotency mismatch'; END IF;
+  IF v_h.state IN ('accepted','rejected','reconciled') THEN
+    RETURN jsonb_build_object('ok',true,'reason','terminal_handshake_not_resubmitted','state',v_h.state,'interfaceVersion',1);
+  END IF;
+  IF v_h.state IN ('unknown','reconciliation_required','pending') THEN
+    RETURN jsonb_build_object('ok',false,'reason','query_before_retry_required','state',v_h.state,'interfaceVersion',1);
+  END IF;
+  v_previous:=v_h.state;
+  UPDATE private.supplier_order_handshakes SET state='submitting',submission_attempts=submission_attempts+1,submitted_at=COALESCE(submitted_at,now()),updated_at=now()
+   WHERE id=v_h.id RETURNING * INTO v_h;
+  UPDATE private.supplier_fulfilment_legs SET status='supplier_submitting',updated_at=now() WHERE id=v_h.fulfilment_leg_id;
+  UPDATE private.supplier_order_orchestrations SET state='supplier_submitting',updated_at=now() WHERE id=v_h.orchestration_id;
+  INSERT INTO private.supplier_order_handshake_events(handshake_id,event_key,event,previous_state,new_state,reason,metadata)
+  VALUES(v_h.id,'submit-start:'||v_h.id::text||':'||v_h.submission_attempts::text,'submission_started',v_previous,'submitting','provider_submission_started',
+    jsonb_build_object('attempt',v_h.submission_attempts));
+  RETURN jsonb_build_object('ok',true,'reason','submission_started','handshakeId',v_h.id,'attempt',v_h.submission_attempts,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_mark_supplier_order_submission_started_v1(uuid,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_mark_supplier_order_submission_started_v1(uuid,text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_record_supplier_order_submission_result_v1(
+  p_handshake_id uuid,
+  p_result_class text,
+  p_ack_state text,
+  p_external_supplier_order_ref text,
+  p_error_class text,
+  p_error_message text
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_h private.supplier_order_handshakes%ROWTYPE;
+  v_result text:=upper(BTRIM(COALESCE(p_result_class,'')));
+  v_ack text:=lower(BTRIM(COALESCE(p_ack_state,'unknown')));
+  v_external text:=NULLIF(BTRIM(p_external_supplier_order_ref),'');
+  v_new_state text;
+  v_recovery text;
+  v_leg_state text;
+  v_orch_state text;
+  v_previous text;
+BEGIN
+  SELECT * INTO v_h FROM private.supplier_order_handshakes WHERE id=p_handshake_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','handshake_not_found','interfaceVersion',1); END IF;
+  IF v_result NOT IN ('SUCCESS','ACCEPTED_PENDING','RETRYABLE_FAILURE','PERMANENT_REJECTION','AUTH_CONFIGURATION_FAILURE','RATE_LIMITED','PRICE_CHANGED','STOCK_CHANGED','UNKNOWN_OUTCOME','MANUAL_REVIEW_REQUIRED') THEN
+    RAISE EXCEPTION 'invalid supplier submission result class';
+  END IF;
+  IF v_ack NOT IN ('accepted','pending','rejected','unknown') THEN RAISE EXCEPTION 'invalid supplier acknowledgement state'; END IF;
+  IF v_h.external_supplier_order_ref IS NOT NULL AND v_external IS NOT NULL AND v_h.external_supplier_order_ref<>v_external THEN
+    RAISE EXCEPTION 'external supplier order reference cannot change';
+  END IF;
+
+  v_new_state:=CASE
+    WHEN v_result='SUCCESS' AND v_ack='accepted' THEN 'accepted'
+    WHEN v_result IN ('SUCCESS','ACCEPTED_PENDING') AND v_ack='pending' THEN 'pending'
+    WHEN v_result='PERMANENT_REJECTION' OR v_ack='rejected' THEN 'rejected'
+    WHEN v_result IN ('UNKNOWN_OUTCOME') OR v_ack='unknown' THEN 'unknown'
+    WHEN v_result IN ('RETRYABLE_FAILURE','RATE_LIMITED') THEN 'retryable_failure'
+    ELSE 'reconciliation_required'
+  END;
+  v_recovery:=CASE
+    WHEN v_new_state='accepted' THEN 'reconcile'
+    WHEN v_new_state='pending' THEN 'query_before_retry'
+    WHEN v_new_state='rejected' THEN 'reconcile'
+    WHEN v_new_state='unknown' THEN 'query_before_retry'
+    WHEN v_new_state='retryable_failure' THEN 'retry_pending'
+    ELSE 'manual_review'
+  END;
+  v_leg_state:=CASE v_new_state
+    WHEN 'accepted' THEN 'supplier_accepted' WHEN 'pending' THEN 'supplier_pending' WHEN 'rejected' THEN 'supplier_rejected'
+    WHEN 'retryable_failure' THEN 'supplier_submitting' ELSE 'reconciliation_required' END;
+  v_orch_state:=CASE v_new_state
+    WHEN 'accepted' THEN 'supplier_accepted' WHEN 'pending' THEN 'supplier_pending' WHEN 'rejected' THEN 'supplier_exception'
+    WHEN 'retryable_failure' THEN 'supplier_submitting' ELSE 'reconciliation_required' END;
+
+  v_previous:=v_h.state;
+  UPDATE private.supplier_order_handshakes SET
+    state=v_new_state,acknowledgement_state=v_ack,recovery_state=v_recovery,
+    external_supplier_order_ref=COALESCE(external_supplier_order_ref,v_external),last_error_class=NULLIF(BTRIM(p_error_class),''),
+    last_error_message=NULLIF(BTRIM(p_error_message),''),acknowledged_at=CASE WHEN v_ack IN ('accepted','rejected') THEN COALESCE(acknowledged_at,now()) ELSE acknowledged_at END,
+    last_checked_at=now(),updated_at=now()
+  WHERE id=v_h.id RETURNING * INTO v_h;
+
+  UPDATE private.supplier_fulfilment_legs SET status=v_leg_state,updated_at=now() WHERE id=v_h.fulfilment_leg_id;
+  UPDATE private.supplier_order_orchestrations SET state=v_orch_state,updated_at=now() WHERE id=v_h.orchestration_id;
+
+  IF v_new_state='accepted' THEN
+    UPDATE private.supplier_stock_reservations SET status='consumed',consumed_at=now()
+     WHERE id=v_h.reservation_id AND status='active';
+  ELSIF v_new_state='rejected' THEN
+    UPDATE private.supplier_stock_reservations SET status='released',released_at=now()
+     WHERE id=v_h.reservation_id AND status='active';
+  END IF;
+
+  INSERT INTO private.supplier_order_handshake_events(
+    handshake_id,event_key,event,previous_state,new_state,result_class,error_class,external_supplier_order_ref,recovery_state,reason,metadata
+  ) VALUES(
+    v_h.id,'submit-result:'||v_h.id::text||':'||v_h.submission_attempts::text,'submission_result',v_previous,v_new_state,v_result,
+    NULLIF(BTRIM(p_error_class),''),v_h.external_supplier_order_ref,v_recovery,'provider_submission_result_recorded',
+    jsonb_build_object('acknowledgementState',v_ack,'attempt',v_h.submission_attempts)
+  ) ON CONFLICT(event_key) DO NOTHING;
+
+  RETURN jsonb_build_object('ok',true,'reason','submission_result_recorded','handshakeId',v_h.id,'state',v_h.state,
+    'acknowledgementState',v_h.acknowledgement_state,'recoveryState',v_h.recovery_state,
+    'externalSupplierOrderRef',v_h.external_supplier_order_ref,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_record_supplier_order_submission_result_v1(uuid,text,text,text,text,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_record_supplier_order_submission_result_v1(uuid,text,text,text,text,text) TO service_role;
+
+COMMENT ON FUNCTION public.server_prepare_supplier_order_handshake_v1(uuid,uuid,text,uuid) IS 'Phase J fail-closed preparation. Requires canonical completed payment evidence, live reservation, stock/price recheck, active adapter and supplier_order control.';
+COMMENT ON FUNCTION public.server_mark_supplier_order_submission_started_v1(uuid,text) IS 'Phase J duplicate-prevention boundary. Unknown/pending outcomes require acknowledgement query before any retry.';
+COMMENT ON FUNCTION public.server_record_supplier_order_submission_result_v1(uuid,text,text,text,text,text) IS 'Phase J records supplier submission outcome separately from customer payment success.';

--- a/supabase/642_supplier_payment_handshake_reconciliation.sql
+++ b/supabase/642_supplier_payment_handshake_reconciliation.sql
@@ -1,0 +1,204 @@
+-- 642_supplier_payment_handshake_reconciliation.sql
+-- Phase J acknowledgement recovery, timeout handling and handshake reconciliation.
+-- This is supplier-order reconciliation only; full financial reconciliation remains Phase L.
+
+CREATE OR REPLACE FUNCTION public.server_record_supplier_order_acknowledgement_v1(
+  p_handshake_id uuid,
+  p_ack_state text,
+  p_external_supplier_order_ref text,
+  p_acknowledged_at timestamptz,
+  p_source text
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_h private.supplier_order_handshakes%ROWTYPE;
+  v_ack text:=lower(BTRIM(COALESCE(p_ack_state,'')));
+  v_external text:=NULLIF(BTRIM(p_external_supplier_order_ref),'');
+  v_source text:=NULLIF(BTRIM(p_source),'');
+  v_previous text;
+  v_state text;
+  v_recovery text;
+BEGIN
+  IF v_ack NOT IN ('accepted','pending','rejected','unknown') OR v_source IS NULL THEN
+    RAISE EXCEPTION 'valid acknowledgement state and source are required';
+  END IF;
+  SELECT * INTO v_h FROM private.supplier_order_handshakes WHERE id=p_handshake_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','handshake_not_found','interfaceVersion',1); END IF;
+  IF v_h.external_supplier_order_ref IS NOT NULL AND v_external IS NOT NULL AND v_h.external_supplier_order_ref<>v_external THEN
+    RAISE EXCEPTION 'duplicate acknowledgement references a different supplier order';
+  END IF;
+  IF v_ack IN ('accepted','pending') AND COALESCE(v_h.external_supplier_order_ref,v_external) IS NULL THEN
+    RETURN jsonb_build_object('ok',false,'reason','supplier_order_reference_required_for_acknowledgement','interfaceVersion',1);
+  END IF;
+
+  v_state:=CASE v_ack WHEN 'accepted' THEN 'accepted' WHEN 'pending' THEN 'pending' WHEN 'rejected' THEN 'rejected' ELSE 'unknown' END;
+  v_recovery:=CASE v_ack WHEN 'accepted' THEN 'reconcile' WHEN 'rejected' THEN 'manual_review' ELSE 'query_before_retry' END;
+  v_previous:=v_h.state;
+
+  UPDATE private.supplier_order_handshakes SET
+    state=v_state,acknowledgement_state=v_ack,recovery_state=v_recovery,
+    external_supplier_order_ref=COALESCE(external_supplier_order_ref,v_external),
+    acknowledged_at=CASE WHEN v_ack IN ('accepted','rejected') THEN COALESCE(p_acknowledged_at,now()) ELSE acknowledged_at END,
+    last_checked_at=now(),updated_at=now()
+  WHERE id=v_h.id RETURNING * INTO v_h;
+
+  UPDATE private.supplier_fulfilment_legs SET status=CASE v_ack
+    WHEN 'accepted' THEN 'supplier_accepted' WHEN 'pending' THEN 'supplier_pending'
+    WHEN 'rejected' THEN 'supplier_rejected' ELSE 'reconciliation_required' END,updated_at=now()
+  WHERE id=v_h.fulfilment_leg_id;
+  UPDATE private.supplier_order_orchestrations SET state=CASE v_ack
+    WHEN 'accepted' THEN 'supplier_accepted' WHEN 'pending' THEN 'supplier_pending'
+    WHEN 'rejected' THEN 'supplier_exception' ELSE 'reconciliation_required' END,updated_at=now()
+  WHERE id=v_h.orchestration_id;
+
+  IF v_ack='accepted' THEN
+    UPDATE private.supplier_stock_reservations SET status='consumed',consumed_at=COALESCE(consumed_at,now())
+     WHERE id=v_h.reservation_id AND status='active';
+  ELSIF v_ack='rejected' THEN
+    UPDATE private.supplier_stock_reservations SET status='released',released_at=COALESCE(released_at,now())
+     WHERE id=v_h.reservation_id AND status='active';
+  END IF;
+
+  INSERT INTO private.supplier_order_handshake_events(
+    handshake_id,event_key,event,previous_state,new_state,external_supplier_order_ref,recovery_state,reason,metadata
+  ) VALUES(
+    v_h.id,'ack:'||v_h.id::text||':'||v_ack||':'||COALESCE(v_h.external_supplier_order_ref,'none'),
+    'acknowledgement',v_previous,v_state,v_h.external_supplier_order_ref,v_recovery,'supplier_acknowledgement_recorded',
+    jsonb_build_object('source',v_source,'acknowledgedAt',COALESCE(p_acknowledged_at,now()))
+  ) ON CONFLICT(event_key) DO NOTHING;
+
+  RETURN jsonb_build_object('ok',true,'reason','supplier_acknowledgement_recorded','handshakeId',v_h.id,
+    'state',v_h.state,'acknowledgementState',v_h.acknowledgement_state,'recoveryState',v_h.recovery_state,
+    'externalSupplierOrderRef',v_h.external_supplier_order_ref,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_record_supplier_order_acknowledgement_v1(uuid,text,text,timestamptz,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_record_supplier_order_acknowledgement_v1(uuid,text,text,timestamptz,text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_mark_supplier_order_handshake_timeout_v1(
+  p_timeout_seconds integer DEFAULT 120
+)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_count integer:=0;
+BEGIN
+  IF p_timeout_seconds IS NULL OR p_timeout_seconds<30 OR p_timeout_seconds>3600 THEN
+    RAISE EXCEPTION 'timeout must be between 30 and 3600 seconds';
+  END IF;
+  WITH timed_out AS (
+    UPDATE private.supplier_order_handshakes h
+       SET state='unknown',acknowledgement_state='unknown',recovery_state='query_before_retry',last_error_class='UNKNOWN_OUTCOME',
+           last_error_message='supplier submission timed out before a trustworthy acknowledgement was recorded',last_checked_at=now(),updated_at=now()
+     WHERE h.state='submitting' AND h.updated_at + make_interval(secs=>p_timeout_seconds)<=now()
+     RETURNING h.id,h.fulfilment_leg_id,h.orchestration_id,h.submission_attempts
+  ), events AS (
+    INSERT INTO private.supplier_order_handshake_events(handshake_id,event_key,event,previous_state,new_state,result_class,error_class,recovery_state,reason,metadata)
+    SELECT id,'timeout:'||id::text||':'||submission_attempts::text,'timeout','submitting','unknown','UNKNOWN_OUTCOME','UNKNOWN_OUTCOME','query_before_retry',
+      'supplier_submission_timeout_requires_query_before_retry',jsonb_build_object('timeoutSeconds',p_timeout_seconds)
+    FROM timed_out ON CONFLICT(event_key) DO NOTHING RETURNING handshake_id
+  ), legs AS (
+    UPDATE private.supplier_fulfilment_legs l SET status='reconciliation_required',updated_at=now()
+     WHERE l.id IN (SELECT fulfilment_leg_id FROM timed_out) RETURNING l.id
+  ), orchestrations AS (
+    UPDATE private.supplier_order_orchestrations o SET state='reconciliation_required',updated_at=now()
+     WHERE o.id IN (SELECT orchestration_id FROM timed_out) RETURNING o.id
+  )
+  SELECT count(*)::integer INTO v_count FROM timed_out;
+  RETURN v_count;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_mark_supplier_order_handshake_timeout_v1(integer) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_mark_supplier_order_handshake_timeout_v1(integer) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_supplier_order_retry_decision_v1(
+  p_handshake_id uuid
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_h private.supplier_order_handshakes%ROWTYPE;
+BEGIN
+  SELECT * INTO v_h FROM private.supplier_order_handshakes WHERE id=p_handshake_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','handshake_not_found','interfaceVersion',1); END IF;
+  IF v_h.state='retryable_failure' AND v_h.recovery_state='retry_pending' THEN
+    RETURN jsonb_build_object('eligible',true,'reason','retry_same_idempotency_key','idempotencyKey',v_h.idempotency_key,'interfaceVersion',1);
+  END IF;
+  IF v_h.state IN ('unknown','pending','reconciliation_required') OR v_h.recovery_state='query_before_retry' THEN
+    RETURN jsonb_build_object('eligible',false,'reason','query_before_retry_required','externalSupplierOrderRef',v_h.external_supplier_order_ref,'interfaceVersion',1);
+  END IF;
+  RETURN jsonb_build_object('eligible',false,'reason','handshake_not_retryable','state',v_h.state,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_supplier_order_retry_decision_v1(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_order_retry_decision_v1(uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_reconcile_supplier_order_handshake_v1(
+  p_handshake_id uuid
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_h private.supplier_order_handshakes%ROWTYPE;
+  v_payment private.supplier_payment_evidence_snapshots%ROWTYPE;
+  v_res private.supplier_stock_reservations%ROWTYPE;
+  v_previous text;
+BEGIN
+  SELECT * INTO v_h FROM private.supplier_order_handshakes WHERE id=p_handshake_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('reconciled',false,'reason','handshake_not_found','interfaceVersion',1); END IF;
+  SELECT * INTO v_payment FROM private.supplier_payment_evidence_snapshots WHERE id=v_h.payment_evidence_id;
+  SELECT * INTO v_res FROM private.supplier_stock_reservations WHERE id=v_h.reservation_id;
+
+  IF NOT FOUND OR v_payment.payment_status<>'completed' THEN
+    UPDATE private.supplier_order_handshakes SET state='reconciliation_required',recovery_state='manual_review',updated_at=now() WHERE id=v_h.id;
+    RETURN jsonb_build_object('reconciled',false,'reason','payment_evidence_missing','interfaceVersion',1);
+  END IF;
+
+  IF v_h.acknowledgement_state='accepted' AND v_h.external_supplier_order_ref IS NOT NULL AND v_res.status='consumed' THEN
+    v_previous:=v_h.state;
+    UPDATE private.supplier_order_handshakes SET state='reconciled',recovery_state='resolved',reconciled_at=COALESCE(reconciled_at,now()),last_checked_at=now(),updated_at=now()
+     WHERE id=v_h.id RETURNING * INTO v_h;
+    INSERT INTO private.supplier_order_handshake_events(handshake_id,event_key,event,previous_state,new_state,recovery_state,reason,metadata)
+    VALUES(v_h.id,'reconciled:'||v_h.id::text,'reconciliation',v_previous,'reconciled','resolved','payment_and_supplier_acknowledgement_reconciled',
+      jsonb_build_object('paymentEvidenceId',v_h.payment_evidence_id,'externalSupplierOrderRef',v_h.external_supplier_order_ref))
+    ON CONFLICT(event_key) DO NOTHING;
+    RETURN jsonb_build_object('reconciled',true,'reason','supplier_order_handshake_reconciled','handshakeId',v_h.id,
+      'externalSupplierOrderRef',v_h.external_supplier_order_ref,'interfaceVersion',1);
+  END IF;
+
+  UPDATE private.supplier_order_handshakes SET
+    recovery_state=CASE WHEN state IN ('unknown','pending') THEN 'query_before_retry' ELSE 'manual_review' END,
+    state=CASE WHEN state IN ('rejected','reconciliation_required') THEN 'reconciliation_required' ELSE state END,last_checked_at=now(),updated_at=now()
+  WHERE id=v_h.id RETURNING * INTO v_h;
+  RETURN jsonb_build_object('reconciled',false,'reason',CASE
+    WHEN v_h.acknowledgement_state='rejected' THEN 'customer_paid_supplier_rejected'
+    WHEN v_h.acknowledgement_state IN ('pending','unknown') THEN 'supplier_acknowledgement_unresolved'
+    ELSE 'supplier_order_not_acknowledged' END,
+    'state',v_h.state,'recoveryState',v_h.recovery_state,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_reconcile_supplier_order_handshake_v1(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_reconcile_supplier_order_handshake_v1(uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_supplier_order_handshake_status_v1(
+  p_actor_id uuid,
+  p_order_id uuid DEFAULT NULL
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM public.users u WHERE u.id=p_actor_id AND u.role='admin' AND u."isActive"=true) THEN
+    RAISE EXCEPTION 'active admin authority is required' USING ERRCODE='42501';
+  END IF;
+  RETURN jsonb_build_object('items',(
+    SELECT COALESCE(jsonb_agg(jsonb_build_object(
+      'handshakeId',h.id,'orderId',h.order_id,'fulfilmentLegId',h.fulfilment_leg_id,'supplierOfferId',h.supplier_offer_id,
+      'providerKey',h.provider_key,'state',h.state,'acknowledgementState',h.acknowledgement_state,'recoveryState',h.recovery_state,
+      'externalSupplierOrderRef',h.external_supplier_order_ref,'submissionAttempts',h.submission_attempts,'lastErrorClass',h.last_error_class,
+      'submittedAt',h.submitted_at,'acknowledgedAt',h.acknowledged_at,'lastCheckedAt',h.last_checked_at,'updatedAt',h.updated_at
+    ) ORDER BY h.updated_at DESC),'[]'::jsonb)
+    FROM private.supplier_order_handshakes h
+    WHERE p_order_id IS NULL OR h.order_id=p_order_id
+  ),'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_supplier_order_handshake_status_v1(uuid,uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_supplier_order_handshake_status_v1(uuid,uuid) TO service_role;
+
+COMMENT ON FUNCTION public.server_record_supplier_order_acknowledgement_v1(uuid,text,text,timestamptz,text) IS 'Phase J idempotent acknowledgement recovery. Duplicate acknowledgement is evidence, never a duplicate supplier submission.';
+COMMENT ON FUNCTION public.server_supplier_order_retry_decision_v1(uuid) IS 'Unknown/pending outcomes are never blindly retried; query-before-retry is mandatory.';
+COMMENT ON FUNCTION public.server_reconcile_supplier_order_handshake_v1(uuid) IS 'Phase J payment/supplier-order handshake reconciliation only. Full financial reconciliation is intentionally deferred to Phase L.';

--- a/supabase/643_supplier_payment_handshake_terminal_closure.sql
+++ b/supabase/643_supplier_payment_handshake_terminal_closure.sql
@@ -1,0 +1,172 @@
+-- 643_supplier_payment_handshake_terminal_closure.sql
+-- Branch Guard closure: terminal acknowledgement cannot regress; reconciliation
+-- checks payment and reservation evidence explicitly instead of relying on FOUND.
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_order_handshake_terminal_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  IF OLD.state='reconciled' AND NEW.state<>'reconciled' THEN
+    RAISE EXCEPTION 'reconciled supplier handshake cannot regress';
+  END IF;
+  IF OLD.acknowledgement_state='accepted' AND NEW.acknowledgement_state NOT IN ('accepted') THEN
+    RAISE EXCEPTION 'accepted supplier acknowledgement cannot regress';
+  END IF;
+  IF OLD.acknowledgement_state='rejected' AND NEW.acknowledgement_state NOT IN ('rejected') THEN
+    RAISE EXCEPTION 'rejected supplier acknowledgement cannot regress';
+  END IF;
+  IF OLD.external_supplier_order_ref IS NOT NULL
+     AND NEW.external_supplier_order_ref IS DISTINCT FROM OLD.external_supplier_order_ref THEN
+    RAISE EXCEPTION 'external supplier order reference is immutable once known';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_order_handshake_terminal_v1 ON private.supplier_order_handshakes;
+CREATE TRIGGER trg_guard_supplier_order_handshake_terminal_v1
+BEFORE UPDATE ON private.supplier_order_handshakes
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_order_handshake_terminal_v1();
+
+CREATE OR REPLACE FUNCTION public.server_record_supplier_order_acknowledgement_v1(
+  p_handshake_id uuid,
+  p_ack_state text,
+  p_external_supplier_order_ref text,
+  p_acknowledged_at timestamptz,
+  p_source text
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_h private.supplier_order_handshakes%ROWTYPE;
+  v_ack text:=lower(BTRIM(COALESCE(p_ack_state,'')));
+  v_external text:=NULLIF(BTRIM(p_external_supplier_order_ref),'');
+  v_source text:=NULLIF(BTRIM(p_source),'');
+  v_previous text;
+  v_state text;
+  v_recovery text;
+BEGIN
+  IF v_ack NOT IN ('accepted','pending','rejected','unknown') OR v_source IS NULL THEN
+    RAISE EXCEPTION 'valid acknowledgement state and source are required';
+  END IF;
+  SELECT * INTO v_h FROM private.supplier_order_handshakes WHERE id=p_handshake_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','handshake_not_found','interfaceVersion',1); END IF;
+
+  IF v_h.external_supplier_order_ref IS NOT NULL AND v_external IS NOT NULL AND v_h.external_supplier_order_ref<>v_external THEN
+    RAISE EXCEPTION 'duplicate acknowledgement references a different supplier order';
+  END IF;
+
+  -- Duplicate/later weaker acknowledgements cannot regress a terminal provider truth.
+  IF v_h.acknowledgement_state='accepted' THEN
+    IF v_ack='rejected' THEN
+      RETURN jsonb_build_object('ok',false,'reason','conflicting_terminal_acknowledgement','state',v_h.state,
+        'externalSupplierOrderRef',v_h.external_supplier_order_ref,'interfaceVersion',1);
+    END IF;
+    RETURN jsonb_build_object('ok',true,'reason','accepted_acknowledgement_replayed','state',v_h.state,
+      'acknowledgementState',v_h.acknowledgement_state,'externalSupplierOrderRef',v_h.external_supplier_order_ref,'interfaceVersion',1);
+  END IF;
+  IF v_h.acknowledgement_state='rejected' THEN
+    IF v_ack='accepted' THEN
+      RETURN jsonb_build_object('ok',false,'reason','conflicting_terminal_acknowledgement','state',v_h.state,
+        'externalSupplierOrderRef',v_h.external_supplier_order_ref,'interfaceVersion',1);
+    END IF;
+    RETURN jsonb_build_object('ok',true,'reason','rejected_acknowledgement_replayed','state',v_h.state,
+      'acknowledgementState',v_h.acknowledgement_state,'externalSupplierOrderRef',v_h.external_supplier_order_ref,'interfaceVersion',1);
+  END IF;
+
+  IF v_ack IN ('accepted','pending') AND COALESCE(v_h.external_supplier_order_ref,v_external) IS NULL THEN
+    RETURN jsonb_build_object('ok',false,'reason','supplier_order_reference_required_for_acknowledgement','interfaceVersion',1);
+  END IF;
+
+  v_state:=CASE v_ack WHEN 'accepted' THEN 'accepted' WHEN 'pending' THEN 'pending' WHEN 'rejected' THEN 'rejected' ELSE 'unknown' END;
+  v_recovery:=CASE v_ack WHEN 'accepted' THEN 'reconcile' WHEN 'rejected' THEN 'manual_review' ELSE 'query_before_retry' END;
+  v_previous:=v_h.state;
+
+  UPDATE private.supplier_order_handshakes SET
+    state=v_state,acknowledgement_state=v_ack,recovery_state=v_recovery,
+    external_supplier_order_ref=COALESCE(external_supplier_order_ref,v_external),
+    acknowledged_at=CASE WHEN v_ack IN ('accepted','rejected') THEN COALESCE(p_acknowledged_at,now()) ELSE acknowledged_at END,
+    last_checked_at=now(),updated_at=now()
+  WHERE id=v_h.id RETURNING * INTO v_h;
+
+  UPDATE private.supplier_fulfilment_legs SET status=CASE v_ack
+    WHEN 'accepted' THEN 'supplier_accepted' WHEN 'pending' THEN 'supplier_pending'
+    WHEN 'rejected' THEN 'supplier_rejected' ELSE 'reconciliation_required' END,updated_at=now()
+  WHERE id=v_h.fulfilment_leg_id;
+  UPDATE private.supplier_order_orchestrations SET state=CASE v_ack
+    WHEN 'accepted' THEN 'supplier_accepted' WHEN 'pending' THEN 'supplier_pending'
+    WHEN 'rejected' THEN 'supplier_exception' ELSE 'reconciliation_required' END,updated_at=now()
+  WHERE id=v_h.orchestration_id;
+
+  IF v_ack='accepted' THEN
+    UPDATE private.supplier_stock_reservations SET status='consumed',consumed_at=COALESCE(consumed_at,now())
+     WHERE id=v_h.reservation_id AND status='active';
+  ELSIF v_ack='rejected' THEN
+    UPDATE private.supplier_stock_reservations SET status='released',released_at=COALESCE(released_at,now())
+     WHERE id=v_h.reservation_id AND status='active';
+  END IF;
+
+  INSERT INTO private.supplier_order_handshake_events(
+    handshake_id,event_key,event,previous_state,new_state,external_supplier_order_ref,recovery_state,reason,metadata
+  ) VALUES(
+    v_h.id,'ack:'||v_h.id::text||':'||v_ack||':'||COALESCE(v_h.external_supplier_order_ref,'none'),
+    'acknowledgement',v_previous,v_state,v_h.external_supplier_order_ref,v_recovery,'supplier_acknowledgement_recorded',
+    jsonb_build_object('source',v_source,'acknowledgedAt',COALESCE(p_acknowledged_at,now()))
+  ) ON CONFLICT(event_key) DO NOTHING;
+
+  RETURN jsonb_build_object('ok',true,'reason','supplier_acknowledgement_recorded','handshakeId',v_h.id,
+    'state',v_h.state,'acknowledgementState',v_h.acknowledgement_state,'recoveryState',v_h.recovery_state,
+    'externalSupplierOrderRef',v_h.external_supplier_order_ref,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_record_supplier_order_acknowledgement_v1(uuid,text,text,timestamptz,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_record_supplier_order_acknowledgement_v1(uuid,text,text,timestamptz,text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_reconcile_supplier_order_handshake_v1(
+  p_handshake_id uuid
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_h private.supplier_order_handshakes%ROWTYPE;
+  v_payment private.supplier_payment_evidence_snapshots%ROWTYPE;
+  v_res private.supplier_stock_reservations%ROWTYPE;
+  v_previous text;
+BEGIN
+  SELECT * INTO v_h FROM private.supplier_order_handshakes WHERE id=p_handshake_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('reconciled',false,'reason','handshake_not_found','interfaceVersion',1); END IF;
+  SELECT * INTO v_payment FROM private.supplier_payment_evidence_snapshots WHERE id=v_h.payment_evidence_id;
+  SELECT * INTO v_res FROM private.supplier_stock_reservations WHERE id=v_h.reservation_id;
+
+  IF v_payment.id IS NULL OR v_payment.payment_status<>'completed' THEN
+    UPDATE private.supplier_order_handshakes SET state='reconciliation_required',recovery_state='manual_review',updated_at=now() WHERE id=v_h.id;
+    RETURN jsonb_build_object('reconciled',false,'reason','payment_evidence_missing','interfaceVersion',1);
+  END IF;
+  IF v_res.id IS NULL THEN
+    UPDATE private.supplier_order_handshakes SET state='reconciliation_required',recovery_state='manual_review',updated_at=now() WHERE id=v_h.id;
+    RETURN jsonb_build_object('reconciled',false,'reason','reservation_evidence_missing','interfaceVersion',1);
+  END IF;
+
+  IF v_h.acknowledgement_state='accepted' AND v_h.external_supplier_order_ref IS NOT NULL AND v_res.status='consumed' THEN
+    v_previous:=v_h.state;
+    UPDATE private.supplier_order_handshakes SET state='reconciled',recovery_state='resolved',reconciled_at=COALESCE(reconciled_at,now()),last_checked_at=now(),updated_at=now()
+     WHERE id=v_h.id RETURNING * INTO v_h;
+    INSERT INTO private.supplier_order_handshake_events(handshake_id,event_key,event,previous_state,new_state,recovery_state,reason,metadata)
+    VALUES(v_h.id,'reconciled:'||v_h.id::text,'reconciliation',v_previous,'reconciled','resolved','payment_and_supplier_acknowledgement_reconciled',
+      jsonb_build_object('paymentEvidenceId',v_h.payment_evidence_id,'externalSupplierOrderRef',v_h.external_supplier_order_ref))
+    ON CONFLICT(event_key) DO NOTHING;
+    RETURN jsonb_build_object('reconciled',true,'reason','supplier_order_handshake_reconciled','handshakeId',v_h.id,
+      'externalSupplierOrderRef',v_h.external_supplier_order_ref,'interfaceVersion',1);
+  END IF;
+
+  UPDATE private.supplier_order_handshakes SET
+    recovery_state=CASE WHEN state IN ('unknown','pending') THEN 'query_before_retry' ELSE 'manual_review' END,
+    state=CASE WHEN state IN ('rejected','reconciliation_required') THEN 'reconciliation_required' ELSE state END,last_checked_at=now(),updated_at=now()
+  WHERE id=v_h.id RETURNING * INTO v_h;
+  RETURN jsonb_build_object('reconciled',false,'reason',CASE
+    WHEN v_h.acknowledgement_state='rejected' THEN 'customer_paid_supplier_rejected'
+    WHEN v_h.acknowledgement_state IN ('pending','unknown') THEN 'supplier_acknowledgement_unresolved'
+    ELSE 'supplier_order_not_acknowledged' END,
+    'state',v_h.state,'recoveryState',v_h.recovery_state,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_reconcile_supplier_order_handshake_v1(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_reconcile_supplier_order_handshake_v1(uuid) TO service_role;
+
+COMMENT ON FUNCTION private.guard_supplier_order_handshake_terminal_v1() IS 'Phase J terminal-state guard: late/duplicate acknowledgements cannot regress accepted/rejected/reconciled provider truth.';


### PR DESCRIPTION
Implements canonical Phase J payment→supplier handshake and reconciliation foundation.

Scope:
- provider-neutral paid-order supplier handshake
- payment evidence before supplier submission
- acknowledgement persistence and unknown-outcome recovery
- idempotency key reuse and provider lookup before retry
- terminal-state monotonicity
- reservation consumption only after confirmed supplier acceptance
- supplier-order reconciliation into canonical financial truth
- fail-closed controls; no Supplier Commerce activation

PowerShell validation on tested HEAD a69bbcd1ea05b14e6be26ee18e2a86625a0de5a3:
- Phase J dedicated: 27/27 PASS
- upstream C–I: 113/113 PASS
- TypeScript: PASS
- lint: PASS
- build: PASS
- full suite: same known 27 baseline failures; no Phase J regression

No unrelated visual Workspace/Super Admin redesign.