### PR TITLE
Phase K — tracking normalisation and exception engine

### DIFF
--- a/netlify/functions/__tests__/supplier-tracking-exceptions.test.ts
+++ b/netlify/functions/__tests__/supplier-tracking-exceptions.test.ts
@@ -1,0 +1,174 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+import type { SupplierAdapterV1 } from '../_shared/supplierAdapter';
+import { SUPPLIER_TRACKING_INTERFACE_VERSION, syncSupplierTracking } from '../_shared/supplierTracking';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const foundation = repo('supabase/644_supplier_tracking_exception_foundation.sql');
+const runtime = repo('supabase/645_supplier_tracking_runtime_guards.sql');
+const exceptions = repo('supabase/646_supplier_exception_engine.sql');
+const closure = repo('supabase/647_supplier_tracking_exception_closure.sql');
+const helper = repo('netlify/functions/_shared/supplierTracking.ts');
+const adminApi = repo('netlify/functions/admin-supplier-tracking.ts');
+
+const HANDSHAKE = '11111111-1111-4111-8111-111111111111';
+const context = {
+  eligible: true,
+  reason: 'supplier_tracking_ready',
+  handshakeId: HANDSHAKE,
+  orderId: '22222222-2222-4222-8222-222222222222',
+  orchestrationId: '33333333-3333-4333-8333-333333333333',
+  fulfilmentLegId: '44444444-4444-4444-8444-444444444444',
+  supplierId: '55555555-5555-4555-8555-555555555555',
+  supplierKey: 'supplier-a',
+  providerKey: 'provider-a',
+  adapterVersion: '2026-08-21',
+  supplierOrderRef: 'SUP-1',
+  correlationId: '66666666-6666-4666-8666-666666666666',
+  interfaceVersion: 1,
+} as const;
+
+function adapter(overrides: Partial<SupplierAdapterV1> = {}): SupplierAdapterV1 {
+  return {
+    interfaceVersion: 1,
+    providerKey: 'provider-a',
+    adapterVersion: '2026-08-21',
+    capabilities: ['tracking'],
+    getTracking: vi.fn(async () => ({
+      ok: true as const,
+      data: [{ supplierOrderRef: 'SUP-1', carrierRef: 'carrier-x', trackingRef: 'TRK-1', status: 'in_transit', occurredAt: '2026-08-21T10:00:00Z' }],
+    })),
+    ...overrides,
+  };
+}
+
+describe('Phase K tracking + exceptions', () => {
+  it('keeps one customer order while allowing internal per-leg shipments', () => {
+    expect(foundation).toContain('Buyer remains on ONE public customer order');
+    expect(foundation).toContain('fulfilment_leg_id uuid NOT NULL UNIQUE');
+    expect(foundation).toContain('private.supplier_leg_shipments');
+  });
+
+  it('normalises provider statuses through versioned approved mappings', () => {
+    expect(foundation).toContain('supplier_tracking_status_mappings');
+    expect(foundation).toContain('version integer NOT NULL');
+    expect(runtime).toContain("m.status='approved'");
+    expect(runtime).toContain('v_mapping.canonical_status');
+  });
+
+  it('implements canonical tracking states from the contract', () => {
+    for (const state of ['pending','accepted','dispatched','in_transit','exception','out_for_delivery','delivered','failed_delivery','returned']) {
+      expect(foundation).toContain(`'${state}'`);
+    }
+  });
+
+  it('requires tracking_ingest kill switch and never enables it', () => {
+    expect(runtime).toContain("server_supplier_commerce_control_decision_v1('tracking_ingest'");
+    expect(runtime).toContain("'tracking_ingest_control_disabled'");
+    expect(foundation).toContain('this migration enables no control');
+    expect(foundation).not.toContain('enabled = true');
+  });
+
+  it('requires reconciled supplier order and tracking-capable adapter context', () => {
+    expect(runtime).toContain("v_h.state<>'reconciled'");
+    expect(runtime).toContain("ARRAY['tracking']::text[]");
+    expect(helper).toContain("adapterSupports(adapter, 'tracking')");
+  });
+
+  it('makes raw tracking events append-only and replay-idempotent', () => {
+    expect(runtime).toContain('supplier tracking events are append-only');
+    expect(foundation).toContain('event_fingerprint text NOT NULL UNIQUE');
+    expect(runtime).toContain('ON CONFLICT(event_fingerprint) DO NOTHING');
+    expect(runtime).toContain("'tracking_event_replayed'");
+  });
+
+  it('protects shipment identity, tracking reference and delivered terminal truth', () => {
+    expect(closure).toContain('supplier leg shipment identity is immutable');
+    expect(closure).toContain('tracking reference is immutable once known');
+    expect(closure).toContain("OLD.canonical_status='delivered'");
+    expect(closure).toContain("NEW.canonical_status NOT IN ('delivered','returned')");
+  });
+
+  it('requires every exception to carry state owner next action customer impact financial impact and resolution', () => {
+    for (const field of ['state text NOT NULL','owner_type text NOT NULL','next_action text NOT NULL','customer_impact text NOT NULL','financial_impact text NOT NULL','resolution text']) {
+      expect(foundation).toContain(field);
+    }
+  });
+
+  it('covers Phase K tracking/fulfilment exception classes while deferring money movement to Phase L', () => {
+    for (const type of ['partial_fulfilment','partial_shipment','delayed_dispatch','no_tracking','lost_shipment','tracking_exception','failed_delivery','supplier_suspended_mid_order']) {
+      expect(foundation).toContain(`'${type}'`);
+    }
+    expect(exceptions).toContain('Returns/refunds/recovery money movement remains Phase L');
+    expect(exceptions).not.toContain('UPDATE public.payment_sessions');
+  });
+
+  it('detects no-tracking delayed-dispatch and carrier exception evidence idempotently', () => {
+    expect(exceptions).toContain("'no-tracking:'||h.id::text");
+    expect(exceptions).toContain("'delayed-dispatch:'||s.id::text");
+    expect(exceptions).toContain("'tracking-exception:'||e.id::text");
+    expect(exceptions).toContain('ON CONFLICT(exception_key) DO NOTHING');
+  });
+
+  it('keeps exception transition/admin visibility active-admin-only', () => {
+    expect(exceptions).toContain("u.role='admin'");
+    expect(exceptions).toContain('u."isActive"=true');
+    expect(adminApi).toContain("authenticateActiveAccount(event, admin, ['admin'])");
+  });
+
+  it('preserves approved mapping history by versioning instead of rewrite', () => {
+    expect(closure).toContain('approved supplier tracking mapping truth is immutable; create a new version');
+    expect(closure).toContain("SET status='retired',effective_to=p_effective_from");
+    expect(closure).toContain('COALESCE(MAX(version),0)+1');
+  });
+
+  it('polls provider tracking through SupplierAdapterV1 and persists via server RPC', async () => {
+    const rpc = vi.fn(async (name: string) => {
+      if (name === 'server_supplier_tracking_context_v1') return { data: context, error: null };
+      if (name === 'server_ingest_supplier_tracking_event_v1') return { data: { ok: true, reason: 'tracking_event_ingested' }, error: null };
+      if (name === 'server_detect_supplier_tracking_exceptions_v1') return { data: 0, error: null };
+      if (name === 'server_record_supplier_commerce_operation_v1') return { data: HANDSHAKE, error: null };
+      return { data: null, error: new Error(`unexpected rpc ${name}`) };
+    });
+    const client = { rpc } as unknown as SupabaseClient;
+    const a = adapter();
+    const result = await syncSupplierTracking(client, a, HANDSHAKE);
+    expect(result).toEqual({ ok: true, ingested: 1, blocked: 0 });
+    expect(a.getTracking).toHaveBeenCalledTimes(1);
+    expect(rpc).toHaveBeenCalledWith('server_ingest_supplier_tracking_event_v1', expect.objectContaining({ p_handshake_id: HANDSHAKE, p_provider_status: 'in_transit' }));
+  });
+
+  it('fails closed before provider call when adapter identity/capability mismatches', async () => {
+    const rpc = vi.fn(async (name: string) => name === 'server_supplier_tracking_context_v1' ? { data: context, error: null } : { data: null, error: null });
+    const client = { rpc } as unknown as SupabaseClient;
+    const a = adapter({ providerKey: 'wrong-provider' });
+    const result = await syncSupplierTracking(client, a, HANDSHAKE);
+    expect(result).toMatchObject({ ok: false, ingested: 0, reason: 'tracking_adapter_identity_or_capability_mismatch' });
+    expect(a.getTracking).not.toHaveBeenCalled();
+  });
+
+  it('blocks malformed or wrong-order provider events instead of laundering them into tracking truth', async () => {
+    const rpc = vi.fn(async (name: string) => {
+      if (name === 'server_supplier_tracking_context_v1') return { data: context, error: null };
+      if (name === 'server_detect_supplier_tracking_exceptions_v1') return { data: 0, error: null };
+      return { data: null, error: null };
+    });
+    const client = { rpc } as unknown as SupabaseClient;
+    const a = adapter({
+      getTracking: vi.fn(async () => ({ ok: true as const, data: [
+        { supplierOrderRef: 'WRONG', status: 'delivered', occurredAt: '2026-08-21T10:00:00Z' },
+        { supplierOrderRef: 'SUP-1', status: '', occurredAt: 'not-a-date' },
+      ] })),
+    });
+    const result = await syncSupplierTracking(client, a, HANDSHAKE);
+    expect(result).toEqual({ ok: false, ingested: 0, blocked: 2 });
+    expect(rpc).not.toHaveBeenCalledWith('server_ingest_supplier_tracking_event_v1', expect.anything());
+  });
+
+  it('exposes interface version 1 without changing SupplierAdapterV1', () => {
+    expect(SUPPLIER_TRACKING_INTERFACE_VERSION).toBe(1);
+    expect(helper).toContain('SUPPLIER_TRACKING_INTERFACE_VERSION = 1');
+  });
+});

--- a/netlify/functions/_shared/supplierTracking.ts
+++ b/netlify/functions/_shared/supplierTracking.ts
@@ -1,0 +1,164 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { SupplierAdapterContext, SupplierAdapterV1, SupplierTrackingEvent } from './supplierAdapter';
+import { adapterSupports } from './supplierAdapter';
+import { recordSupplierCommerceOperation } from './supplierCommerceControl';
+
+export const SUPPLIER_TRACKING_INTERFACE_VERSION = 1 as const;
+
+export interface SupplierTrackingContext {
+  eligible: true;
+  reason: 'supplier_tracking_ready';
+  handshakeId: string;
+  orderId: string;
+  orchestrationId: string;
+  fulfilmentLegId: string;
+  supplierId: string;
+  supplierKey: string;
+  providerKey: string;
+  adapterVersion: string;
+  supplierOrderRef: string;
+  correlationId: string;
+  interfaceVersion: 1;
+}
+
+export interface SupplierTrackingSyncResult {
+  ok: boolean;
+  ingested: number;
+  blocked?: number;
+  reason?: string;
+}
+
+function isTrackingContext(value: unknown): value is SupplierTrackingContext {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  return row.eligible === true
+    && row.reason === 'supplier_tracking_ready'
+    && typeof row.handshakeId === 'string'
+    && typeof row.orderId === 'string'
+    && typeof row.orchestrationId === 'string'
+    && typeof row.fulfilmentLegId === 'string'
+    && typeof row.supplierKey === 'string'
+    && typeof row.providerKey === 'string'
+    && typeof row.adapterVersion === 'string'
+    && typeof row.supplierOrderRef === 'string'
+    && typeof row.correlationId === 'string'
+    && row.interfaceVersion === SUPPLIER_TRACKING_INTERFACE_VERSION;
+}
+
+function structurallyValidTrackingEvent(event: SupplierTrackingEvent): boolean {
+  return Boolean(
+    event
+      && typeof event.supplierOrderRef === 'string'
+      && event.supplierOrderRef.trim()
+      && typeof event.status === 'string'
+      && event.status.trim()
+      && typeof event.occurredAt === 'string'
+      && !Number.isNaN(Date.parse(event.occurredAt)),
+  );
+}
+
+/**
+ * Phase K provider-neutral tracking poll/ingest.
+ * Supplier/carrier statuses are never trusted as canonical state directly;
+ * the database applies an approved versioned mapping under tracking_ingest control.
+ */
+export async function syncSupplierTracking(
+  client: SupabaseClient,
+  adapter: SupplierAdapterV1,
+  handshakeId: string,
+): Promise<SupplierTrackingSyncResult> {
+  const startedAt = new Date().toISOString();
+  const { data: rawContext, error: contextError } = await client.rpc('server_supplier_tracking_context_v1', {
+    p_handshake_id: handshakeId,
+  });
+  if (contextError || !isTrackingContext(rawContext)) {
+    const reason = rawContext && typeof rawContext === 'object' && typeof (rawContext as { reason?: unknown }).reason === 'string'
+      ? String((rawContext as { reason: string }).reason)
+      : 'supplier_tracking_context_unavailable';
+    return { ok: false, ingested: 0, reason };
+  }
+  const context = rawContext;
+
+  if (
+    adapter.interfaceVersion !== SUPPLIER_TRACKING_INTERFACE_VERSION
+    || adapter.providerKey !== context.providerKey
+    || adapter.adapterVersion !== context.adapterVersion
+    || !adapterSupports(adapter, 'tracking')
+    || !adapter.getTracking
+  ) {
+    return { ok: false, ingested: 0, reason: 'tracking_adapter_identity_or_capability_mismatch' };
+  }
+
+  const adapterContext: SupplierAdapterContext = {
+    correlationId: context.correlationId,
+    idempotencyKey: `tracking:${context.handshakeId}`,
+    supplierKey: context.supplierKey,
+    territory: 'GB',
+  };
+
+  let events: SupplierTrackingEvent[];
+  try {
+    const result = await adapter.getTracking(adapterContext, context.supplierOrderRef);
+    if (!result.ok) {
+      await recordSupplierCommerceOperation(client, {
+        correlationId: context.correlationId,
+        requestId: `tracking:${context.handshakeId}`,
+        operation: 'tracking_ingest',
+        providerRef: adapter.providerKey,
+        supplierRef: context.supplierKey,
+        entityType: 'supplier_order_handshake',
+        entityRef: context.handshakeId,
+        resultClass: result.errorClass === 'AUTH_CONFIGURATION_FAILURE' ? 'AUTH_CONFIGURATION_FAILURE'
+          : result.errorClass === 'RATE_LIMITED' ? 'RATE_LIMITED'
+            : result.errorClass === 'PERMANENT_REJECTION' ? 'PERMANENT_REJECTION'
+              : result.errorClass === 'CAPABILITY_UNAVAILABLE' ? 'MANUAL_REVIEW_REQUIRED'
+                : 'RETRYABLE_FAILURE',
+        errorClass: result.errorClass,
+        recoveryState: 'tracking_exception_review',
+        externalRef: result.externalRef,
+        customerImpact: 'tracking_update_unavailable',
+        financialImpact: 'delivery_exception_risk',
+        startedAt,
+        finishedAt: new Date().toISOString(),
+      });
+      return { ok: false, ingested: 0, reason: result.errorClass };
+    }
+    events = result.data;
+  } catch {
+    return { ok: false, ingested: 0, reason: 'tracking_provider_call_failed' };
+  }
+
+  let ingested = 0;
+  let blocked = 0;
+  for (const event of events) {
+    if (!structurallyValidTrackingEvent(event) || event.supplierOrderRef !== context.supplierOrderRef) {
+      blocked += 1;
+      continue;
+    }
+    const { data, error } = await client.rpc('server_ingest_supplier_tracking_event_v1', {
+      p_handshake_id: context.handshakeId,
+      p_provider_status: event.status,
+      p_carrier_ref: event.carrierRef ?? null,
+      p_tracking_ref: event.trackingRef ?? null,
+      p_provider_event_ref: null,
+      p_occurred_at: event.occurredAt,
+      p_raw_evidence: {
+        supplierOrderRef: event.supplierOrderRef,
+        carrierRef: event.carrierRef ?? null,
+        trackingRef: event.trackingRef ?? null,
+        providerStatus: event.status,
+        occurredAt: event.occurredAt,
+      },
+    });
+    if (error || !data || typeof data !== 'object' || (data as { ok?: unknown }).ok !== true) blocked += 1;
+    else ingested += 1;
+  }
+
+  await client.rpc('server_detect_supplier_tracking_exceptions_v1', {
+    p_now: new Date().toISOString(),
+    p_no_tracking_after_minutes: 120,
+    p_dispatch_delay_minutes: 60,
+  });
+
+  return { ok: blocked === 0, ingested, blocked };
+}

--- a/netlify/functions/admin-supplier-tracking.ts
+++ b/netlify/functions/admin-supplier-tracking.ts
@@ -1,0 +1,84 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { jsonResponse, optionsResponse } from './_shared/http';
+
+const METHODS = 'POST, OPTIONS';
+
+type AdminAction =
+  | { action: 'status'; orderId?: string }
+  | { action: 'approve_mapping'; providerKey: string; providerStatus: string; canonicalStatus: string; evidence: Record<string, unknown>; effectiveFrom?: string }
+  | { action: 'transition_exception'; exceptionId: string; state: string; ownerType: string; nextAction: string; reason: string; resolution?: string; metadata?: Record<string, unknown> };
+
+const text = (value: unknown) => typeof value === 'string' ? value.trim() : '';
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return optionsResponse(METHODS);
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' }, METHODS);
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) return jsonResponse(500, { error: 'Server configuration error' }, METHODS);
+
+  const admin = createClient(supabaseUrl, serviceRoleKey, { auth: { autoRefreshToken: false, persistSession: false } });
+  const auth = await authenticateActiveAccount(event, admin, ['admin']);
+  if (!auth.ok) return jsonResponse(auth.status, { error: 'Unauthorized' }, METHODS);
+
+  let body: AdminAction;
+  try { body = JSON.parse(event.body || '{}') as AdminAction; }
+  catch { return jsonResponse(400, { error: 'Invalid JSON body' }, METHODS); }
+  if (!body || typeof body !== 'object' || !('action' in body)) return jsonResponse(400, { error: 'Unsupported Phase K admin action' }, METHODS);
+
+  if (body.action === 'status') {
+    const orderId = body.orderId === undefined ? null : text(body.orderId);
+    if (body.orderId !== undefined && !orderId) return jsonResponse(400, { error: 'orderId must be non-empty when supplied' }, METHODS);
+    const { data, error } = await admin.rpc('server_admin_supplier_tracking_status_v1', {
+      p_actor_id: auth.actor.id,
+      p_order_id: orderId,
+    });
+    if (error) return jsonResponse(500, { error: 'Unable to read supplier tracking status' }, METHODS);
+    return jsonResponse(200, { ok: true, result: data }, METHODS);
+  }
+
+  if (body.action === 'approve_mapping') {
+    const providerKey = text(body.providerKey);
+    const providerStatus = text(body.providerStatus);
+    const canonicalStatus = text(body.canonicalStatus);
+    if (!providerKey || !providerStatus || !canonicalStatus || !body.evidence || typeof body.evidence !== 'object' || Array.isArray(body.evidence)) {
+      return jsonResponse(400, { error: 'Complete tracking mapping evidence is required' }, METHODS);
+    }
+    const { data, error } = await admin.rpc('server_admin_approve_supplier_tracking_mapping_v1', {
+      p_actor_id: auth.actor.id,
+      p_provider_key: providerKey,
+      p_provider_status: providerStatus,
+      p_canonical_status: canonicalStatus,
+      p_evidence: body.evidence,
+      p_effective_from: body.effectiveFrom ? text(body.effectiveFrom) : new Date().toISOString(),
+    });
+    if (error) return jsonResponse(400, { error: 'Unable to approve supplier tracking mapping' }, METHODS);
+    return jsonResponse(200, { ok: true, mappingId: data }, METHODS);
+  }
+
+  if (body.action === 'transition_exception') {
+    const exceptionId = text(body.exceptionId);
+    const state = text(body.state);
+    const ownerType = text(body.ownerType);
+    const nextAction = text(body.nextAction);
+    const reason = text(body.reason);
+    if (!exceptionId || !state || !ownerType || !nextAction || !reason) return jsonResponse(400, { error: 'Incomplete exception transition' }, METHODS);
+    const { data, error } = await admin.rpc('server_transition_supplier_order_exception_v1', {
+      p_actor_id: auth.actor.id,
+      p_exception_id: exceptionId,
+      p_state: state,
+      p_owner_type: ownerType,
+      p_next_action: nextAction,
+      p_reason: reason,
+      p_resolution: body.resolution ? text(body.resolution) : null,
+      p_metadata: body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata) ? body.metadata : {},
+    });
+    if (error) return jsonResponse(400, { error: 'Unable to transition supplier exception' }, METHODS);
+    return jsonResponse(200, { ok: true, result: data }, METHODS);
+  }
+
+  return jsonResponse(400, { error: 'Unsupported Phase K admin action' }, METHODS);
+};

--- a/supabase/644_supplier_tracking_exception_foundation.sql
+++ b/supabase/644_supplier_tracking_exception_foundation.sql
@@ -1,0 +1,161 @@
+-- 644_supplier_tracking_exception_foundation.sql
+-- Phase K — provider-neutral tracking normalisation + operational exception foundation.
+-- Buyer remains on ONE public customer order. Internal shipment legs are not a parallel order system.
+-- Supplier Commerce remains fail-closed; this migration enables no control.
+
+CREATE TABLE IF NOT EXISTS private.supplier_tracking_status_mappings (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  provider_key text NOT NULL,
+  provider_status text NOT NULL,
+  canonical_status text NOT NULL,
+  version integer NOT NULL CHECK (version > 0),
+  status text NOT NULL DEFAULT 'draft',
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  approved_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  approved_at timestamptz,
+  effective_from timestamptz NOT NULL DEFAULT now(),
+  effective_to timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_tracking_mapping_identity_unique UNIQUE(provider_key, provider_status, version),
+  CONSTRAINT supplier_tracking_mapping_provider_check CHECK (NULLIF(BTRIM(provider_key),'') IS NOT NULL),
+  CONSTRAINT supplier_tracking_mapping_source_status_check CHECK (NULLIF(BTRIM(provider_status),'') IS NOT NULL),
+  CONSTRAINT supplier_tracking_mapping_status_check CHECK (canonical_status IN (
+    'pending','accepted','dispatched','in_transit','exception','out_for_delivery','delivered','failed_delivery','returned'
+  )),
+  CONSTRAINT supplier_tracking_mapping_lifecycle_check CHECK (status IN ('draft','approved','retired')),
+  CONSTRAINT supplier_tracking_mapping_evidence_check CHECK (jsonb_typeof(evidence)='object'),
+  CONSTRAINT supplier_tracking_mapping_approval_check CHECK (
+    status <> 'approved' OR (approved_by IS NOT NULL AND approved_at IS NOT NULL AND evidence <> '{}'::jsonb)
+  ),
+  CONSTRAINT supplier_tracking_mapping_effective_check CHECK (effective_to IS NULL OR effective_to > effective_from)
+);
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_tracking_mapping_one_active_idx
+  ON private.supplier_tracking_status_mappings(provider_key, lower(provider_status))
+  WHERE status='approved' AND effective_to IS NULL;
+
+CREATE TABLE IF NOT EXISTS private.supplier_leg_shipments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id uuid NOT NULL REFERENCES public.orders(id) ON DELETE RESTRICT,
+  orchestration_id uuid NOT NULL REFERENCES private.supplier_order_orchestrations(id) ON DELETE RESTRICT,
+  fulfilment_leg_id uuid NOT NULL UNIQUE REFERENCES private.supplier_fulfilment_legs(id) ON DELETE RESTRICT,
+  handshake_id uuid NOT NULL UNIQUE REFERENCES private.supplier_order_handshakes(id) ON DELETE RESTRICT,
+  supplier_id uuid NOT NULL REFERENCES private.supplier_foundation_suppliers(id) ON DELETE RESTRICT,
+  provider_key text NOT NULL,
+  external_supplier_order_ref text NOT NULL,
+  carrier_ref text,
+  tracking_ref text,
+  canonical_status text NOT NULL DEFAULT 'accepted',
+  dispatch_due_at timestamptz,
+  dispatched_at timestamptz,
+  delivered_at timestamptz,
+  last_event_at timestamptz,
+  last_ingested_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_leg_shipment_provider_check CHECK (NULLIF(BTRIM(provider_key),'') IS NOT NULL),
+  CONSTRAINT supplier_leg_shipment_order_ref_check CHECK (NULLIF(BTRIM(external_supplier_order_ref),'') IS NOT NULL),
+  CONSTRAINT supplier_leg_shipment_status_check CHECK (canonical_status IN (
+    'pending','accepted','dispatched','in_transit','exception','out_for_delivery','delivered','failed_delivery','returned'
+  ))
+);
+CREATE INDEX IF NOT EXISTS supplier_leg_shipment_order_idx ON private.supplier_leg_shipments(order_id, created_at);
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_leg_shipment_provider_tracking_unique
+  ON private.supplier_leg_shipments(provider_key, tracking_ref)
+  WHERE tracking_ref IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS private.supplier_tracking_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  shipment_id uuid NOT NULL REFERENCES private.supplier_leg_shipments(id) ON DELETE RESTRICT,
+  provider_key text NOT NULL,
+  provider_status text NOT NULL,
+  canonical_status text NOT NULL,
+  mapping_id uuid NOT NULL REFERENCES private.supplier_tracking_status_mappings(id) ON DELETE RESTRICT,
+  carrier_ref text,
+  tracking_ref text,
+  provider_event_ref text,
+  event_fingerprint text NOT NULL UNIQUE,
+  occurred_at timestamptz NOT NULL,
+  ingested_at timestamptz NOT NULL DEFAULT now(),
+  raw_evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT supplier_tracking_event_provider_check CHECK (NULLIF(BTRIM(provider_key),'') IS NOT NULL),
+  CONSTRAINT supplier_tracking_event_provider_status_check CHECK (NULLIF(BTRIM(provider_status),'') IS NOT NULL),
+  CONSTRAINT supplier_tracking_event_status_check CHECK (canonical_status IN (
+    'pending','accepted','dispatched','in_transit','exception','out_for_delivery','delivered','failed_delivery','returned'
+  )),
+  CONSTRAINT supplier_tracking_event_fingerprint_check CHECK (NULLIF(BTRIM(event_fingerprint),'') IS NOT NULL),
+  CONSTRAINT supplier_tracking_event_evidence_check CHECK (jsonb_typeof(raw_evidence)='object')
+);
+CREATE INDEX IF NOT EXISTS supplier_tracking_event_timeline_idx
+  ON private.supplier_tracking_events(shipment_id, occurred_at, ingested_at);
+
+CREATE TABLE IF NOT EXISTS private.supplier_order_exceptions (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id uuid NOT NULL REFERENCES public.orders(id) ON DELETE RESTRICT,
+  orchestration_id uuid NOT NULL REFERENCES private.supplier_order_orchestrations(id) ON DELETE RESTRICT,
+  fulfilment_leg_id uuid REFERENCES private.supplier_fulfilment_legs(id) ON DELETE RESTRICT,
+  handshake_id uuid REFERENCES private.supplier_order_handshakes(id) ON DELETE RESTRICT,
+  shipment_id uuid REFERENCES private.supplier_leg_shipments(id) ON DELETE RESTRICT,
+  exception_key text NOT NULL UNIQUE,
+  exception_type text NOT NULL,
+  state text NOT NULL DEFAULT 'open',
+  owner_type text NOT NULL,
+  next_action text NOT NULL,
+  customer_impact text NOT NULL,
+  financial_impact text NOT NULL,
+  resolution text,
+  source_event_id uuid REFERENCES private.supplier_tracking_events(id) ON DELETE RESTRICT,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  opened_at timestamptz NOT NULL DEFAULT now(),
+  resolved_at timestamptz,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_order_exception_key_check CHECK (NULLIF(BTRIM(exception_key),'') IS NOT NULL),
+  CONSTRAINT supplier_order_exception_type_check CHECK (exception_type IN (
+    'supplier_timeout','accepted_response_lost','duplicate_submit','duplicate_acknowledgement','stock_disappeared','price_changed',
+    'api_unavailable','partial_fulfilment','partial_shipment','delayed_dispatch','no_tracking','lost_shipment',
+    'supplier_cancellation','buyer_cancellation','supplier_suspended_mid_order','tracking_exception','failed_delivery'
+  )),
+  CONSTRAINT supplier_order_exception_state_check CHECK (state IN ('open','investigating','waiting_supplier','waiting_carrier','waiting_customer','resolved','closed')),
+  CONSTRAINT supplier_order_exception_owner_check CHECK (owner_type IN ('loadify_ops','supplier','carrier','customer','finance','risk')),
+  CONSTRAINT supplier_order_exception_action_check CHECK (NULLIF(BTRIM(next_action),'') IS NOT NULL),
+  CONSTRAINT supplier_order_exception_customer_impact_check CHECK (NULLIF(BTRIM(customer_impact),'') IS NOT NULL),
+  CONSTRAINT supplier_order_exception_financial_impact_check CHECK (NULLIF(BTRIM(financial_impact),'') IS NOT NULL),
+  CONSTRAINT supplier_order_exception_metadata_check CHECK (jsonb_typeof(metadata)='object'),
+  CONSTRAINT supplier_order_exception_resolution_check CHECK (
+    (state IN ('resolved','closed') AND resolution IS NOT NULL AND resolved_at IS NOT NULL)
+    OR (state NOT IN ('resolved','closed') AND resolved_at IS NULL)
+  )
+);
+CREATE INDEX IF NOT EXISTS supplier_order_exception_open_idx
+  ON private.supplier_order_exceptions(state, exception_type, updated_at);
+CREATE INDEX IF NOT EXISTS supplier_order_exception_order_idx
+  ON private.supplier_order_exceptions(order_id, opened_at DESC);
+
+CREATE TABLE IF NOT EXISTS private.supplier_order_exception_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  exception_id uuid NOT NULL REFERENCES private.supplier_order_exceptions(id) ON DELETE RESTRICT,
+  event_key text NOT NULL UNIQUE,
+  previous_state text,
+  new_state text NOT NULL,
+  owner_type text NOT NULL,
+  next_action text NOT NULL,
+  reason text NOT NULL,
+  actor_id uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  metadata jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_order_exception_event_key_check CHECK (NULLIF(BTRIM(event_key),'') IS NOT NULL),
+  CONSTRAINT supplier_order_exception_event_state_check CHECK (new_state IN ('open','investigating','waiting_supplier','waiting_carrier','waiting_customer','resolved','closed')),
+  CONSTRAINT supplier_order_exception_event_owner_check CHECK (owner_type IN ('loadify_ops','supplier','carrier','customer','finance','risk')),
+  CONSTRAINT supplier_order_exception_event_action_check CHECK (NULLIF(BTRIM(next_action),'') IS NOT NULL),
+  CONSTRAINT supplier_order_exception_event_reason_check CHECK (NULLIF(BTRIM(reason),'') IS NOT NULL),
+  CONSTRAINT supplier_order_exception_event_metadata_check CHECK (jsonb_typeof(metadata)='object')
+);
+
+REVOKE ALL ON TABLE private.supplier_tracking_status_mappings FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_leg_shipments FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_tracking_events FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_order_exceptions FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_order_exception_events FROM PUBLIC, anon, authenticated, service_role;
+
+COMMENT ON TABLE private.supplier_leg_shipments IS 'Phase K internal shipment truth per fulfilment leg. Buyer still sees one canonical customer order.';
+COMMENT ON TABLE private.supplier_tracking_events IS 'Append-only provider/carrier tracking evidence normalised into canonical Loadify shipment states.';
+COMMENT ON TABLE private.supplier_order_exceptions IS 'Phase K operational exceptions: every record carries state, owner, next action, customer impact, financial impact and resolution.';

--- a/supabase/645_supplier_tracking_runtime_guards.sql
+++ b/supabase/645_supplier_tracking_runtime_guards.sql
@@ -1,0 +1,166 @@
+-- 645_supplier_tracking_runtime_guards.sql
+-- Phase K runtime: fail-closed tracking ingestion, mapping, idempotency and shipment progression.
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_tracking_event_immutable_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  RAISE EXCEPTION 'supplier tracking events are append-only';
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_tracking_event_immutable_v1 ON private.supplier_tracking_events;
+CREATE TRIGGER trg_guard_supplier_tracking_event_immutable_v1
+BEFORE UPDATE OR DELETE ON private.supplier_tracking_events
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_tracking_event_immutable_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_order_exception_event_immutable_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  RAISE EXCEPTION 'supplier order exception events are append-only';
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_order_exception_event_immutable_v1 ON private.supplier_order_exception_events;
+CREATE TRIGGER trg_guard_supplier_order_exception_event_immutable_v1
+BEFORE UPDATE OR DELETE ON private.supplier_order_exception_events
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_order_exception_event_immutable_v1();
+
+CREATE OR REPLACE FUNCTION public.server_supplier_tracking_context_v1(p_handshake_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_h private.supplier_order_handshakes%ROWTYPE;
+  v_s private.supplier_foundation_suppliers%ROWTYPE;
+  v_adapter private.supplier_adapter_registrations%ROWTYPE;
+BEGIN
+  SELECT * INTO v_h FROM private.supplier_order_handshakes WHERE id=p_handshake_id;
+  IF NOT FOUND OR v_h.state<>'reconciled' OR v_h.acknowledgement_state<>'accepted' OR v_h.external_supplier_order_ref IS NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','supplier_order_not_reconciled','interfaceVersion',1);
+  END IF;
+  SELECT * INTO v_s FROM private.supplier_foundation_suppliers WHERE id=v_h.supplier_id AND lifecycle_status='approved';
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','supplier_not_approved','interfaceVersion',1); END IF;
+  SELECT * INTO v_adapter FROM private.supplier_adapter_registrations a
+   WHERE a.supplier_id=v_h.supplier_id AND a.status='active' AND a.interface_version=1
+     AND a.capabilities @> ARRAY['tracking']::text[]
+   ORDER BY a.verified_at DESC LIMIT 1;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','tracking_adapter_not_ready','interfaceVersion',1); END IF;
+  RETURN jsonb_build_object(
+    'eligible',true,'reason','supplier_tracking_ready','handshakeId',v_h.id,'orderId',v_h.order_id,
+    'orchestrationId',v_h.orchestration_id,'fulfilmentLegId',v_h.fulfilment_leg_id,'supplierId',v_h.supplier_id,
+    'supplierKey',v_s.supplier_key,'providerKey',v_adapter.provider_key,'adapterVersion',v_adapter.adapter_version,
+    'supplierOrderRef',v_h.external_supplier_order_ref,'correlationId',v_h.correlation_id,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_supplier_tracking_context_v1(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_tracking_context_v1(uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_ingest_supplier_tracking_event_v1(
+  p_handshake_id uuid,
+  p_provider_status text,
+  p_carrier_ref text,
+  p_tracking_ref text,
+  p_provider_event_ref text,
+  p_occurred_at timestamptz,
+  p_raw_evidence jsonb
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_h private.supplier_order_handshakes%ROWTYPE;
+  v_leg private.supplier_fulfilment_legs%ROWTYPE;
+  v_mapping private.supplier_tracking_status_mappings%ROWTYPE;
+  v_ship private.supplier_leg_shipments%ROWTYPE;
+  v_event private.supplier_tracking_events%ROWTYPE;
+  v_control jsonb;
+  v_status text;
+  v_fingerprint text;
+  v_progress integer;
+  v_current_progress integer;
+BEGIN
+  IF NULLIF(BTRIM(p_provider_status),'') IS NULL OR p_occurred_at IS NULL OR jsonb_typeof(COALESCE(p_raw_evidence,'{}'::jsonb))<>'object' THEN
+    RAISE EXCEPTION 'valid provider status, occurred_at and object evidence are required';
+  END IF;
+
+  SELECT * INTO v_h FROM private.supplier_order_handshakes WHERE id=p_handshake_id FOR UPDATE;
+  IF NOT FOUND OR v_h.state<>'reconciled' OR v_h.acknowledgement_state<>'accepted' OR v_h.external_supplier_order_ref IS NULL THEN
+    RETURN jsonb_build_object('ok',false,'reason','supplier_order_not_reconciled','interfaceVersion',1);
+  END IF;
+
+  v_control:=public.server_supplier_commerce_control_decision_v1('tracking_ingest',jsonb_build_object(
+    'supplierRef',v_h.supplier_id::text,'offerRef',v_h.supplier_offer_id::text,'productRef',NULL,'territory',NULL
+  ));
+  IF COALESCE((v_control->>'enabled')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('ok',false,'reason','tracking_ingest_control_disabled','control',v_control,'interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_mapping FROM private.supplier_tracking_status_mappings m
+   WHERE m.provider_key=v_h.provider_key AND lower(m.provider_status)=lower(BTRIM(p_provider_status))
+     AND m.status='approved' AND m.effective_from<=p_occurred_at
+     AND (m.effective_to IS NULL OR m.effective_to>p_occurred_at)
+   ORDER BY m.version DESC LIMIT 1;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok',false,'reason','tracking_status_mapping_missing','providerStatus',p_provider_status,'interfaceVersion',1);
+  END IF;
+  v_status:=v_mapping.canonical_status;
+
+  SELECT * INTO v_leg FROM private.supplier_fulfilment_legs WHERE id=v_h.fulfilment_leg_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','fulfilment_leg_missing','interfaceVersion',1); END IF;
+
+  INSERT INTO private.supplier_leg_shipments(
+    order_id,orchestration_id,fulfilment_leg_id,handshake_id,supplier_id,provider_key,external_supplier_order_ref,
+    carrier_ref,tracking_ref,canonical_status,last_event_at,last_ingested_at
+  ) VALUES(
+    v_h.order_id,v_h.orchestration_id,v_h.fulfilment_leg_id,v_h.id,v_h.supplier_id,v_h.provider_key,v_h.external_supplier_order_ref,
+    NULLIF(BTRIM(p_carrier_ref),''),NULLIF(BTRIM(p_tracking_ref),''),'accepted',p_occurred_at,now()
+  ) ON CONFLICT(fulfilment_leg_id) DO NOTHING;
+  SELECT * INTO v_ship FROM private.supplier_leg_shipments WHERE fulfilment_leg_id=v_h.fulfilment_leg_id FOR UPDATE;
+
+  IF v_ship.provider_key<>v_h.provider_key OR v_ship.external_supplier_order_ref<>v_h.external_supplier_order_ref THEN
+    RAISE EXCEPTION 'supplier tracking shipment identity mismatch';
+  END IF;
+  IF v_ship.tracking_ref IS NOT NULL AND NULLIF(BTRIM(p_tracking_ref),'') IS NOT NULL AND v_ship.tracking_ref<>BTRIM(p_tracking_ref) THEN
+    RAISE EXCEPTION 'tracking reference cannot change once established';
+  END IF;
+
+  v_fingerprint:=md5(concat_ws('|',v_h.id::text,lower(BTRIM(p_provider_status)),COALESCE(BTRIM(p_carrier_ref),''),
+    COALESCE(BTRIM(p_tracking_ref),''),COALESCE(BTRIM(p_provider_event_ref),''),p_occurred_at::text));
+
+  INSERT INTO private.supplier_tracking_events(
+    shipment_id,provider_key,provider_status,canonical_status,mapping_id,carrier_ref,tracking_ref,provider_event_ref,
+    event_fingerprint,occurred_at,raw_evidence
+  ) VALUES(
+    v_ship.id,v_h.provider_key,BTRIM(p_provider_status),v_status,v_mapping.id,NULLIF(BTRIM(p_carrier_ref),''),
+    NULLIF(BTRIM(p_tracking_ref),''),NULLIF(BTRIM(p_provider_event_ref),''),v_fingerprint,p_occurred_at,COALESCE(p_raw_evidence,'{}'::jsonb)
+  ) ON CONFLICT(event_fingerprint) DO NOTHING RETURNING * INTO v_event;
+
+  IF v_event.id IS NULL THEN
+    SELECT * INTO v_event FROM private.supplier_tracking_events WHERE event_fingerprint=v_fingerprint;
+    RETURN jsonb_build_object('ok',true,'reason','tracking_event_replayed','shipmentId',v_ship.id,'eventId',v_event.id,
+      'canonicalStatus',v_event.canonical_status,'interfaceVersion',1);
+  END IF;
+
+  v_progress:=CASE v_status
+    WHEN 'pending' THEN 0 WHEN 'accepted' THEN 1 WHEN 'dispatched' THEN 2 WHEN 'in_transit' THEN 3
+    WHEN 'out_for_delivery' THEN 4 WHEN 'delivered' THEN 5 WHEN 'returned' THEN 6 ELSE -1 END;
+  v_current_progress:=CASE v_ship.canonical_status
+    WHEN 'pending' THEN 0 WHEN 'accepted' THEN 1 WHEN 'dispatched' THEN 2 WHEN 'in_transit' THEN 3
+    WHEN 'out_for_delivery' THEN 4 WHEN 'delivered' THEN 5 WHEN 'returned' THEN 6 ELSE -1 END;
+
+  IF v_status IN ('exception','failed_delivery') OR v_progress>=v_current_progress THEN
+    UPDATE private.supplier_leg_shipments SET
+      carrier_ref=COALESCE(carrier_ref,NULLIF(BTRIM(p_carrier_ref),'')),
+      tracking_ref=COALESCE(tracking_ref,NULLIF(BTRIM(p_tracking_ref),'')),
+      canonical_status=v_status,
+      dispatched_at=CASE WHEN v_status IN ('dispatched','in_transit','out_for_delivery','delivered') THEN COALESCE(dispatched_at,p_occurred_at) ELSE dispatched_at END,
+      delivered_at=CASE WHEN v_status='delivered' THEN COALESCE(delivered_at,p_occurred_at) ELSE delivered_at END,
+      last_event_at=GREATEST(COALESCE(last_event_at,p_occurred_at),p_occurred_at),last_ingested_at=now(),updated_at=now()
+    WHERE id=v_ship.id RETURNING * INTO v_ship;
+  ELSE
+    UPDATE private.supplier_leg_shipments SET last_ingested_at=now(),updated_at=now() WHERE id=v_ship.id RETURNING * INTO v_ship;
+  END IF;
+
+  RETURN jsonb_build_object('ok',true,'reason','tracking_event_ingested','shipmentId',v_ship.id,'eventId',v_event.id,
+    'canonicalStatus',v_status,'mappingVersion',v_mapping.version,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_ingest_supplier_tracking_event_v1(uuid,text,text,text,text,timestamptz,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_ingest_supplier_tracking_event_v1(uuid,text,text,text,text,timestamptz,jsonb) TO service_role;
+
+COMMENT ON FUNCTION public.server_ingest_supplier_tracking_event_v1(uuid,text,text,text,text,timestamptz,jsonb) IS 'Phase K provider-neutral tracking ingestion. Requires approved mapping + tracking_ingest control and preserves append-only raw evidence.';

--- a/supabase/646_supplier_exception_engine.sql
+++ b/supabase/646_supplier_exception_engine.sql
@@ -1,0 +1,180 @@
+-- 646_supplier_exception_engine.sql
+-- Phase K exception engine: open/advance/resolve operational exceptions with complete ownership/impact truth.
+-- Returns/refunds/recovery money movement remains Phase L.
+
+CREATE OR REPLACE FUNCTION public.server_open_supplier_order_exception_v1(
+  p_order_id uuid,
+  p_orchestration_id uuid,
+  p_fulfilment_leg_id uuid,
+  p_handshake_id uuid,
+  p_shipment_id uuid,
+  p_exception_key text,
+  p_exception_type text,
+  p_owner_type text,
+  p_next_action text,
+  p_customer_impact text,
+  p_financial_impact text,
+  p_source_event_id uuid,
+  p_metadata jsonb
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_e private.supplier_order_exceptions%ROWTYPE;
+BEGIN
+  IF NULLIF(BTRIM(p_exception_key),'') IS NULL OR NULLIF(BTRIM(p_next_action),'') IS NULL
+     OR NULLIF(BTRIM(p_customer_impact),'') IS NULL OR NULLIF(BTRIM(p_financial_impact),'') IS NULL THEN
+    RAISE EXCEPTION 'exception key, next action and customer/financial impact are required';
+  END IF;
+  IF p_exception_type NOT IN (
+    'supplier_timeout','accepted_response_lost','duplicate_submit','duplicate_acknowledgement','stock_disappeared','price_changed',
+    'api_unavailable','partial_fulfilment','partial_shipment','delayed_dispatch','no_tracking','lost_shipment',
+    'supplier_cancellation','buyer_cancellation','supplier_suspended_mid_order','tracking_exception','failed_delivery'
+  ) THEN RAISE EXCEPTION 'invalid supplier order exception type'; END IF;
+  IF p_owner_type NOT IN ('loadify_ops','supplier','carrier','customer','finance','risk') THEN RAISE EXCEPTION 'invalid exception owner'; END IF;
+
+  INSERT INTO private.supplier_order_exceptions(
+    order_id,orchestration_id,fulfilment_leg_id,handshake_id,shipment_id,exception_key,exception_type,state,owner_type,
+    next_action,customer_impact,financial_impact,source_event_id,metadata
+  ) VALUES(
+    p_order_id,p_orchestration_id,p_fulfilment_leg_id,p_handshake_id,p_shipment_id,BTRIM(p_exception_key),p_exception_type,
+    'open',p_owner_type,BTRIM(p_next_action),BTRIM(p_customer_impact),BTRIM(p_financial_impact),p_source_event_id,COALESCE(p_metadata,'{}'::jsonb)
+  ) ON CONFLICT(exception_key) DO NOTHING;
+  SELECT * INTO v_e FROM private.supplier_order_exceptions WHERE exception_key=BTRIM(p_exception_key) FOR UPDATE;
+
+  INSERT INTO private.supplier_order_exception_events(exception_id,event_key,new_state,owner_type,next_action,reason,metadata)
+  VALUES(v_e.id,'opened:'||v_e.id::text,'open',v_e.owner_type,v_e.next_action,'exception_opened',v_e.metadata)
+  ON CONFLICT(event_key) DO NOTHING;
+
+  RETURN jsonb_build_object('ok',true,'exceptionId',v_e.id,'state',v_e.state,'owner',v_e.owner_type,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_open_supplier_order_exception_v1(uuid,uuid,uuid,uuid,uuid,text,text,text,text,text,text,uuid,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_open_supplier_order_exception_v1(uuid,uuid,uuid,uuid,uuid,text,text,text,text,text,text,uuid,jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_transition_supplier_order_exception_v1(
+  p_actor_id uuid,
+  p_exception_id uuid,
+  p_state text,
+  p_owner_type text,
+  p_next_action text,
+  p_reason text,
+  p_resolution text,
+  p_metadata jsonb
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_e private.supplier_order_exceptions%ROWTYPE;
+  v_previous text;
+  v_actor_active boolean;
+  v_actor_role text;
+BEGIN
+  SELECT u."isActive",u.role INTO v_actor_active,v_actor_role FROM public.users u WHERE u.id=p_actor_id;
+  IF v_actor_active IS DISTINCT FROM true OR v_actor_role<>'admin' THEN
+    RAISE EXCEPTION 'active admin authority is required' USING ERRCODE='42501';
+  END IF;
+  IF p_state NOT IN ('open','investigating','waiting_supplier','waiting_carrier','waiting_customer','resolved','closed') THEN
+    RAISE EXCEPTION 'invalid exception state';
+  END IF;
+  IF p_owner_type NOT IN ('loadify_ops','supplier','carrier','customer','finance','risk') THEN RAISE EXCEPTION 'invalid exception owner'; END IF;
+  IF NULLIF(BTRIM(p_next_action),'') IS NULL OR NULLIF(BTRIM(p_reason),'') IS NULL THEN RAISE EXCEPTION 'next action and reason are required'; END IF;
+  IF p_state IN ('resolved','closed') AND NULLIF(BTRIM(p_resolution),'') IS NULL THEN RAISE EXCEPTION 'terminal exception requires resolution'; END IF;
+
+  SELECT * INTO v_e FROM private.supplier_order_exceptions WHERE id=p_exception_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','exception_not_found','interfaceVersion',1); END IF;
+  IF v_e.state='closed' AND p_state<>'closed' THEN RAISE EXCEPTION 'closed exception cannot regress'; END IF;
+  v_previous:=v_e.state;
+
+  UPDATE private.supplier_order_exceptions SET
+    state=p_state,owner_type=p_owner_type,next_action=BTRIM(p_next_action),
+    resolution=CASE WHEN p_state IN ('resolved','closed') THEN BTRIM(p_resolution) ELSE NULL END,
+    resolved_at=CASE WHEN p_state IN ('resolved','closed') THEN COALESCE(resolved_at,now()) ELSE NULL END,
+    metadata=COALESCE(p_metadata,metadata),updated_at=now()
+  WHERE id=v_e.id RETURNING * INTO v_e;
+
+  INSERT INTO private.supplier_order_exception_events(
+    exception_id,event_key,previous_state,new_state,owner_type,next_action,reason,actor_id,metadata
+  ) VALUES(
+    v_e.id,'transition:'||v_e.id::text||':'||extract(epoch from clock_timestamp())::bigint::text,v_previous,v_e.state,v_e.owner_type,
+    v_e.next_action,BTRIM(p_reason),p_actor_id,COALESCE(p_metadata,'{}'::jsonb)
+  );
+  RETURN jsonb_build_object('ok',true,'exceptionId',v_e.id,'state',v_e.state,'owner',v_e.owner_type,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_transition_supplier_order_exception_v1(uuid,uuid,text,text,text,text,text,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_transition_supplier_order_exception_v1(uuid,uuid,text,text,text,text,text,jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_detect_supplier_tracking_exceptions_v1(
+  p_now timestamptz DEFAULT now(),
+  p_no_tracking_after_minutes integer DEFAULT 120,
+  p_dispatch_delay_minutes integer DEFAULT 60
+)
+RETURNS integer LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_count integer:=0; v_inserted integer:=0;
+BEGIN
+  IF p_no_tracking_after_minutes<15 OR p_dispatch_delay_minutes<15 THEN RAISE EXCEPTION 'tracking exception thresholds must be at least 15 minutes'; END IF;
+
+  INSERT INTO private.supplier_order_exceptions(
+    order_id,orchestration_id,fulfilment_leg_id,handshake_id,shipment_id,exception_key,exception_type,state,owner_type,
+    next_action,customer_impact,financial_impact,metadata
+  )
+  SELECT h.order_id,h.orchestration_id,h.fulfilment_leg_id,h.id,s.id,
+    'no-tracking:'||h.id::text,'no_tracking','open','supplier','obtain trustworthy carrier tracking evidence',
+    'buyer cannot see shipment progress','delivery promise at risk',jsonb_build_object('detectedAt',p_now)
+  FROM private.supplier_order_handshakes h
+  LEFT JOIN private.supplier_leg_shipments s ON s.handshake_id=h.id
+  WHERE h.state='reconciled' AND h.acknowledgement_state='accepted'
+    AND COALESCE(s.tracking_ref,'')=''
+    AND h.reconciled_at + make_interval(mins=>p_no_tracking_after_minutes)<=p_now
+  ON CONFLICT(exception_key) DO NOTHING;
+  GET DIAGNOSTICS v_inserted=ROW_COUNT; v_count:=v_count+v_inserted;
+
+  INSERT INTO private.supplier_order_exceptions(
+    order_id,orchestration_id,fulfilment_leg_id,handshake_id,shipment_id,exception_key,exception_type,state,owner_type,
+    next_action,customer_impact,financial_impact,source_event_id,metadata
+  )
+  SELECT s.order_id,s.orchestration_id,s.fulfilment_leg_id,s.handshake_id,s.id,
+    'tracking-exception:'||e.id::text,
+    CASE WHEN e.canonical_status='failed_delivery' THEN 'failed_delivery' ELSE 'tracking_exception' END,
+    'open','carrier','investigate carrier exception and update buyer-facing delivery expectation',
+    'delivery may be delayed or unsuccessful','additional fulfilment/support cost may arise',e.id,jsonb_build_object('detectedAt',p_now)
+  FROM private.supplier_tracking_events e JOIN private.supplier_leg_shipments s ON s.id=e.shipment_id
+  WHERE e.canonical_status IN ('exception','failed_delivery')
+  ON CONFLICT(exception_key) DO NOTHING;
+  GET DIAGNOSTICS v_inserted=ROW_COUNT; v_count:=v_count+v_inserted;
+
+  INSERT INTO private.supplier_order_exceptions(
+    order_id,orchestration_id,fulfilment_leg_id,handshake_id,shipment_id,exception_key,exception_type,state,owner_type,
+    next_action,customer_impact,financial_impact,metadata
+  )
+  SELECT s.order_id,s.orchestration_id,s.fulfilment_leg_id,s.handshake_id,s.id,
+    'delayed-dispatch:'||s.id::text,'delayed_dispatch','open','supplier','confirm dispatch or provide corrective fulfilment plan',
+    'dispatch is later than expected','potential support/refund exposure',jsonb_build_object('detectedAt',p_now,'dispatchDueAt',s.dispatch_due_at)
+  FROM private.supplier_leg_shipments s
+  WHERE s.dispatch_due_at IS NOT NULL AND s.dispatched_at IS NULL
+    AND s.dispatch_due_at + make_interval(mins=>p_dispatch_delay_minutes)<=p_now
+  ON CONFLICT(exception_key) DO NOTHING;
+  GET DIAGNOSTICS v_inserted=ROW_COUNT; v_count:=v_count+v_inserted;
+
+  RETURN v_count;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_detect_supplier_tracking_exceptions_v1(timestamptz,integer,integer) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_detect_supplier_tracking_exceptions_v1(timestamptz,integer,integer) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_supplier_tracking_status_v1(p_actor_id uuid,p_order_id uuid DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+BEGIN
+  IF NOT EXISTS(SELECT 1 FROM public.users u WHERE u.id=p_actor_id AND u.role='admin' AND u."isActive"=true) THEN
+    RAISE EXCEPTION 'active admin authority is required' USING ERRCODE='42501';
+  END IF;
+  RETURN jsonb_build_object(
+    'shipments',(SELECT COALESCE(jsonb_agg(to_jsonb(s) ORDER BY s.updated_at DESC),'[]'::jsonb) FROM private.supplier_leg_shipments s WHERE p_order_id IS NULL OR s.order_id=p_order_id),
+    'exceptions',(SELECT COALESCE(jsonb_agg(to_jsonb(e) ORDER BY e.updated_at DESC),'[]'::jsonb) FROM private.supplier_order_exceptions e WHERE p_order_id IS NULL OR e.order_id=p_order_id),
+    'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_supplier_tracking_status_v1(uuid,uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_supplier_tracking_status_v1(uuid,uuid) TO service_role;
+
+COMMENT ON FUNCTION public.server_detect_supplier_tracking_exceptions_v1(timestamptz,integer,integer) IS 'Phase K operational detector only. It opens no-tracking, delayed-dispatch and tracking/failure exceptions; return/refund/recovery execution remains Phase L.';

--- a/supabase/647_supplier_tracking_exception_closure.sql
+++ b/supabase/647_supplier_tracking_exception_closure.sql
@@ -1,0 +1,96 @@
+-- 647_supplier_tracking_exception_closure.sql
+-- Phase K Branch Guard closure: tracking identity/terminal monotonicity + exception lifecycle history.
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_leg_shipment_identity_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  IF NEW.order_id IS DISTINCT FROM OLD.order_id OR NEW.orchestration_id IS DISTINCT FROM OLD.orchestration_id
+     OR NEW.fulfilment_leg_id IS DISTINCT FROM OLD.fulfilment_leg_id OR NEW.handshake_id IS DISTINCT FROM OLD.handshake_id
+     OR NEW.supplier_id IS DISTINCT FROM OLD.supplier_id OR NEW.provider_key IS DISTINCT FROM OLD.provider_key
+     OR NEW.external_supplier_order_ref IS DISTINCT FROM OLD.external_supplier_order_ref THEN
+    RAISE EXCEPTION 'supplier leg shipment identity is immutable';
+  END IF;
+  IF OLD.tracking_ref IS NOT NULL AND NEW.tracking_ref IS DISTINCT FROM OLD.tracking_ref THEN
+    RAISE EXCEPTION 'supplier leg shipment tracking reference is immutable once known';
+  END IF;
+  IF OLD.canonical_status='delivered' AND NEW.canonical_status NOT IN ('delivered','returned') THEN
+    RAISE EXCEPTION 'delivered supplier shipment cannot regress';
+  END IF;
+  IF OLD.canonical_status='returned' AND NEW.canonical_status<>'returned' THEN
+    RAISE EXCEPTION 'returned supplier shipment cannot regress';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_leg_shipment_identity_v1 ON private.supplier_leg_shipments;
+CREATE TRIGGER trg_guard_supplier_leg_shipment_identity_v1
+BEFORE UPDATE ON private.supplier_leg_shipments
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_leg_shipment_identity_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_tracking_mapping_history_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  IF TG_OP='DELETE' THEN RAISE EXCEPTION 'supplier tracking mapping history cannot be deleted'; END IF;
+  IF OLD.status='approved' AND (
+    NEW.provider_key IS DISTINCT FROM OLD.provider_key OR NEW.provider_status IS DISTINCT FROM OLD.provider_status
+    OR NEW.canonical_status IS DISTINCT FROM OLD.canonical_status OR NEW.version IS DISTINCT FROM OLD.version
+    OR NEW.evidence IS DISTINCT FROM OLD.evidence OR NEW.approved_by IS DISTINCT FROM OLD.approved_by
+    OR NEW.approved_at IS DISTINCT FROM OLD.approved_at OR NEW.effective_from IS DISTINCT FROM OLD.effective_from
+  ) THEN RAISE EXCEPTION 'approved supplier tracking mapping truth is immutable; create a new version'; END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_tracking_mapping_history_v1 ON private.supplier_tracking_status_mappings;
+CREATE TRIGGER trg_guard_supplier_tracking_mapping_history_v1
+BEFORE UPDATE OR DELETE ON private.supplier_tracking_status_mappings
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_tracking_mapping_history_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_exception_identity_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  IF NEW.order_id IS DISTINCT FROM OLD.order_id OR NEW.orchestration_id IS DISTINCT FROM OLD.orchestration_id
+     OR NEW.fulfilment_leg_id IS DISTINCT FROM OLD.fulfilment_leg_id OR NEW.handshake_id IS DISTINCT FROM OLD.handshake_id
+     OR NEW.shipment_id IS DISTINCT FROM OLD.shipment_id OR NEW.exception_key IS DISTINCT FROM OLD.exception_key
+     OR NEW.exception_type IS DISTINCT FROM OLD.exception_type OR NEW.source_event_id IS DISTINCT FROM OLD.source_event_id
+     OR NEW.customer_impact IS DISTINCT FROM OLD.customer_impact OR NEW.financial_impact IS DISTINCT FROM OLD.financial_impact THEN
+    RAISE EXCEPTION 'supplier order exception identity/impact evidence is immutable';
+  END IF;
+  IF OLD.state='closed' AND NEW.state<>'closed' THEN RAISE EXCEPTION 'closed supplier order exception cannot regress'; END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_exception_identity_v1 ON private.supplier_order_exceptions;
+CREATE TRIGGER trg_guard_supplier_exception_identity_v1
+BEFORE UPDATE ON private.supplier_order_exceptions
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_exception_identity_v1();
+
+CREATE OR REPLACE FUNCTION public.server_admin_approve_supplier_tracking_mapping_v1(
+  p_actor_id uuid,p_provider_key text,p_provider_status text,p_canonical_status text,p_evidence jsonb,p_effective_from timestamptz DEFAULT now()
+)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_id uuid; v_version integer;
+BEGIN
+  IF NOT EXISTS(SELECT 1 FROM public.users u WHERE u.id=p_actor_id AND u.role='admin' AND u."isActive"=true) THEN
+    RAISE EXCEPTION 'active admin authority is required' USING ERRCODE='42501';
+  END IF;
+  IF NULLIF(BTRIM(p_provider_key),'') IS NULL OR NULLIF(BTRIM(p_provider_status),'') IS NULL
+     OR p_canonical_status NOT IN ('pending','accepted','dispatched','in_transit','exception','out_for_delivery','delivered','failed_delivery','returned')
+     OR jsonb_typeof(COALESCE(p_evidence,'{}'::jsonb))<>'object' OR COALESCE(p_evidence,'{}'::jsonb)='{}'::jsonb THEN
+    RAISE EXCEPTION 'complete tracking mapping evidence is required';
+  END IF;
+  UPDATE private.supplier_tracking_status_mappings SET status='retired',effective_to=p_effective_from
+   WHERE provider_key=BTRIM(p_provider_key) AND lower(provider_status)=lower(BTRIM(p_provider_status))
+     AND status='approved' AND effective_to IS NULL;
+  SELECT COALESCE(MAX(version),0)+1 INTO v_version FROM private.supplier_tracking_status_mappings
+   WHERE provider_key=BTRIM(p_provider_key) AND lower(provider_status)=lower(BTRIM(p_provider_status));
+  INSERT INTO private.supplier_tracking_status_mappings(
+    provider_key,provider_status,canonical_status,version,status,evidence,approved_by,approved_at,effective_from
+  ) VALUES(BTRIM(p_provider_key),BTRIM(p_provider_status),p_canonical_status,v_version,'approved',p_evidence,p_actor_id,now(),p_effective_from)
+  RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_approve_supplier_tracking_mapping_v1(uuid,text,text,text,jsonb,timestamptz) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_approve_supplier_tracking_mapping_v1(uuid,text,text,text,jsonb,timestamptz) TO service_role;
+
+COMMENT ON FUNCTION private.guard_supplier_leg_shipment_identity_v1() IS 'Phase K terminal/identity guard: delivered tracking truth may only stay delivered or proceed to returned.';


### PR DESCRIPTION
Phase K canonical Supplier Commerce implementation.

PowerShell Branch Guard evidence on exact head 22c62dfd6d1dc6a965ffb38d99806d40754f657b:
- Phase K dedicated tests: 16/16 PASS
- upstream Phase C–J Supplier Commerce tests: PASS
- TypeScript: PASS
- ESLint: PASS
- production build: PASS
- full suite remains at the known 27-failure baseline, with 355 passing tests and no new Phase K failure family

Scope:
- provider-neutral supplier tracking ingestion through SupplierAdapterV1
- versioned tracking status normalisation
- append-only/idempotent raw tracking evidence
- per-fulfilment-leg canonical shipment tracking without parallel customer-order truth
- fail-closed tracking_ingest control
- canonical Phase K exception engine with owner/next action/customer impact/financial impact/resolution
- admin visibility/governance
- no unrelated visual Workspace/Super Admin changes
- no Supplier Commerce control enabled