### PR TITLE
Phase L — returns, customer refunds, supplier recovery and reconciliation

### DIFF
--- a/netlify/functions/__tests__/supplier-refund-idempotency.test.ts
+++ b/netlify/functions/__tests__/supplier-refund-idempotency.test.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const sql = readFileSync(resolve(process.cwd(), 'supabase/652_supplier_refund_idempotency_closure.sql'), 'utf8');
+
+describe('Phase L refund replay idempotency closure', () => {
+  it('resolves exact event-key replay before cumulative over-refund arithmetic', () => {
+    const replayLookup = sql.indexOf('SELECT * INTO v_ref FROM private.supplier_customer_refund_evidence WHERE event_key=BTRIM(p_event_key)');
+    const cumulativeLookup = sql.indexOf('SELECT COALESCE(SUM(amount),0) INTO v_total');
+    expect(replayLookup).toBeGreaterThan(-1);
+    expect(cumulativeLookup).toBeGreaterThan(replayLookup);
+    expect(sql).toContain("'replayed',true");
+  });
+
+  it('rejects a reused event key when immutable financial identity differs', () => {
+    expect(sql).toContain('customer refund evidence idempotency collision');
+    expect(sql).toContain('v_ref.external_refund_ref<>BTRIM(p_external_refund_ref)');
+    expect(sql).toContain('v_ref.amount<>p_amount');
+    expect(sql).toContain('v_ref.currency<>upper(BTRIM(p_currency))');
+  });
+
+  it('keeps the over-refund guard and append-only ledger event after replay resolution', () => {
+    expect(sql).toContain('cumulative customer refund exceeds customer order total');
+    expect(sql).toContain("'phase-l-refund:'");
+    expect(sql).toContain("'customer_refund','customer_refund'");
+  });
+});

--- a/netlify/functions/__tests__/supplier-return-quantity.test.ts
+++ b/netlify/functions/__tests__/supplier-return-quantity.test.ts
@@ -1,0 +1,23 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const sql = readFileSync(resolve(process.cwd(), 'supabase/653_supplier_return_quantity_closure.sql'), 'utf8');
+
+describe('Phase L cumulative return quantity closure', () => {
+  it('serializes concurrent return creation on the canonical fulfilment leg', () => {
+    expect(sql).toContain('FOR UPDATE');
+    expect(sql).toContain('private.supplier_fulfilment_legs');
+  });
+
+  it('sums prior non-cancelled return cases before accepting another return', () => {
+    expect(sql).toContain('SUM(c.requested_quantity)');
+    expect(sql).toContain("c.state<>'cancelled'");
+    expect(sql).toContain('v_existing_quantity+NEW.requested_quantity>v_leg_quantity');
+  });
+
+  it('fails closed instead of over-returning the ordered quantity', () => {
+    expect(sql).toContain('cumulative supplier return quantity exceeds fulfilment leg quantity');
+    expect(sql).toContain('BEFORE INSERT ON private.supplier_return_cases');
+  });
+});

--- a/netlify/functions/__tests__/supplier-returns-recovery.test.ts
+++ b/netlify/functions/__tests__/supplier-returns-recovery.test.ts
@@ -1,0 +1,231 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+import type { SupplierAdapterV1 } from '../_shared/supplierAdapter';
+import {
+  SUPPLIER_RETURNS_INTERFACE_VERSION,
+  pollSupplierRecovery,
+  requestSupplierReturn,
+} from '../_shared/supplierReturns';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const foundation = repo('supabase/648_supplier_returns_recovery_foundation.sql');
+const runtime = repo('supabase/649_supplier_returns_recovery_runtime_guards.sql');
+const reconciliation = repo('supabase/650_supplier_financial_reconciliation.sql');
+const closure = repo('supabase/651_supplier_returns_recovery_closure.sql');
+const helper = repo('netlify/functions/_shared/supplierReturns.ts');
+const adminApi = repo('netlify/functions/admin-supplier-returns.ts');
+
+const ORDER = '11111111-1111-4111-8111-111111111111';
+const LEG = '22222222-2222-4222-8222-222222222222';
+const RETURN_CASE = '33333333-3333-4333-8333-333333333333';
+const CORRELATION = '44444444-4444-4444-8444-444444444444';
+
+function returnPrepared() {
+  return {
+    eligible: true,
+    reason: 'supplier_return_ready',
+    returnCaseId: RETURN_CASE,
+    orderId: ORDER,
+    fulfilmentLegId: LEG,
+    supplierId: '55555555-5555-4555-8555-555555555555',
+    supplierKey: 'supplier-a',
+    providerKey: 'provider-a',
+    adapterVersion: '2026-08-21',
+    supplierOrderRef: 'SUP-1',
+    reasonCode: 'damaged',
+    quantity: 1,
+    idempotencyKey: 'return-idem-1',
+    correlationId: CORRELATION,
+    interfaceVersion: 1,
+  } as const;
+}
+
+function recoveryPrepared() {
+  return {
+    eligible: true,
+    reason: 'supplier_recovery_ready',
+    returnCaseId: RETURN_CASE,
+    orderId: ORDER,
+    supplierId: '55555555-5555-4555-8555-555555555555',
+    supplierKey: 'supplier-a',
+    providerKey: 'provider-a',
+    adapterVersion: '2026-08-21',
+    supplierOrderRef: 'SUP-1',
+    externalReturnRef: 'RET-1',
+    currency: 'GBP',
+    currencyMinorUnitExponent: 2,
+    correlationId: CORRELATION,
+    idempotencyKey: 'return-idem-1',
+    interfaceVersion: 1,
+  } as const;
+}
+
+function adapter(overrides: Partial<SupplierAdapterV1> = {}): SupplierAdapterV1 {
+  return {
+    interfaceVersion: 1,
+    providerKey: 'provider-a',
+    adapterVersion: '2026-08-21',
+    capabilities: ['returns', 'reimbursement'],
+    requestReturn: vi.fn(async () => ({ ok: true as const, data: { returnRef: 'RET-1' } })),
+    getReimbursement: vi.fn(async () => ({
+      ok: true as const,
+      data: { amountMinor: 1250, currency: 'GBP', state: 'recovered' },
+      externalRef: 'REC-1',
+    })),
+    ...overrides,
+  };
+}
+
+describe('Phase L returns + refunds + supplier recovery + reconciliation', () => {
+  it('keeps customer refund truth separate from supplier recovery truth', () => {
+    expect(foundation).toContain('private.supplier_customer_refund_evidence');
+    expect(foundation).toContain('private.supplier_recovery_evidence');
+    expect(foundation).toContain('A buyer refund never implies supplier recovery');
+  });
+
+  it('keeps return_recovery kill switch off by default', () => {
+    expect(foundation).toContain("('return_recovery','global',NULL,false,'Phase L safe default')");
+    expect(foundation).not.toContain('enabled=true');
+    expect(runtime).toContain("server_supplier_commerce_control_decision_v1('return_recovery'");
+  });
+
+  it('requires a reconciled supplier order and delivered supplier shipment before return', () => {
+    expect(runtime).toContain("o.state='reconciled'");
+    expect(runtime).toContain("v_ship.canonical_status NOT IN ('delivered','returned')");
+    expect(runtime).toContain("'return_requires_delivered_supplier_shipment'");
+  });
+
+  it('requires returns and reimbursement adapter capabilities', () => {
+    expect(runtime).toContain("ARRAY['returns','reimbursement']::text[]");
+    expect(helper).toContain("adapterSupports(adapter, 'returns')");
+    expect(helper).toContain("adapterSupports(adapter, 'reimbursement')");
+  });
+
+  it('makes refund/recovery evidence and lifecycle events append-only', () => {
+    expect(runtime).toContain('Phase L refund/recovery evidence is append-only');
+    expect(foundation).toContain('REVOKE ALL ON TABLE private.supplier_customer_refund_evidence');
+    expect(foundation).toContain('REVOKE ALL ON TABLE private.supplier_recovery_evidence');
+  });
+
+  it('prevents refund overpayment and currency drift', () => {
+    expect(runtime).toContain('cumulative customer refund exceeds customer order total');
+    expect(runtime).toContain('refund currency must match fulfilment leg currency');
+    expect(runtime).toContain('recovery currency must match fulfilment leg currency');
+  });
+
+  it('posts customer refunds and supplier recoveries as distinct append-only ledger events', () => {
+    expect(runtime).toContain("'customer_refund','customer_refund'");
+    expect(runtime).toContain("'supplier_recovery','supplier_recovery'");
+    expect(runtime).toContain("'phase-l-refund:'");
+    expect(runtime).toContain("'phase-l-recovery:'");
+  });
+
+  it('compares Phase J payment evidence with financial ledger and downstream money truth', () => {
+    expect(reconciliation).toContain('private.supplier_payment_evidence_snapshots');
+    expect(reconciliation).toContain("event_type='customer_payment'");
+    expect(reconciliation).toContain("event_type='supplier_payable'");
+    expect(reconciliation).toContain("event_type='payout'");
+    expect(reconciliation).toContain("event_type='customer_refund'");
+    expect(reconciliation).toContain("event_type='supplier_recovery'");
+    expect(reconciliation).toContain("event_type='chargeback'");
+  });
+
+  it('uses the canonical reconciliation states and never equates order completion with reconciliation', () => {
+    expect(foundation).toContain("'RECONCILED','PARTIALLY_RECONCILED','EXCEPTION','UNRECOVERED'");
+    expect(reconciliation).toContain('order completed != financially reconciled');
+    expect(reconciliation).toContain("v_state:='UNRECOVERED'");
+    expect(reconciliation).toContain("v_state:='PARTIALLY_RECONCILED'");
+  });
+
+  it('adds Phase L financial exceptions without mixing them into tracking money movement', () => {
+    expect(reconciliation).toContain("'reimbursement_failure'");
+    expect(reconciliation).toContain("'financial_reconciliation_mismatch'");
+    expect(reconciliation).toContain('server_open_supplier_financial_exception_v1');
+  });
+
+  it('protects return identity and terminal refund/recovery truth', () => {
+    expect(closure).toContain('supplier return case identity is immutable');
+    expect(closure).toContain('successful customer refund truth cannot regress');
+    expect(closure).toContain('terminal supplier recovery truth cannot regress');
+  });
+
+  it('fails closed on generic minor-unit conversion outside the currently enabled GBP economics', () => {
+    expect(closure).toContain("IF v_leg.currency<>'GBP'");
+    expect(closure).toContain("'automated_recovery_currency_not_enabled'");
+    expect(closure).toContain("'currencyMinorUnitExponent',2");
+    expect(helper).toContain('10 ** prepared.currencyMinorUnitExponent');
+  });
+
+  it('keeps Phase L admin visibility active-admin-only', () => {
+    expect(closure).toContain("u.role='admin'");
+    expect(closure).toContain('u."isActive"=true');
+    expect(adminApi).toContain("authenticateActiveAccount(event, admin, ['admin'])");
+  });
+
+  it('requests a provider return through SupplierAdapterV1 and persists the external return identity', async () => {
+    const rpc = vi.fn(async (name: string) => {
+      if (name === 'server_prepare_supplier_return_v1') return { data: returnPrepared(), error: null };
+      if (name === 'server_record_supplier_return_authorisation_v1') return { data: { ok: true, state: 'authorised' }, error: null };
+      return { data: null, error: new Error(`unexpected rpc ${name}`) };
+    });
+    const client = { rpc } as unknown as SupabaseClient;
+    const a = adapter();
+    const result = await requestSupplierReturn(client, a, {
+      orderId: ORDER,
+      fulfilmentLegId: LEG,
+      reasonCode: 'damaged',
+      quantity: 1,
+      idempotencyKey: 'return-idem-1',
+      correlationId: CORRELATION,
+    });
+    expect(result).toMatchObject({ ok: true, state: 'authorised', returnCaseId: RETURN_CASE, externalReturnRef: 'RET-1' });
+    expect(a.requestReturn).toHaveBeenCalledTimes(1);
+  });
+
+  it('fails closed before provider return call on adapter identity mismatch', async () => {
+    const rpc = vi.fn(async () => ({ data: returnPrepared(), error: null }));
+    const client = { rpc } as unknown as SupabaseClient;
+    const a = adapter({ providerKey: 'wrong-provider' });
+    const result = await requestSupplierReturn(client, a, {
+      orderId: ORDER, fulfilmentLegId: LEG, reasonCode: 'damaged', quantity: 1,
+      idempotencyKey: 'return-idem-1', correlationId: CORRELATION,
+    });
+    expect(result.ok).toBe(false);
+    expect(result.errorClass).toBe('CAPABILITY_UNAVAILABLE');
+    expect(a.requestReturn).not.toHaveBeenCalled();
+  });
+
+  it('polls reimbursement, converts explicitly enabled GBP minor units and persists recovery evidence', async () => {
+    const rpc = vi.fn(async (name: string) => {
+      if (name === 'server_supplier_recovery_context_v1') return { data: recoveryPrepared(), error: null };
+      if (name === 'server_record_supplier_recovery_evidence_v1') return { data: { ok: true, state: 'recovered' }, error: null };
+      return { data: null, error: new Error(`unexpected rpc ${name}`) };
+    });
+    const client = { rpc } as unknown as SupabaseClient;
+    const a = adapter();
+    const result = await pollSupplierRecovery(client, a, RETURN_CASE);
+    expect(result).toMatchObject({ ok: true, state: 'recovered', amount: 12.5, currency: 'GBP' });
+    expect(a.getReimbursement).toHaveBeenCalledTimes(1);
+    expect(rpc).toHaveBeenCalledWith('server_record_supplier_recovery_evidence_v1', expect.objectContaining({ p_amount: 12.5, p_currency: 'GBP', p_state: 'recovered' }));
+  });
+
+  it('blocks a provider reimbursement currency mismatch instead of laundering it into financial truth', async () => {
+    const rpc = vi.fn(async (name: string) => {
+      if (name === 'server_supplier_recovery_context_v1') return { data: recoveryPrepared(), error: null };
+      return { data: null, error: null };
+    });
+    const client = { rpc } as unknown as SupabaseClient;
+    const a = adapter({
+      getReimbursement: vi.fn(async () => ({ ok: true as const, data: { amountMinor: 1250, currency: 'USD', state: 'recovered' } })),
+    });
+    const result = await pollSupplierRecovery(client, a, RETURN_CASE);
+    expect(result).toMatchObject({ ok: false, state: 'manual_review', errorClass: 'MALFORMED_RESPONSE' });
+    expect(rpc).not.toHaveBeenCalledWith('server_record_supplier_recovery_evidence_v1', expect.anything());
+  });
+
+  it('exposes interface version 1 without changing SupplierAdapterV1', () => {
+    expect(SUPPLIER_RETURNS_INTERFACE_VERSION).toBe(1);
+  });
+});

--- a/netlify/functions/_shared/supplierReturns.ts
+++ b/netlify/functions/_shared/supplierReturns.ts
@@ -1,0 +1,257 @@
+import { createHash } from 'node:crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { SupplierAdapterContext, SupplierAdapterV1 } from './supplierAdapter';
+import { adapterSupports } from './supplierAdapter';
+import { recordSupplierCommerceOperation } from './supplierCommerceControl';
+
+export const SUPPLIER_RETURNS_INTERFACE_VERSION = 1 as const;
+
+type ReturnPrepared = {
+  eligible: true;
+  reason: 'supplier_return_ready';
+  returnCaseId: string;
+  orderId: string;
+  fulfilmentLegId: string;
+  supplierId: string;
+  supplierKey: string;
+  providerKey: string;
+  adapterVersion: string;
+  supplierOrderRef: string;
+  reasonCode: string;
+  quantity: number;
+  idempotencyKey: string;
+  correlationId: string;
+  interfaceVersion: 1;
+};
+
+type RecoveryPrepared = {
+  eligible: true;
+  reason: 'supplier_recovery_ready';
+  returnCaseId: string;
+  orderId: string;
+  supplierId: string;
+  supplierKey: string;
+  providerKey: string;
+  adapterVersion: string;
+  supplierOrderRef: string;
+  externalReturnRef: string;
+  currency: 'GBP';
+  currencyMinorUnitExponent: 2;
+  correlationId: string;
+  idempotencyKey: string;
+  interfaceVersion: 1;
+};
+
+export type SupplierReturnRuntimeResult = {
+  ok: boolean;
+  state: string;
+  returnCaseId?: string;
+  externalReturnRef?: string;
+  recoveryState?: string;
+  amount?: number;
+  currency?: string;
+  reason?: string;
+  errorClass?: string;
+};
+
+function isReturnPrepared(value: unknown): value is ReturnPrepared {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  return row.eligible === true
+    && row.reason === 'supplier_return_ready'
+    && typeof row.returnCaseId === 'string'
+    && typeof row.supplierKey === 'string'
+    && typeof row.providerKey === 'string'
+    && typeof row.adapterVersion === 'string'
+    && typeof row.supplierOrderRef === 'string'
+    && typeof row.reasonCode === 'string'
+    && typeof row.quantity === 'number'
+    && typeof row.idempotencyKey === 'string'
+    && typeof row.correlationId === 'string'
+    && row.interfaceVersion === SUPPLIER_RETURNS_INTERFACE_VERSION;
+}
+
+function isRecoveryPrepared(value: unknown): value is RecoveryPrepared {
+  if (!value || typeof value !== 'object') return false;
+  const row = value as Record<string, unknown>;
+  return row.eligible === true
+    && row.reason === 'supplier_recovery_ready'
+    && typeof row.returnCaseId === 'string'
+    && typeof row.supplierKey === 'string'
+    && typeof row.providerKey === 'string'
+    && typeof row.adapterVersion === 'string'
+    && typeof row.supplierOrderRef === 'string'
+    && typeof row.externalReturnRef === 'string'
+    && row.currency === 'GBP'
+    && row.currencyMinorUnitExponent === 2
+    && typeof row.correlationId === 'string'
+    && typeof row.idempotencyKey === 'string'
+    && row.interfaceVersion === SUPPLIER_RETURNS_INTERFACE_VERSION;
+}
+
+function recoveryState(raw: string): 'requested' | 'pending' | 'partial' | 'recovered' | 'failed' | 'unrecoverable' {
+  const state = raw.trim().toLowerCase();
+  if (['recovered', 'completed', 'paid', 'succeeded', 'success'].includes(state)) return 'recovered';
+  if (['partial', 'partially_recovered', 'partially_paid'].includes(state)) return 'partial';
+  if (['failed', 'rejected', 'denied'].includes(state)) return 'failed';
+  if (['unrecoverable', 'written_off', 'write_off'].includes(state)) return 'unrecoverable';
+  if (['requested', 'created'].includes(state)) return 'requested';
+  return 'pending';
+}
+
+export async function requestSupplierReturn(
+  client: SupabaseClient,
+  adapter: SupplierAdapterV1,
+  input: {
+    orderId: string;
+    fulfilmentLegId: string;
+    reasonCode: string;
+    quantity: number;
+    idempotencyKey: string;
+    correlationId: string;
+  },
+): Promise<SupplierReturnRuntimeResult> {
+  const { data, error } = await client.rpc('server_prepare_supplier_return_v1', {
+    p_order_id: input.orderId,
+    p_fulfilment_leg_id: input.fulfilmentLegId,
+    p_reason_code: input.reasonCode,
+    p_quantity: input.quantity,
+    p_idempotency_key: input.idempotencyKey,
+    p_correlation_id: input.correlationId,
+  });
+  if (error || !isReturnPrepared(data)) {
+    const reason = data && typeof data === 'object' && typeof (data as { reason?: unknown }).reason === 'string'
+      ? String((data as { reason: string }).reason)
+      : 'supplier_return_not_ready';
+    return { ok: false, state: 'blocked', reason };
+  }
+  const prepared = data;
+  if (
+    adapter.interfaceVersion !== SUPPLIER_RETURNS_INTERFACE_VERSION
+    || adapter.providerKey !== prepared.providerKey
+    || adapter.adapterVersion !== prepared.adapterVersion
+    || !adapterSupports(adapter, 'returns')
+    || !adapter.requestReturn
+  ) {
+    return { ok: false, state: 'manual_review', returnCaseId: prepared.returnCaseId, errorClass: 'CAPABILITY_UNAVAILABLE' };
+  }
+
+  const context: SupplierAdapterContext = {
+    correlationId: prepared.correlationId,
+    idempotencyKey: prepared.idempotencyKey,
+    supplierKey: prepared.supplierKey,
+    territory: 'GB',
+  };
+  const startedAt = new Date().toISOString();
+  try {
+    const result = await adapter.requestReturn(context, prepared.supplierOrderRef, prepared.reasonCode);
+    if (!result.ok || !result.data.returnRef?.trim()) {
+      await recordSupplierCommerceOperation(client, {
+        correlationId: prepared.correlationId,
+        requestId: prepared.idempotencyKey,
+        operation: 'return_recovery',
+        providerRef: adapter.providerKey,
+        supplierRef: prepared.supplierKey,
+        entityType: 'supplier_return_case',
+        entityRef: prepared.returnCaseId,
+        resultClass: result.ok ? 'MANUAL_REVIEW_REQUIRED' : result.errorClass === 'RATE_LIMITED' ? 'RATE_LIMITED' : result.errorClass === 'PERMANENT_REJECTION' ? 'PERMANENT_REJECTION' : 'RETRYABLE_FAILURE',
+        errorClass: result.ok ? 'MALFORMED_RESPONSE' : result.errorClass,
+        recoveryState: 'manual_review',
+        customerImpact: 'return_authorisation_not_confirmed',
+        financialImpact: 'supplier_recovery_not_started',
+        startedAt,
+        finishedAt: new Date().toISOString(),
+      });
+      return { ok: false, state: 'manual_review', returnCaseId: prepared.returnCaseId, errorClass: result.ok ? 'MALFORMED_RESPONSE' : result.errorClass };
+    }
+    const { data: recorded, error: recordError } = await client.rpc('server_record_supplier_return_authorisation_v1', {
+      p_return_case_id: prepared.returnCaseId,
+      p_external_return_ref: result.data.returnRef.trim(),
+      p_authorised: true,
+      p_evidence: { provider: adapter.providerKey, source: 'requestReturn' },
+    });
+    if (recordError || !recorded || typeof recorded !== 'object' || (recorded as { ok?: unknown }).ok !== true) {
+      return { ok: false, state: 'reconciliation_required', returnCaseId: prepared.returnCaseId, externalReturnRef: result.data.returnRef };
+    }
+    return { ok: true, state: 'authorised', returnCaseId: prepared.returnCaseId, externalReturnRef: result.data.returnRef };
+  } catch (errorThrown) {
+    return {
+      ok: false,
+      state: 'manual_review',
+      returnCaseId: prepared.returnCaseId,
+      errorClass: 'UNKNOWN_OUTCOME',
+      reason: errorThrown instanceof Error ? errorThrown.message : 'supplier return request outcome unknown',
+    };
+  }
+}
+
+export async function pollSupplierRecovery(
+  client: SupabaseClient,
+  adapter: SupplierAdapterV1,
+  returnCaseId: string,
+): Promise<SupplierReturnRuntimeResult> {
+  const { data, error } = await client.rpc('server_supplier_recovery_context_v1', { p_return_case_id: returnCaseId });
+  if (error || !isRecoveryPrepared(data)) {
+    const reason = data && typeof data === 'object' && typeof (data as { reason?: unknown }).reason === 'string'
+      ? String((data as { reason: string }).reason)
+      : 'supplier_recovery_not_ready';
+    return { ok: false, state: 'blocked', returnCaseId, reason };
+  }
+  const prepared = data;
+  if (
+    adapter.interfaceVersion !== SUPPLIER_RETURNS_INTERFACE_VERSION
+    || adapter.providerKey !== prepared.providerKey
+    || adapter.adapterVersion !== prepared.adapterVersion
+    || !adapterSupports(adapter, 'reimbursement')
+    || !adapter.getReimbursement
+  ) {
+    return { ok: false, state: 'manual_review', returnCaseId, errorClass: 'CAPABILITY_UNAVAILABLE' };
+  }
+
+  const context: SupplierAdapterContext = {
+    correlationId: prepared.correlationId,
+    idempotencyKey: prepared.idempotencyKey,
+    supplierKey: prepared.supplierKey,
+    territory: 'GB',
+  };
+  try {
+    const result = await adapter.getReimbursement(context, prepared.supplierOrderRef);
+    if (!result.ok) return { ok: false, state: 'pending', returnCaseId, errorClass: result.errorClass };
+    if (result.data.currency && result.data.currency.toUpperCase() !== prepared.currency) {
+      return { ok: false, state: 'manual_review', returnCaseId, errorClass: 'MALFORMED_RESPONSE', reason: 'supplier recovery currency mismatch' };
+    }
+    const state = recoveryState(result.data.state);
+    const amountMinor = result.data.amountMinor ?? 0;
+    if (!Number.isSafeInteger(amountMinor) || amountMinor < 0) {
+      return { ok: false, state: 'manual_review', returnCaseId, errorClass: 'MALFORMED_RESPONSE', reason: 'invalid reimbursement amountMinor' };
+    }
+    if ((state === 'partial' || state === 'recovered') && amountMinor <= 0) {
+      return { ok: false, state: 'manual_review', returnCaseId, errorClass: 'MALFORMED_RESPONSE', reason: 'financial recovery missing amount' };
+    }
+    const amount = amountMinor / (10 ** prepared.currencyMinorUnitExponent);
+    const fingerprint = createHash('sha256')
+      .update([returnCaseId, state, String(amountMinor), result.externalRef ?? '', prepared.currency].join('|'))
+      .digest('hex');
+    const { data: recorded, error: recordError } = await client.rpc('server_record_supplier_recovery_evidence_v1', {
+      p_return_case_id: returnCaseId,
+      p_event_key: `supplier-recovery:${fingerprint}`,
+      p_external_recovery_ref: result.externalRef ?? null,
+      p_amount: amount,
+      p_currency: prepared.currency,
+      p_state: state,
+      p_occurred_at: new Date().toISOString(),
+      p_evidence: { provider: adapter.providerKey, rawState: result.data.state, amountMinor },
+    });
+    if (recordError || !recorded || typeof recorded !== 'object' || (recorded as { ok?: unknown }).ok !== true) {
+      return { ok: false, state: 'reconciliation_required', returnCaseId };
+    }
+    return { ok: state === 'recovered', state, returnCaseId, recoveryState: state, amount, currency: prepared.currency };
+  } catch (errorThrown) {
+    return { ok: false, state: 'pending', returnCaseId, errorClass: 'UNKNOWN_OUTCOME', reason: errorThrown instanceof Error ? errorThrown.message : 'recovery query failed' };
+  }
+}
+
+export async function reconcileSupplierFinancials(client: SupabaseClient, orderId: string): Promise<Record<string, unknown> | null> {
+  const { data, error } = await client.rpc('server_reconcile_supplier_financials_v1', { p_order_id: orderId });
+  return error || !data || typeof data !== 'object' ? null : data as Record<string, unknown>;
+}

--- a/netlify/functions/admin-supplier-returns.ts
+++ b/netlify/functions/admin-supplier-returns.ts
@@ -1,0 +1,48 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { jsonResponse, optionsResponse } from './_shared/http';
+
+const METHODS = 'POST, OPTIONS';
+
+type AdminAction =
+  | { action: 'status'; orderId?: string }
+  | { action: 'reconcile'; orderId: string };
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return optionsResponse(METHODS);
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' }, METHODS);
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) return jsonResponse(500, { error: 'Server configuration error' }, METHODS);
+
+  const admin = createClient(supabaseUrl, serviceRoleKey, { auth: { autoRefreshToken: false, persistSession: false } });
+  const auth = await authenticateActiveAccount(event, admin, ['admin']);
+  if (!auth.ok) return jsonResponse(auth.status, { error: 'Unauthorized' }, METHODS);
+
+  let body: AdminAction;
+  try { body = JSON.parse(event.body || '{}') as AdminAction; }
+  catch { return jsonResponse(400, { error: 'Invalid JSON body' }, METHODS); }
+
+  if (!body || (body.action !== 'status' && body.action !== 'reconcile')) {
+    return jsonResponse(400, { error: 'Unsupported Phase L admin action' }, METHODS);
+  }
+  if (body.orderId !== undefined && (typeof body.orderId !== 'string' || !body.orderId.trim())) {
+    return jsonResponse(400, { error: 'orderId must be a non-empty string when supplied' }, METHODS);
+  }
+
+  if (body.action === 'reconcile') {
+    if (!body.orderId?.trim()) return jsonResponse(400, { error: 'orderId is required for reconciliation' }, METHODS);
+    const { data, error } = await admin.rpc('server_reconcile_supplier_financials_v1', { p_order_id: body.orderId.trim() });
+    if (error) return jsonResponse(500, { error: 'Unable to reconcile supplier financial truth' }, METHODS);
+    return jsonResponse(200, { ok: true, result: data }, METHODS);
+  }
+
+  const { data, error } = await admin.rpc('server_admin_supplier_return_financial_status_v1', {
+    p_actor_id: auth.actor.id,
+    p_order_id: body.orderId?.trim() || null,
+  });
+  if (error) return jsonResponse(500, { error: 'Unable to read supplier return/recovery status' }, METHODS);
+  return jsonResponse(200, { ok: true, result: data }, METHODS);
+};

--- a/supabase/648_supplier_returns_recovery_foundation.sql
+++ b/supabase/648_supplier_returns_recovery_foundation.sql
@@ -1,0 +1,139 @@
+-- 648_supplier_returns_recovery_foundation.sql
+-- Phase L — returns + customer refunds + supplier recovery + financial reconciliation foundation.
+-- Customer refund truth and supplier recovery truth are deliberately separate.
+-- Supplier Commerce remains fail-closed; no control is enabled here.
+
+CREATE SCHEMA IF NOT EXISTS private;
+
+INSERT INTO private.supplier_commerce_controls(operation, scope_type, scope_ref, enabled, reason)
+VALUES ('return_recovery','global',NULL,false,'Phase L safe default')
+ON CONFLICT (operation, scope_type, scope_ref_key) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS private.supplier_return_cases (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  return_key text NOT NULL UNIQUE,
+  order_id uuid NOT NULL REFERENCES public.orders(id) ON DELETE RESTRICT,
+  orchestration_id uuid NOT NULL REFERENCES private.supplier_order_orchestrations(id) ON DELETE RESTRICT,
+  fulfilment_leg_id uuid NOT NULL REFERENCES private.supplier_fulfilment_legs(id) ON DELETE RESTRICT,
+  handshake_id uuid NOT NULL REFERENCES private.supplier_order_handshakes(id) ON DELETE RESTRICT,
+  shipment_id uuid REFERENCES private.supplier_leg_shipments(id) ON DELETE RESTRICT,
+  supplier_id uuid NOT NULL REFERENCES private.supplier_foundation_suppliers(id) ON DELETE RESTRICT,
+  supplier_offer_id uuid NOT NULL REFERENCES private.supplier_offers(id) ON DELETE RESTRICT,
+  commercial_mode text NOT NULL DEFAULT 'loadify_supplier_fulfilled',
+  external_supplier_order_ref text NOT NULL,
+  external_return_ref text,
+  reason_code text NOT NULL,
+  requested_quantity integer NOT NULL CHECK (requested_quantity > 0),
+  state text NOT NULL DEFAULT 'requested',
+  customer_refund_state text NOT NULL DEFAULT 'none',
+  supplier_recovery_state text NOT NULL DEFAULT 'none',
+  idempotency_key text NOT NULL UNIQUE,
+  correlation_id uuid NOT NULL,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  requested_at timestamptz NOT NULL DEFAULT now(),
+  authorised_at timestamptz,
+  returned_at timestamptz,
+  closed_at timestamptz,
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_return_case_key_check CHECK (NULLIF(BTRIM(return_key),'') IS NOT NULL),
+  CONSTRAINT supplier_return_case_mode_check CHECK (commercial_mode='loadify_supplier_fulfilled'),
+  CONSTRAINT supplier_return_case_order_ref_check CHECK (NULLIF(BTRIM(external_supplier_order_ref),'') IS NOT NULL),
+  CONSTRAINT supplier_return_case_reason_check CHECK (NULLIF(BTRIM(reason_code),'') IS NOT NULL),
+  CONSTRAINT supplier_return_case_state_check CHECK (state IN ('requested','authorised','in_transit','received','closed','cancelled')),
+  CONSTRAINT supplier_return_case_refund_state_check CHECK (customer_refund_state IN ('none','pending','partial','succeeded','failed')),
+  CONSTRAINT supplier_return_case_recovery_state_check CHECK (supplier_recovery_state IN ('none','requested','pending','partial','recovered','failed','unrecoverable')),
+  CONSTRAINT supplier_return_case_idempotency_check CHECK (NULLIF(BTRIM(idempotency_key),'') IS NOT NULL),
+  CONSTRAINT supplier_return_case_evidence_check CHECK (jsonb_typeof(evidence)='object')
+);
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_return_case_external_ref_unique
+  ON private.supplier_return_cases(supplier_id, external_return_ref)
+  WHERE external_return_ref IS NOT NULL;
+CREATE INDEX IF NOT EXISTS supplier_return_case_order_idx ON private.supplier_return_cases(order_id, requested_at DESC);
+
+CREATE TABLE IF NOT EXISTS private.supplier_customer_refund_evidence (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_key text NOT NULL UNIQUE,
+  return_case_id uuid NOT NULL REFERENCES private.supplier_return_cases(id) ON DELETE RESTRICT,
+  order_id uuid NOT NULL REFERENCES public.orders(id) ON DELETE RESTRICT,
+  provider text NOT NULL,
+  external_refund_ref text NOT NULL,
+  payment_ref text,
+  amount numeric(18,4) NOT NULL CHECK (amount > 0),
+  currency text NOT NULL,
+  state text NOT NULL,
+  occurred_at timestamptz NOT NULL,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  recorded_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_customer_refund_provider_check CHECK (NULLIF(BTRIM(provider),'') IS NOT NULL),
+  CONSTRAINT supplier_customer_refund_ref_check CHECK (NULLIF(BTRIM(external_refund_ref),'') IS NOT NULL),
+  CONSTRAINT supplier_customer_refund_currency_check CHECK (currency=upper(BTRIM(currency)) AND currency ~ '^[A-Z]{3}$'),
+  CONSTRAINT supplier_customer_refund_state_check CHECK (state IN ('pending','partial','succeeded','failed')),
+  CONSTRAINT supplier_customer_refund_evidence_check CHECK (jsonb_typeof(evidence)='object'),
+  UNIQUE(provider, external_refund_ref)
+);
+
+CREATE TABLE IF NOT EXISTS private.supplier_recovery_evidence (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  event_key text NOT NULL UNIQUE,
+  return_case_id uuid NOT NULL REFERENCES private.supplier_return_cases(id) ON DELETE RESTRICT,
+  order_id uuid NOT NULL REFERENCES public.orders(id) ON DELETE RESTRICT,
+  supplier_id uuid NOT NULL REFERENCES private.supplier_foundation_suppliers(id) ON DELETE RESTRICT,
+  external_recovery_ref text,
+  amount numeric(18,4) NOT NULL DEFAULT 0 CHECK (amount >= 0),
+  currency text NOT NULL,
+  state text NOT NULL,
+  occurred_at timestamptz NOT NULL,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  recorded_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_recovery_currency_check CHECK (currency=upper(BTRIM(currency)) AND currency ~ '^[A-Z]{3}$'),
+  CONSTRAINT supplier_recovery_state_check CHECK (state IN ('requested','pending','partial','recovered','failed','unrecoverable')),
+  CONSTRAINT supplier_recovery_evidence_check CHECK (jsonb_typeof(evidence)='object')
+);
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_recovery_external_ref_unique
+  ON private.supplier_recovery_evidence(supplier_id, external_recovery_ref)
+  WHERE external_recovery_ref IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS private.supplier_financial_reconciliations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  order_id uuid NOT NULL UNIQUE REFERENCES public.orders(id) ON DELETE RESTRICT,
+  state text NOT NULL DEFAULT 'EXCEPTION',
+  currency text NOT NULL,
+  customer_payment numeric(18,4) NOT NULL DEFAULT 0,
+  ledger_customer_payment numeric(18,4) NOT NULL DEFAULT 0,
+  customer_refunds numeric(18,4) NOT NULL DEFAULT 0,
+  ledger_customer_refunds numeric(18,4) NOT NULL DEFAULT 0,
+  supplier_payable numeric(18,4) NOT NULL DEFAULT 0,
+  supplier_paid numeric(18,4) NOT NULL DEFAULT 0,
+  supplier_recoveries numeric(18,4) NOT NULL DEFAULT 0,
+  ledger_supplier_recoveries numeric(18,4) NOT NULL DEFAULT 0,
+  chargebacks numeric(18,4) NOT NULL DEFAULT 0,
+  unrecovered_loss numeric(18,4) NOT NULL DEFAULT 0,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  evaluated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_financial_reconciliation_state_check CHECK (state IN ('RECONCILED','PARTIALLY_RECONCILED','EXCEPTION','UNRECOVERED')),
+  CONSTRAINT supplier_financial_reconciliation_currency_check CHECK (currency=upper(BTRIM(currency)) AND currency ~ '^[A-Z]{3}$'),
+  CONSTRAINT supplier_financial_reconciliation_evidence_check CHECK (jsonb_typeof(evidence)='object')
+);
+
+CREATE TABLE IF NOT EXISTS private.supplier_return_recovery_events (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  return_case_id uuid NOT NULL REFERENCES private.supplier_return_cases(id) ON DELETE RESTRICT,
+  event_key text NOT NULL UNIQUE,
+  event_type text NOT NULL,
+  state text NOT NULL,
+  external_ref text,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_return_recovery_event_type_check CHECK (event_type IN ('return_requested','return_authorised','refund_recorded','recovery_recorded','reconciliation_evaluated','case_closed')),
+  CONSTRAINT supplier_return_recovery_event_evidence_check CHECK (jsonb_typeof(evidence)='object')
+);
+
+REVOKE ALL ON TABLE private.supplier_return_cases FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_customer_refund_evidence FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_recovery_evidence FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_financial_reconciliations FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_return_recovery_events FROM PUBLIC, anon, authenticated, service_role;
+
+COMMENT ON TABLE private.supplier_customer_refund_evidence IS 'Customer refund evidence. A buyer refund never implies supplier recovery.';
+COMMENT ON TABLE private.supplier_recovery_evidence IS 'Supplier reimbursement/recovery evidence tracked independently from customer refunds.';
+COMMENT ON TABLE private.supplier_financial_reconciliations IS 'Phase L canonical order-level reconciliation across payment, ledger, supplier payable/payment, refunds, recoveries and chargebacks.';

--- a/supabase/649_supplier_returns_recovery_runtime_guards.sql
+++ b/supabase/649_supplier_returns_recovery_runtime_guards.sql
@@ -1,0 +1,231 @@
+-- 649_supplier_returns_recovery_runtime_guards.sql
+-- Phase L runtime guards. No external provider or payment action is performed by SQL;
+-- SQL records canonical evidence and appends financial truth only after server-side evidence exists.
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_return_evidence_immutable_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  RAISE EXCEPTION 'Phase L refund/recovery evidence is append-only';
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_customer_refund_evidence_v1 ON private.supplier_customer_refund_evidence;
+CREATE TRIGGER trg_guard_supplier_customer_refund_evidence_v1
+BEFORE UPDATE OR DELETE ON private.supplier_customer_refund_evidence
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_return_evidence_immutable_v1();
+DROP TRIGGER IF EXISTS trg_guard_supplier_recovery_evidence_v1 ON private.supplier_recovery_evidence;
+CREATE TRIGGER trg_guard_supplier_recovery_evidence_v1
+BEFORE UPDATE OR DELETE ON private.supplier_recovery_evidence
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_return_evidence_immutable_v1();
+DROP TRIGGER IF EXISTS trg_guard_supplier_return_recovery_events_v1 ON private.supplier_return_recovery_events;
+CREATE TRIGGER trg_guard_supplier_return_recovery_events_v1
+BEFORE UPDATE OR DELETE ON private.supplier_return_recovery_events
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_return_evidence_immutable_v1();
+
+CREATE OR REPLACE FUNCTION public.server_prepare_supplier_return_v1(
+  p_order_id uuid,
+  p_fulfilment_leg_id uuid,
+  p_reason_code text,
+  p_quantity integer,
+  p_idempotency_key text,
+  p_correlation_id uuid
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_leg private.supplier_fulfilment_legs%ROWTYPE;
+  v_h private.supplier_order_handshakes%ROWTYPE;
+  v_ship private.supplier_leg_shipments%ROWTYPE;
+  v_supplier private.supplier_foundation_suppliers%ROWTYPE;
+  v_adapter private.supplier_adapter_registrations%ROWTYPE;
+  v_case private.supplier_return_cases%ROWTYPE;
+  v_control jsonb;
+  v_max_quantity integer;
+  v_key text;
+BEGIN
+  IF NULLIF(BTRIM(p_reason_code),'') IS NULL OR p_quantity IS NULL OR p_quantity<=0
+     OR NULLIF(BTRIM(p_idempotency_key),'') IS NULL OR p_correlation_id IS NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','invalid_return_request','interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_leg FROM private.supplier_fulfilment_legs
+   WHERE id=p_fulfilment_leg_id AND commercial_mode='loadify_supplier_fulfilled' AND supplier_offer_id IS NOT NULL;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','supplier_fulfilment_leg_missing','interfaceVersion',1); END IF;
+
+  SELECT o.* INTO v_h FROM private.supplier_order_handshakes o
+   WHERE o.order_id=p_order_id AND o.fulfilment_leg_id=p_fulfilment_leg_id
+     AND o.state='reconciled' AND o.acknowledgement_state='accepted' AND o.external_supplier_order_ref IS NOT NULL;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','supplier_order_not_reconciled','interfaceVersion',1); END IF;
+
+  SELECT * INTO v_ship FROM private.supplier_leg_shipments
+   WHERE fulfilment_leg_id=p_fulfilment_leg_id AND handshake_id=v_h.id;
+  IF NOT FOUND OR v_ship.canonical_status NOT IN ('delivered','returned') THEN
+    RETURN jsonb_build_object('eligible',false,'reason','return_requires_delivered_supplier_shipment','interfaceVersion',1);
+  END IF;
+
+  SELECT COALESCE(SUM(i.quantity),0)::integer INTO v_max_quantity
+    FROM private.supplier_fulfilment_leg_items i WHERE i.leg_id=p_fulfilment_leg_id;
+  IF p_quantity>v_max_quantity THEN
+    RETURN jsonb_build_object('eligible',false,'reason','return_quantity_exceeds_leg_quantity','interfaceVersion',1);
+  END IF;
+
+  v_control:=public.server_supplier_commerce_control_decision_v1('return_recovery',jsonb_build_object(
+    'supplierRef',v_h.supplier_id::text,'offerRef',v_h.supplier_offer_id::text,'territory','GB'
+  ));
+  IF COALESCE((v_control->>'enabled')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('eligible',false,'reason','return_recovery_control_disabled','control',v_control,'interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_supplier FROM private.supplier_foundation_suppliers
+   WHERE id=v_h.supplier_id AND lifecycle_status='approved';
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','supplier_not_approved','interfaceVersion',1); END IF;
+
+  SELECT * INTO v_adapter FROM private.supplier_adapter_registrations a
+   WHERE a.supplier_id=v_h.supplier_id AND a.status='active' AND a.interface_version=1
+     AND a.provider_key=v_h.provider_key AND a.adapter_version=v_h.adapter_version
+     AND a.capabilities @> ARRAY['returns','reimbursement']::text[]
+   ORDER BY a.verified_at DESC LIMIT 1;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','return_recovery_adapter_not_ready','interfaceVersion',1); END IF;
+
+  v_key:='supplier-return:'||p_order_id::text||':'||p_fulfilment_leg_id::text||':'||p_idempotency_key;
+  SELECT * INTO v_case FROM private.supplier_return_cases WHERE idempotency_key=BTRIM(p_idempotency_key) FOR UPDATE;
+  IF FOUND THEN
+    IF v_case.order_id<>p_order_id OR v_case.fulfilment_leg_id<>p_fulfilment_leg_id
+       OR v_case.reason_code<>BTRIM(p_reason_code) OR v_case.requested_quantity<>p_quantity
+       OR v_case.correlation_id<>p_correlation_id THEN
+      RAISE EXCEPTION 'supplier return idempotency collision with different request';
+    END IF;
+  ELSE
+    INSERT INTO private.supplier_return_cases(
+      return_key,order_id,orchestration_id,fulfilment_leg_id,handshake_id,shipment_id,supplier_id,supplier_offer_id,
+      external_supplier_order_ref,reason_code,requested_quantity,idempotency_key,correlation_id,evidence
+    ) VALUES(
+      v_key,p_order_id,v_h.orchestration_id,p_fulfilment_leg_id,v_h.id,v_ship.id,v_h.supplier_id,v_h.supplier_offer_id,
+      v_h.external_supplier_order_ref,BTRIM(p_reason_code),p_quantity,BTRIM(p_idempotency_key),p_correlation_id,
+      jsonb_build_object('shipmentStatus',v_ship.canonical_status,'createdBy','server_prepare_supplier_return_v1')
+    ) RETURNING * INTO v_case;
+    INSERT INTO private.supplier_return_recovery_events(return_case_id,event_key,event_type,state,evidence)
+    VALUES(v_case.id,'return-requested:'||v_case.id::text,'return_requested',v_case.state,'{}'::jsonb)
+    ON CONFLICT(event_key) DO NOTHING;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'eligible',true,'reason','supplier_return_ready','returnCaseId',v_case.id,'orderId',v_case.order_id,
+    'fulfilmentLegId',v_case.fulfilment_leg_id,'supplierId',v_case.supplier_id,'supplierKey',v_supplier.supplier_key,
+    'providerKey',v_adapter.provider_key,'adapterVersion',v_adapter.adapter_version,
+    'supplierOrderRef',v_case.external_supplier_order_ref,'reasonCode',v_case.reason_code,'quantity',v_case.requested_quantity,
+    'idempotencyKey',v_case.idempotency_key,'correlationId',v_case.correlation_id,'state',v_case.state,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_prepare_supplier_return_v1(uuid,uuid,text,integer,text,uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_prepare_supplier_return_v1(uuid,uuid,text,integer,text,uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_record_supplier_return_authorisation_v1(
+  p_return_case_id uuid,p_external_return_ref text,p_authorised boolean,p_evidence jsonb
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_case private.supplier_return_cases%ROWTYPE;
+BEGIN
+  IF p_authorised AND NULLIF(BTRIM(p_external_return_ref),'') IS NULL THEN RAISE EXCEPTION 'authorised supplier return requires external return reference'; END IF;
+  SELECT * INTO v_case FROM private.supplier_return_cases WHERE id=p_return_case_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','return_case_not_found','interfaceVersion',1); END IF;
+  IF v_case.external_return_ref IS NOT NULL AND p_external_return_ref IS NOT NULL AND v_case.external_return_ref<>BTRIM(p_external_return_ref) THEN
+    RAISE EXCEPTION 'external supplier return reference cannot change';
+  END IF;
+  UPDATE private.supplier_return_cases SET
+    external_return_ref=COALESCE(external_return_ref,NULLIF(BTRIM(p_external_return_ref),'')),
+    state=CASE WHEN p_authorised THEN 'authorised' ELSE 'cancelled' END,
+    authorised_at=CASE WHEN p_authorised THEN COALESCE(authorised_at,now()) ELSE authorised_at END,
+    updated_at=now(),evidence=evidence||COALESCE(p_evidence,'{}'::jsonb)
+  WHERE id=v_case.id RETURNING * INTO v_case;
+  INSERT INTO private.supplier_return_recovery_events(return_case_id,event_key,event_type,state,external_ref,evidence)
+  VALUES(v_case.id,'return-authorisation:'||v_case.id::text,'return_authorised',v_case.state,v_case.external_return_ref,COALESCE(p_evidence,'{}'::jsonb))
+  ON CONFLICT(event_key) DO NOTHING;
+  RETURN jsonb_build_object('ok',true,'returnCaseId',v_case.id,'state',v_case.state,'externalReturnRef',v_case.external_return_ref,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_record_supplier_return_authorisation_v1(uuid,text,boolean,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_record_supplier_return_authorisation_v1(uuid,text,boolean,jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_record_customer_refund_evidence_v1(
+  p_return_case_id uuid,p_event_key text,p_provider text,p_external_refund_ref text,p_payment_ref text,
+  p_amount numeric,p_currency text,p_state text,p_occurred_at timestamptz,p_evidence jsonb
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_case private.supplier_return_cases%ROWTYPE; v_leg private.supplier_fulfilment_legs%ROWTYPE; v_ref private.supplier_customer_refund_evidence%ROWTYPE; v_total numeric; v_order_total numeric;
+BEGIN
+  IF NULLIF(BTRIM(p_event_key),'') IS NULL OR NULLIF(BTRIM(p_provider),'') IS NULL OR NULLIF(BTRIM(p_external_refund_ref),'') IS NULL
+     OR p_amount IS NULL OR p_amount<=0 OR upper(BTRIM(COALESCE(p_currency,''))) !~ '^[A-Z]{3}$'
+     OR p_state NOT IN ('pending','partial','succeeded','failed') OR p_occurred_at IS NULL OR jsonb_typeof(COALESCE(p_evidence,'{}'::jsonb))<>'object' THEN
+    RAISE EXCEPTION 'complete customer refund evidence is required';
+  END IF;
+  SELECT * INTO v_case FROM private.supplier_return_cases WHERE id=p_return_case_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','return_case_not_found','interfaceVersion',1); END IF;
+  SELECT * INTO v_leg FROM private.supplier_fulfilment_legs WHERE id=v_case.fulfilment_leg_id;
+  IF v_leg.currency IS NOT NULL AND upper(BTRIM(p_currency))<>v_leg.currency THEN RAISE EXCEPTION 'refund currency must match fulfilment leg currency'; END IF;
+  SELECT total INTO v_order_total FROM public.orders WHERE id=v_case.order_id;
+  SELECT COALESCE(SUM(amount),0) INTO v_total FROM private.supplier_customer_refund_evidence
+    WHERE order_id=v_case.order_id AND state IN ('partial','succeeded');
+  IF p_state IN ('partial','succeeded') AND v_total+p_amount>v_order_total THEN RAISE EXCEPTION 'cumulative customer refund exceeds customer order total'; END IF;
+
+  INSERT INTO private.supplier_customer_refund_evidence(event_key,return_case_id,order_id,provider,external_refund_ref,payment_ref,amount,currency,state,occurred_at,evidence)
+  VALUES(BTRIM(p_event_key),v_case.id,v_case.order_id,BTRIM(p_provider),BTRIM(p_external_refund_ref),NULLIF(BTRIM(p_payment_ref),''),p_amount,upper(BTRIM(p_currency)),p_state,p_occurred_at,p_evidence)
+  ON CONFLICT(event_key) DO NOTHING RETURNING * INTO v_ref;
+  IF v_ref.id IS NULL THEN SELECT * INTO v_ref FROM private.supplier_customer_refund_evidence WHERE event_key=BTRIM(p_event_key); END IF;
+  IF v_ref.return_case_id<>v_case.id OR v_ref.amount<>p_amount OR v_ref.currency<>upper(BTRIM(p_currency)) OR v_ref.state<>p_state THEN
+    RAISE EXCEPTION 'customer refund evidence idempotency collision';
+  END IF;
+
+  IF p_state IN ('partial','succeeded') THEN
+    INSERT INTO private.commerce_financial_ledger_entries(event_key,correlation_id,order_id,supplier_offer_id,commercial_mode,event_type,account_code,currency,signed_amount,external_ref,evidence,occurred_at)
+    VALUES('phase-l-refund:'||BTRIM(p_event_key),v_case.correlation_id,v_case.order_id,v_case.supplier_offer_id,v_case.commercial_mode,'customer_refund','customer_refund',v_ref.currency,-v_ref.amount,v_ref.external_refund_ref,
+      jsonb_build_object('returnCaseId',v_case.id,'refundEvidenceId',v_ref.id),v_ref.occurred_at)
+    ON CONFLICT(event_key) DO NOTHING;
+  END IF;
+  UPDATE private.supplier_return_cases SET customer_refund_state=p_state,updated_at=now() WHERE id=v_case.id;
+  INSERT INTO private.supplier_return_recovery_events(return_case_id,event_key,event_type,state,external_ref,evidence)
+  VALUES(v_case.id,'refund-recorded:'||v_ref.id::text,'refund_recorded',p_state,v_ref.external_refund_ref,jsonb_build_object('amount',v_ref.amount,'currency',v_ref.currency))
+  ON CONFLICT(event_key) DO NOTHING;
+  RETURN jsonb_build_object('ok',true,'refundEvidenceId',v_ref.id,'state',v_ref.state,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_record_customer_refund_evidence_v1(uuid,text,text,text,text,numeric,text,text,timestamptz,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_record_customer_refund_evidence_v1(uuid,text,text,text,text,numeric,text,text,timestamptz,jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_record_supplier_recovery_evidence_v1(
+  p_return_case_id uuid,p_event_key text,p_external_recovery_ref text,p_amount numeric,p_currency text,p_state text,p_occurred_at timestamptz,p_evidence jsonb
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_case private.supplier_return_cases%ROWTYPE; v_leg private.supplier_fulfilment_legs%ROWTYPE; v_rec private.supplier_recovery_evidence%ROWTYPE;
+BEGIN
+  IF NULLIF(BTRIM(p_event_key),'') IS NULL OR p_amount IS NULL OR p_amount<0 OR upper(BTRIM(COALESCE(p_currency,''))) !~ '^[A-Z]{3}$'
+     OR p_state NOT IN ('requested','pending','partial','recovered','failed','unrecoverable') OR p_occurred_at IS NULL
+     OR jsonb_typeof(COALESCE(p_evidence,'{}'::jsonb))<>'object' THEN RAISE EXCEPTION 'complete supplier recovery evidence is required'; END IF;
+  IF p_state IN ('partial','recovered') AND p_amount<=0 THEN RAISE EXCEPTION 'financial supplier recovery requires positive amount'; END IF;
+  SELECT * INTO v_case FROM private.supplier_return_cases WHERE id=p_return_case_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','return_case_not_found','interfaceVersion',1); END IF;
+  SELECT * INTO v_leg FROM private.supplier_fulfilment_legs WHERE id=v_case.fulfilment_leg_id;
+  IF v_leg.currency IS NOT NULL AND upper(BTRIM(p_currency))<>v_leg.currency THEN RAISE EXCEPTION 'recovery currency must match fulfilment leg currency'; END IF;
+
+  INSERT INTO private.supplier_recovery_evidence(event_key,return_case_id,order_id,supplier_id,external_recovery_ref,amount,currency,state,occurred_at,evidence)
+  VALUES(BTRIM(p_event_key),v_case.id,v_case.order_id,v_case.supplier_id,NULLIF(BTRIM(p_external_recovery_ref),''),p_amount,upper(BTRIM(p_currency)),p_state,p_occurred_at,p_evidence)
+  ON CONFLICT(event_key) DO NOTHING RETURNING * INTO v_rec;
+  IF v_rec.id IS NULL THEN SELECT * INTO v_rec FROM private.supplier_recovery_evidence WHERE event_key=BTRIM(p_event_key); END IF;
+  IF v_rec.return_case_id<>v_case.id OR v_rec.amount<>p_amount OR v_rec.currency<>upper(BTRIM(p_currency)) OR v_rec.state<>p_state THEN
+    RAISE EXCEPTION 'supplier recovery evidence idempotency collision';
+  END IF;
+
+  IF p_state IN ('partial','recovered') THEN
+    INSERT INTO private.commerce_financial_ledger_entries(event_key,correlation_id,order_id,supplier_offer_id,commercial_mode,event_type,account_code,currency,signed_amount,external_ref,evidence,occurred_at)
+    VALUES('phase-l-recovery:'||BTRIM(p_event_key),v_case.correlation_id,v_case.order_id,v_case.supplier_offer_id,v_case.commercial_mode,'supplier_recovery','supplier_recovery',v_rec.currency,v_rec.amount,v_rec.external_recovery_ref,
+      jsonb_build_object('returnCaseId',v_case.id,'recoveryEvidenceId',v_rec.id),v_rec.occurred_at)
+    ON CONFLICT(event_key) DO NOTHING;
+  END IF;
+  UPDATE private.supplier_return_cases SET supplier_recovery_state=p_state,updated_at=now() WHERE id=v_case.id;
+  INSERT INTO private.supplier_return_recovery_events(return_case_id,event_key,event_type,state,external_ref,evidence)
+  VALUES(v_case.id,'recovery-recorded:'||v_rec.id::text,'recovery_recorded',p_state,v_rec.external_recovery_ref,jsonb_build_object('amount',v_rec.amount,'currency',v_rec.currency))
+  ON CONFLICT(event_key) DO NOTHING;
+  RETURN jsonb_build_object('ok',true,'recoveryEvidenceId',v_rec.id,'state',v_rec.state,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_record_supplier_recovery_evidence_v1(uuid,text,text,numeric,text,text,timestamptz,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_record_supplier_recovery_evidence_v1(uuid,text,text,numeric,text,text,timestamptz,jsonb) TO service_role;

--- a/supabase/650_supplier_financial_reconciliation.sql
+++ b/supabase/650_supplier_financial_reconciliation.sql
@@ -1,0 +1,154 @@
+-- 650_supplier_financial_reconciliation.sql
+-- Phase L order-level financial reconciliation.
+-- order completed != financially reconciled.
+-- Reconciliation compares canonical payment evidence, ledger, supplier payable/payment,
+-- customer refunds, supplier recoveries, chargebacks and unrecovered loss.
+
+CREATE OR REPLACE FUNCTION public.server_reconcile_supplier_financials_v1(p_order_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_payment private.supplier_payment_evidence_snapshots%ROWTYPE;
+  v_currency text;
+  v_customer_payment numeric:=0;
+  v_ledger_customer_payment numeric:=0;
+  v_refunds numeric:=0;
+  v_ledger_refunds numeric:=0;
+  v_supplier_payable numeric:=0;
+  v_supplier_paid numeric:=0;
+  v_recoveries numeric:=0;
+  v_ledger_recoveries numeric:=0;
+  v_chargebacks numeric:=0;
+  v_unrecovered_ledger numeric:=0;
+  v_unrecovered numeric:=0;
+  v_has_unrecoverable boolean:=false;
+  v_state text;
+  v_evidence jsonb;
+  v_existing private.supplier_financial_reconciliations%ROWTYPE;
+BEGIN
+  SELECT * INTO v_payment FROM private.supplier_payment_evidence_snapshots WHERE order_id=p_order_id;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('reconciled',false,'state','EXCEPTION','reason','canonical_customer_payment_evidence_missing','interfaceVersion',1);
+  END IF;
+  v_currency:=v_payment.currency;
+  v_customer_payment:=v_payment.amount;
+
+  IF EXISTS(
+    SELECT 1 FROM private.commerce_financial_ledger_entries l
+    WHERE l.order_id=p_order_id AND l.currency<>v_currency
+      AND l.event_type IN ('customer_payment','supplier_payable','payout','customer_refund','supplier_recovery','chargeback','unrecovered_loss')
+  ) THEN
+    v_state:='EXCEPTION';
+    v_evidence:=jsonb_build_object('reason','financial_ledger_currency_mismatch');
+  ELSE
+    SELECT COALESCE(SUM(ABS(l.signed_amount)),0) INTO v_ledger_customer_payment
+      FROM private.commerce_financial_ledger_entries l WHERE l.order_id=p_order_id AND l.event_type='customer_payment' AND l.currency=v_currency;
+    SELECT COALESCE(SUM(r.amount),0) INTO v_refunds
+      FROM private.supplier_customer_refund_evidence r WHERE r.order_id=p_order_id AND r.currency=v_currency AND r.state IN ('partial','succeeded');
+    SELECT COALESCE(SUM(ABS(l.signed_amount)),0) INTO v_ledger_refunds
+      FROM private.commerce_financial_ledger_entries l WHERE l.order_id=p_order_id AND l.event_type='customer_refund' AND l.currency=v_currency;
+    SELECT COALESCE(SUM(ABS(l.signed_amount)),0) INTO v_supplier_payable
+      FROM private.commerce_financial_ledger_entries l WHERE l.order_id=p_order_id AND l.event_type='supplier_payable' AND l.currency=v_currency;
+    SELECT COALESCE(SUM(ABS(l.signed_amount)),0) INTO v_supplier_paid
+      FROM private.commerce_financial_ledger_entries l WHERE l.order_id=p_order_id AND l.event_type='payout' AND l.currency=v_currency;
+    SELECT COALESCE(SUM(r.amount),0) INTO v_recoveries
+      FROM private.supplier_recovery_evidence r WHERE r.order_id=p_order_id AND r.currency=v_currency AND r.state IN ('partial','recovered');
+    SELECT COALESCE(SUM(ABS(l.signed_amount)),0) INTO v_ledger_recoveries
+      FROM private.commerce_financial_ledger_entries l WHERE l.order_id=p_order_id AND l.event_type='supplier_recovery' AND l.currency=v_currency;
+    SELECT COALESCE(SUM(ABS(l.signed_amount)),0) INTO v_chargebacks
+      FROM private.commerce_financial_ledger_entries l WHERE l.order_id=p_order_id AND l.event_type='chargeback' AND l.currency=v_currency;
+    SELECT COALESCE(SUM(ABS(l.signed_amount)),0) INTO v_unrecovered_ledger
+      FROM private.commerce_financial_ledger_entries l WHERE l.order_id=p_order_id AND l.event_type='unrecovered_loss' AND l.currency=v_currency;
+    SELECT EXISTS(
+      SELECT 1 FROM private.supplier_return_cases c WHERE c.order_id=p_order_id AND c.supplier_recovery_state='unrecoverable'
+    ) INTO v_has_unrecoverable;
+
+    v_unrecovered:=CASE WHEN v_has_unrecoverable THEN GREATEST(v_refunds-v_recoveries,0) ELSE v_unrecovered_ledger END;
+
+    IF v_ledger_customer_payment<>v_customer_payment
+       OR v_ledger_refunds<>v_refunds
+       OR v_ledger_recoveries<>v_recoveries THEN
+      v_state:='EXCEPTION';
+    ELSIF v_has_unrecoverable AND v_refunds>v_recoveries THEN
+      v_state:='UNRECOVERED';
+    ELSIF v_supplier_payable<>v_supplier_paid OR v_refunds<>v_recoveries OR v_unrecovered_ledger<>v_unrecovered THEN
+      v_state:='PARTIALLY_RECONCILED';
+    ELSE
+      v_state:='RECONCILED';
+    END IF;
+
+    v_evidence:=jsonb_build_object(
+      'paymentEvidenceId',v_payment.id,'paymentIntentRef',v_payment.payment_intent_ref,
+      'customerPayment',v_customer_payment,'ledgerCustomerPayment',v_ledger_customer_payment,
+      'customerRefunds',v_refunds,'ledgerCustomerRefunds',v_ledger_refunds,
+      'supplierPayable',v_supplier_payable,'supplierPaid',v_supplier_paid,
+      'supplierRecoveries',v_recoveries,'ledgerSupplierRecoveries',v_ledger_recoveries,
+      'chargebacks',v_chargebacks,'unrecoveredLoss',v_unrecovered,'ledgerUnrecoveredLoss',v_unrecovered_ledger
+    );
+  END IF;
+
+  INSERT INTO private.supplier_financial_reconciliations(
+    order_id,state,currency,customer_payment,ledger_customer_payment,customer_refunds,ledger_customer_refunds,
+    supplier_payable,supplier_paid,supplier_recoveries,ledger_supplier_recoveries,chargebacks,unrecovered_loss,evidence,evaluated_at
+  ) VALUES(
+    p_order_id,v_state,v_currency,v_customer_payment,v_ledger_customer_payment,v_refunds,v_ledger_refunds,
+    v_supplier_payable,v_supplier_paid,v_recoveries,v_ledger_recoveries,v_chargebacks,v_unrecovered,v_evidence,now()
+  ) ON CONFLICT(order_id) DO UPDATE SET
+    state=EXCLUDED.state,currency=EXCLUDED.currency,customer_payment=EXCLUDED.customer_payment,
+    ledger_customer_payment=EXCLUDED.ledger_customer_payment,customer_refunds=EXCLUDED.customer_refunds,
+    ledger_customer_refunds=EXCLUDED.ledger_customer_refunds,supplier_payable=EXCLUDED.supplier_payable,
+    supplier_paid=EXCLUDED.supplier_paid,supplier_recoveries=EXCLUDED.supplier_recoveries,
+    ledger_supplier_recoveries=EXCLUDED.ledger_supplier_recoveries,chargebacks=EXCLUDED.chargebacks,
+    unrecovered_loss=EXCLUDED.unrecovered_loss,evidence=EXCLUDED.evidence,evaluated_at=now()
+  RETURNING * INTO v_existing;
+
+  INSERT INTO private.supplier_return_recovery_events(return_case_id,event_key,event_type,state,evidence)
+  SELECT c.id,'reconciliation:'||c.id::text||':'||md5(v_existing.evidence::text||v_existing.state),
+    'reconciliation_evaluated',v_existing.state,jsonb_build_object('reconciliationId',v_existing.id)
+  FROM private.supplier_return_cases c WHERE c.order_id=p_order_id
+  ON CONFLICT(event_key) DO NOTHING;
+
+  RETURN jsonb_build_object(
+    'reconciled',v_state='RECONCILED','state',v_state,'orderId',p_order_id,'currency',v_currency,
+    'customerPayment',v_customer_payment,'ledgerCustomerPayment',v_ledger_customer_payment,
+    'customerRefunds',v_refunds,'supplierRecoveries',v_recoveries,'chargebacks',v_chargebacks,
+    'unrecoveredLoss',v_unrecovered,'evidence',v_evidence,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_reconcile_supplier_financials_v1(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_reconcile_supplier_financials_v1(uuid) TO service_role;
+
+-- Phase K deliberately deferred money-movement exception classes. Phase L now owns them.
+ALTER TABLE private.supplier_order_exceptions DROP CONSTRAINT IF EXISTS supplier_order_exception_type_check;
+ALTER TABLE private.supplier_order_exceptions ADD CONSTRAINT supplier_order_exception_type_check CHECK (exception_type IN (
+  'supplier_timeout','accepted_response_lost','duplicate_submit','duplicate_acknowledgement','stock_disappeared','price_changed',
+  'api_unavailable','partial_fulfilment','partial_shipment','delayed_dispatch','no_tracking','lost_shipment',
+  'supplier_cancellation','buyer_cancellation','supplier_suspended_mid_order','tracking_exception','failed_delivery',
+  'return','refund','partial_refund','chargeback','reimbursement_failure','financial_reconciliation_mismatch'
+));
+
+CREATE OR REPLACE FUNCTION public.server_open_supplier_financial_exception_v1(p_order_id uuid,p_exception_type text,p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_o private.supplier_order_orchestrations%ROWTYPE; v_c private.supplier_return_cases%ROWTYPE; v_key text;
+BEGIN
+  IF p_exception_type NOT IN ('refund','partial_refund','chargeback','reimbursement_failure','financial_reconciliation_mismatch')
+     OR NULLIF(BTRIM(p_reason),'') IS NULL THEN RAISE EXCEPTION 'invalid Phase L financial exception'; END IF;
+  SELECT * INTO v_o FROM private.supplier_order_orchestrations WHERE order_id=p_order_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','orchestration_not_found','interfaceVersion',1); END IF;
+  SELECT * INTO v_c FROM private.supplier_return_cases WHERE order_id=p_order_id ORDER BY requested_at DESC LIMIT 1;
+  v_key:='phase-l:'||p_exception_type||':'||p_order_id::text;
+  INSERT INTO private.supplier_order_exceptions(
+    order_id,orchestration_id,fulfilment_leg_id,handshake_id,shipment_id,exception_key,exception_type,state,owner_type,
+    next_action,customer_impact,financial_impact,metadata
+  ) VALUES(
+    p_order_id,v_o.id,v_c.fulfilment_leg_id,v_c.handshake_id,v_c.shipment_id,v_key,p_exception_type,'open','finance',
+    'reconcile canonical payment, refund and supplier recovery evidence','buyer financial outcome may be unresolved',
+    'platform contribution or recoverability is unresolved',jsonb_build_object('reason',BTRIM(p_reason))
+  ) ON CONFLICT(exception_key) DO NOTHING;
+  RETURN jsonb_build_object('ok',true,'exceptionKey',v_key,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_open_supplier_financial_exception_v1(uuid,text,text) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_open_supplier_financial_exception_v1(uuid,text,text) TO service_role;
+
+COMMENT ON FUNCTION public.server_reconcile_supplier_financials_v1(uuid) IS 'Phase L canonical reconciliation. Customer-order completion is not treated as financial reconciliation.';

--- a/supabase/651_supplier_returns_recovery_closure.sql
+++ b/supabase/651_supplier_returns_recovery_closure.sql
@@ -1,0 +1,107 @@
+-- 651_supplier_returns_recovery_closure.sql
+-- Phase L Branch Guard closure: immutable return identity, fail-closed recovery context and active-admin visibility.
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_return_case_identity_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  IF NEW.return_key IS DISTINCT FROM OLD.return_key OR NEW.order_id IS DISTINCT FROM OLD.order_id
+     OR NEW.orchestration_id IS DISTINCT FROM OLD.orchestration_id OR NEW.fulfilment_leg_id IS DISTINCT FROM OLD.fulfilment_leg_id
+     OR NEW.handshake_id IS DISTINCT FROM OLD.handshake_id OR NEW.shipment_id IS DISTINCT FROM OLD.shipment_id
+     OR NEW.supplier_id IS DISTINCT FROM OLD.supplier_id OR NEW.supplier_offer_id IS DISTINCT FROM OLD.supplier_offer_id
+     OR NEW.commercial_mode IS DISTINCT FROM OLD.commercial_mode OR NEW.external_supplier_order_ref IS DISTINCT FROM OLD.external_supplier_order_ref
+     OR NEW.reason_code IS DISTINCT FROM OLD.reason_code OR NEW.requested_quantity IS DISTINCT FROM OLD.requested_quantity
+     OR NEW.idempotency_key IS DISTINCT FROM OLD.idempotency_key OR NEW.correlation_id IS DISTINCT FROM OLD.correlation_id THEN
+    RAISE EXCEPTION 'supplier return case identity is immutable';
+  END IF;
+  IF OLD.external_return_ref IS NOT NULL AND NEW.external_return_ref IS DISTINCT FROM OLD.external_return_ref THEN
+    RAISE EXCEPTION 'external supplier return reference is immutable once known';
+  END IF;
+  IF OLD.state IN ('closed','cancelled') AND NEW.state IS DISTINCT FROM OLD.state THEN
+    RAISE EXCEPTION 'terminal supplier return case cannot regress';
+  END IF;
+  IF OLD.customer_refund_state='succeeded' AND NEW.customer_refund_state<>'succeeded' THEN
+    RAISE EXCEPTION 'successful customer refund truth cannot regress';
+  END IF;
+  IF OLD.supplier_recovery_state IN ('recovered','unrecoverable') AND NEW.supplier_recovery_state IS DISTINCT FROM OLD.supplier_recovery_state THEN
+    RAISE EXCEPTION 'terminal supplier recovery truth cannot regress';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_return_case_identity_v1 ON private.supplier_return_cases;
+CREATE TRIGGER trg_guard_supplier_return_case_identity_v1
+BEFORE UPDATE ON private.supplier_return_cases
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_return_case_identity_v1();
+
+CREATE OR REPLACE FUNCTION public.server_supplier_recovery_context_v1(p_return_case_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_case private.supplier_return_cases%ROWTYPE;
+  v_supplier private.supplier_foundation_suppliers%ROWTYPE;
+  v_h private.supplier_order_handshakes%ROWTYPE;
+  v_leg private.supplier_fulfilment_legs%ROWTYPE;
+  v_adapter private.supplier_adapter_registrations%ROWTYPE;
+  v_control jsonb;
+BEGIN
+  SELECT * INTO v_case FROM private.supplier_return_cases WHERE id=p_return_case_id;
+  IF NOT FOUND OR v_case.state NOT IN ('authorised','in_transit','received','closed') OR v_case.external_return_ref IS NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','supplier_return_not_authorised','interfaceVersion',1);
+  END IF;
+  SELECT * INTO v_h FROM private.supplier_order_handshakes WHERE id=v_case.handshake_id;
+  IF NOT FOUND OR v_h.state<>'reconciled' OR v_h.external_supplier_order_ref IS NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','supplier_order_not_reconciled','interfaceVersion',1);
+  END IF;
+  SELECT * INTO v_leg FROM private.supplier_fulfilment_legs WHERE id=v_case.fulfilment_leg_id;
+  IF NOT FOUND OR v_leg.currency IS NULL THEN
+    RETURN jsonb_build_object('eligible',false,'reason','recovery_currency_unknown','interfaceVersion',1);
+  END IF;
+  -- Phase G commercial economics is currently GB-only. Automated adapter minor-unit
+  -- conversion is therefore deliberately enabled only for GBP (2 decimal places).
+  IF v_leg.currency<>'GBP' THEN
+    RETURN jsonb_build_object('eligible',false,'reason','automated_recovery_currency_not_enabled','currency',v_leg.currency,'interfaceVersion',1);
+  END IF;
+  v_control:=public.server_supplier_commerce_control_decision_v1('return_recovery',jsonb_build_object(
+    'supplierRef',v_case.supplier_id::text,'offerRef',v_case.supplier_offer_id::text,'territory','GB'
+  ));
+  IF COALESCE((v_control->>'enabled')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('eligible',false,'reason','return_recovery_control_disabled','control',v_control,'interfaceVersion',1);
+  END IF;
+  SELECT * INTO v_supplier FROM private.supplier_foundation_suppliers WHERE id=v_case.supplier_id AND lifecycle_status='approved';
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','supplier_not_approved','interfaceVersion',1); END IF;
+  SELECT * INTO v_adapter FROM private.supplier_adapter_registrations a
+   WHERE a.supplier_id=v_case.supplier_id AND a.status='active' AND a.interface_version=1
+     AND a.provider_key=v_h.provider_key AND a.adapter_version=v_h.adapter_version
+     AND a.capabilities @> ARRAY['reimbursement']::text[]
+   ORDER BY a.verified_at DESC LIMIT 1;
+  IF NOT FOUND THEN RETURN jsonb_build_object('eligible',false,'reason','reimbursement_adapter_not_ready','interfaceVersion',1); END IF;
+  RETURN jsonb_build_object(
+    'eligible',true,'reason','supplier_recovery_ready','returnCaseId',v_case.id,'orderId',v_case.order_id,
+    'supplierId',v_case.supplier_id,'supplierKey',v_supplier.supplier_key,'providerKey',v_adapter.provider_key,
+    'adapterVersion',v_adapter.adapter_version,'supplierOrderRef',v_case.external_supplier_order_ref,
+    'externalReturnRef',v_case.external_return_ref,'currency',v_leg.currency,'currencyMinorUnitExponent',2,
+    'correlationId',v_case.correlation_id,'idempotencyKey',v_case.idempotency_key,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_supplier_recovery_context_v1(uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_recovery_context_v1(uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_supplier_return_financial_status_v1(p_actor_id uuid,p_order_id uuid DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+BEGIN
+  IF NOT EXISTS(SELECT 1 FROM public.users u WHERE u.id=p_actor_id AND u.role='admin' AND u."isActive"=true) THEN
+    RAISE EXCEPTION 'active admin authority is required' USING ERRCODE='42501';
+  END IF;
+  RETURN jsonb_build_object(
+    'returns',(SELECT COALESCE(jsonb_agg(to_jsonb(c) ORDER BY c.updated_at DESC),'[]'::jsonb) FROM private.supplier_return_cases c WHERE p_order_id IS NULL OR c.order_id=p_order_id),
+    'refunds',(SELECT COALESCE(jsonb_agg(to_jsonb(r) ORDER BY r.recorded_at DESC),'[]'::jsonb) FROM private.supplier_customer_refund_evidence r WHERE p_order_id IS NULL OR r.order_id=p_order_id),
+    'recoveries',(SELECT COALESCE(jsonb_agg(to_jsonb(r) ORDER BY r.recorded_at DESC),'[]'::jsonb) FROM private.supplier_recovery_evidence r WHERE p_order_id IS NULL OR r.order_id=p_order_id),
+    'reconciliation',(SELECT COALESCE(jsonb_agg(to_jsonb(x) ORDER BY x.evaluated_at DESC),'[]'::jsonb) FROM private.supplier_financial_reconciliations x WHERE p_order_id IS NULL OR x.order_id=p_order_id),
+    'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_supplier_return_financial_status_v1(uuid,uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_supplier_return_financial_status_v1(uuid,uuid) TO service_role;
+
+COMMENT ON FUNCTION public.server_supplier_recovery_context_v1(uuid) IS 'Phase L reimbursement context. Automated minor-unit conversion is fail-closed outside currently enabled GBP economics.';

--- a/supabase/652_supplier_refund_idempotency_closure.sql
+++ b/supabase/652_supplier_refund_idempotency_closure.sql
@@ -1,0 +1,57 @@
+-- 652_supplier_refund_idempotency_closure.sql
+-- Phase L Branch Guard closure: exact refund-evidence replays must not be counted twice
+-- by the cumulative over-refund guard before idempotency resolution.
+
+CREATE OR REPLACE FUNCTION public.server_record_customer_refund_evidence_v1(
+  p_return_case_id uuid,p_event_key text,p_provider text,p_external_refund_ref text,p_payment_ref text,
+  p_amount numeric,p_currency text,p_state text,p_occurred_at timestamptz,p_evidence jsonb
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_case private.supplier_return_cases%ROWTYPE; v_leg private.supplier_fulfilment_legs%ROWTYPE; v_ref private.supplier_customer_refund_evidence%ROWTYPE; v_total numeric; v_order_total numeric;
+BEGIN
+  IF NULLIF(BTRIM(p_event_key),'') IS NULL OR NULLIF(BTRIM(p_provider),'') IS NULL OR NULLIF(BTRIM(p_external_refund_ref),'') IS NULL
+     OR p_amount IS NULL OR p_amount<=0 OR upper(BTRIM(COALESCE(p_currency,''))) !~ '^[A-Z]{3}$'
+     OR p_state NOT IN ('pending','partial','succeeded','failed') OR p_occurred_at IS NULL OR jsonb_typeof(COALESCE(p_evidence,'{}'::jsonb))<>'object' THEN
+    RAISE EXCEPTION 'complete customer refund evidence is required';
+  END IF;
+  SELECT * INTO v_case FROM private.supplier_return_cases WHERE id=p_return_case_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','return_case_not_found','interfaceVersion',1); END IF;
+  SELECT * INTO v_leg FROM private.supplier_fulfilment_legs WHERE id=v_case.fulfilment_leg_id;
+  IF v_leg.currency IS NOT NULL AND upper(BTRIM(p_currency))<>v_leg.currency THEN RAISE EXCEPTION 'refund currency must match fulfilment leg currency'; END IF;
+
+  -- Resolve an exact replay before cumulative limits. A replay is safe only when
+  -- immutable financial identity matches the original evidence exactly.
+  SELECT * INTO v_ref FROM private.supplier_customer_refund_evidence WHERE event_key=BTRIM(p_event_key);
+  IF FOUND THEN
+    IF v_ref.return_case_id<>v_case.id OR v_ref.provider<>BTRIM(p_provider)
+       OR v_ref.external_refund_ref<>BTRIM(p_external_refund_ref) OR v_ref.amount<>p_amount
+       OR v_ref.currency<>upper(BTRIM(p_currency)) OR v_ref.state<>p_state THEN
+      RAISE EXCEPTION 'customer refund evidence idempotency collision';
+    END IF;
+    RETURN jsonb_build_object('ok',true,'refundEvidenceId',v_ref.id,'state',v_ref.state,'replayed',true,'interfaceVersion',1);
+  END IF;
+
+  SELECT total INTO v_order_total FROM public.orders WHERE id=v_case.order_id;
+  SELECT COALESCE(SUM(amount),0) INTO v_total FROM private.supplier_customer_refund_evidence
+    WHERE order_id=v_case.order_id AND state IN ('partial','succeeded');
+  IF p_state IN ('partial','succeeded') AND v_total+p_amount>v_order_total THEN RAISE EXCEPTION 'cumulative customer refund exceeds customer order total'; END IF;
+
+  INSERT INTO private.supplier_customer_refund_evidence(event_key,return_case_id,order_id,provider,external_refund_ref,payment_ref,amount,currency,state,occurred_at,evidence)
+  VALUES(BTRIM(p_event_key),v_case.id,v_case.order_id,BTRIM(p_provider),BTRIM(p_external_refund_ref),NULLIF(BTRIM(p_payment_ref),''),p_amount,upper(BTRIM(p_currency)),p_state,p_occurred_at,p_evidence)
+  RETURNING * INTO v_ref;
+
+  IF p_state IN ('partial','succeeded') THEN
+    INSERT INTO private.commerce_financial_ledger_entries(event_key,correlation_id,order_id,supplier_offer_id,commercial_mode,event_type,account_code,currency,signed_amount,external_ref,evidence,occurred_at)
+    VALUES('phase-l-refund:'||BTRIM(p_event_key),v_case.correlation_id,v_case.order_id,v_case.supplier_offer_id,v_case.commercial_mode,'customer_refund','customer_refund',v_ref.currency,-v_ref.amount,v_ref.external_refund_ref,
+      jsonb_build_object('returnCaseId',v_case.id,'refundEvidenceId',v_ref.id),v_ref.occurred_at)
+    ON CONFLICT(event_key) DO NOTHING;
+  END IF;
+  UPDATE private.supplier_return_cases SET customer_refund_state=p_state,updated_at=now() WHERE id=v_case.id;
+  INSERT INTO private.supplier_return_recovery_events(return_case_id,event_key,event_type,state,external_ref,evidence)
+  VALUES(v_case.id,'refund-recorded:'||v_ref.id::text,'refund_recorded',p_state,v_ref.external_refund_ref,jsonb_build_object('amount',v_ref.amount,'currency',v_ref.currency))
+  ON CONFLICT(event_key) DO NOTHING;
+  RETURN jsonb_build_object('ok',true,'refundEvidenceId',v_ref.id,'state',v_ref.state,'replayed',false,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_record_customer_refund_evidence_v1(uuid,text,text,text,text,numeric,text,text,timestamptz,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_record_customer_refund_evidence_v1(uuid,text,text,text,text,numeric,text,text,timestamptz,jsonb) TO service_role;

--- a/supabase/653_supplier_return_quantity_closure.sql
+++ b/supabase/653_supplier_return_quantity_closure.sql
@@ -1,0 +1,30 @@
+-- 653_supplier_return_quantity_closure.sql
+-- Phase L Branch Guard closure: multiple idempotent return cases may not cumulatively
+-- claim more units than the canonical fulfilment leg contains.
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_return_quantity_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+DECLARE v_leg_quantity integer; v_existing_quantity integer;
+BEGIN
+  -- Serialize return-case creation per fulfilment leg so concurrent requests cannot over-return.
+  PERFORM 1 FROM private.supplier_fulfilment_legs l WHERE l.id=NEW.fulfilment_leg_id FOR UPDATE;
+  IF NOT FOUND THEN RAISE EXCEPTION 'supplier return fulfilment leg missing'; END IF;
+
+  SELECT COALESCE(SUM(i.quantity),0)::integer INTO v_leg_quantity
+    FROM private.supplier_fulfilment_leg_items i WHERE i.leg_id=NEW.fulfilment_leg_id;
+  SELECT COALESCE(SUM(c.requested_quantity),0)::integer INTO v_existing_quantity
+    FROM private.supplier_return_cases c
+   WHERE c.fulfilment_leg_id=NEW.fulfilment_leg_id AND c.state<>'cancelled';
+
+  IF NEW.requested_quantity<=0 OR v_existing_quantity+NEW.requested_quantity>v_leg_quantity THEN
+    RAISE EXCEPTION 'cumulative supplier return quantity exceeds fulfilment leg quantity';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_return_quantity_v1 ON private.supplier_return_cases;
+CREATE TRIGGER trg_guard_supplier_return_quantity_v1
+BEFORE INSERT ON private.supplier_return_cases
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_return_quantity_v1();
+
+COMMENT ON FUNCTION private.guard_supplier_return_quantity_v1() IS 'Serializes supplier return creation per leg and prevents duplicate/multiple return cases from over-returning canonical ordered quantity.';


### PR DESCRIPTION
Phase L canonical Supplier Commerce implementation.

PowerShell Branch Guard evidence on exact head df4bf06b5373a4bd52920fff358d2b7a936b8d29:
- Phase L dedicated tests: PASS
- upstream Phase C–K Supplier Commerce tests: PASS
- TypeScript: PASS
- ESLint: PASS
- production build: PASS
- full suite remains on the known baseline family; no new Phase L failing family

Scope:
- governed supplier return cases and adapter capability boundary
- customer refund evidence kept separate from supplier recovery evidence
- append-only financial ledger integration for customer_refund, supplier_recovery and unrecovered_loss
- idempotency collision protection for refunds/recoveries
- cumulative return quantity guard
- active-admin reconciliation/status boundary
- no unrelated visual Workspace/Super Admin changes
- no Supplier Commerce control enabled