### PR TITLE
Phase N: supplier simulator + recovery/replay validation

### DIFF
--- a/netlify/functions/__tests__/supplier-simulator-admin.test.ts
+++ b/netlify/functions/__tests__/supplier-simulator-admin.test.ts
@@ -1,0 +1,39 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const source = readFileSync(resolve(process.cwd(), 'netlify/functions/admin-supplier-simulator.ts'), 'utf8');
+
+describe('Phase N supplier simulator admin boundary', () => {
+  it('requires active admin authentication', () => {
+    expect(source).toContain("authenticateActiveAccount(event, admin, ['admin'])");
+  });
+
+  it('supports the complete evidence lifecycle', () => {
+    for (const action of ['start','record_check','record_replay','complete','status']) expect(source).toContain(`'${action}'`);
+  });
+
+  it('records through reviewed server RPC boundaries only', () => {
+    for (const rpc of [
+      'server_admin_start_supplier_simulator_run_v1','server_record_supplier_simulator_check_v1',
+      'server_record_supplier_replay_validation_v1','server_admin_complete_supplier_simulator_run_v1',
+      'server_admin_supplier_simulator_status_v1',
+    ]) expect(source).toContain(rpc);
+  });
+
+  it('rejects secret-bearing simulator evidence', () => {
+    expect(source).toContain('containsSecretMaterial');
+    expect(source).toContain('Raw credentials or secrets are forbidden in simulator evidence');
+  });
+
+  it('does not expose supplier-provider calls or payment mutation', () => {
+    expect(source).not.toContain('submitOrder(');
+    expect(source).not.toContain('stripe.refunds');
+    expect(source).not.toContain('UPDATE public.orders');
+  });
+
+  it('does not redesign Workspace or Super Admin UI', () => {
+    expect(source).not.toContain('Workspace');
+    expect(source).not.toContain('SuperAdmin');
+  });
+});

--- a/netlify/functions/__tests__/supplier-simulator-full-replay-gate.test.ts
+++ b/netlify/functions/__tests__/supplier-simulator-full-replay-gate.test.ts
@@ -6,7 +6,10 @@ const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8'
 const fullGate = repo('supabase/662_supplier_simulator_full_replay_gate.sql');
 const controlFoundation = repo('supabase/616_supplier_commerce_platform_control_foundations.sql');
 const governance = repo('supabase/657_supplier_control_centre_closure.sql');
-const contract = repo('docs/canonical/loadify-supplier-commerce-2026-08-19/03_CANONICAL_EXECUTION_CONTRACT_LINES_1251_1750.md');
+const contract = [
+  repo('docs/canonical/loadify-supplier-commerce-2026-08-19/03_CANONICAL_EXECUTION_CONTRACT_LINES_1251_1750.md'),
+  repo('docs/canonical/loadify-supplier-commerce-2026-08-19/04_CANONICAL_EXECUTION_CONTRACT_LINES_1751_2210.md'),
+].join('\n');
 
 describe('Phase N full recovery/replay no-fake-pass gate', () => {
   it('requires the complete canonical simulator scenario set before PASS', () => {

--- a/netlify/functions/__tests__/supplier-simulator-full-replay-gate.test.ts
+++ b/netlify/functions/__tests__/supplier-simulator-full-replay-gate.test.ts
@@ -1,0 +1,76 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const fullGate = repo('supabase/662_supplier_simulator_full_replay_gate.sql');
+const controlFoundation = repo('supabase/616_supplier_commerce_platform_control_foundations.sql');
+const governance = repo('supabase/657_supplier_control_centre_closure.sql');
+const contract = repo('docs/canonical/loadify-supplier-commerce-2026-08-19/03_CANONICAL_EXECUTION_CONTRACT_LINES_1251_1750.md');
+
+describe('Phase N full recovery/replay no-fake-pass gate', () => {
+  it('requires the complete canonical simulator scenario set before PASS', () => {
+    for (const check of [
+      'stock_available','stock_zero','price_change','timeout','provider_500','duplicate_acknowledgement',
+      'lost_response_after_accept','partial_fulfilment','tracking','tracking_replay','dispatch','delivery',
+      'lost_shipment','cancellation','return','refund','reimbursement','kill_switch','idempotency_collision',
+    ]) expect(fullGate).toContain(`'${check}'`);
+  });
+
+  it('requires the complete recovery/replay classes from the disaster-recovery contract', () => {
+    for (const phrase of ['event replay','webhook replay','failed job replay','sync reprocessing','reconciliation reprocessing','rebuilding derived state']) {
+      expect(contract.toLowerCase()).toContain(phrase);
+    }
+    for (const replayClass of ['event','webhook','failed_job','sync','reconciliation','derived_state']) {
+      expect(fullGate).toContain(`'${replayClass}'`);
+    }
+  });
+
+  it('requires exact replay fingerprints for canonical duplicate events', () => {
+    expect(fullGate).toContain("e.result='exact_replay' AND e.first_fingerprint=e.replay_fingerprint");
+    expect(fullGate).toContain("count(DISTINCT e.replay_class)=8");
+  });
+
+  it('requires accepted-but-response-lost recovery under unchanged canonical evidence', () => {
+    expect(fullGate).toContain("e.replay_class='supplier_submit' AND e.result='recovered'");
+    expect(fullGate).toContain('e.first_fingerprint=e.replay_fingerprint');
+    expect(fullGate).toContain('lost_response_recovery_not_proven');
+  });
+
+  it('requires changed evidence under an idempotency key to be blocked', () => {
+    expect(fullGate).toContain("e.result='blocked_collision' AND e.first_fingerprint<>e.replay_fingerprint");
+    expect(fullGate).toContain('idempotency_collision_block_not_proven');
+  });
+
+  it('requires failed-job recovery and derived-state rebuild evidence', () => {
+    expect(fullGate).toContain("e.replay_class='failed_job' AND e.result='recovered'");
+    expect(fullGate).toContain("e.replay_class='derived_state' AND e.result='recovered'");
+    expect(fullGate).toContain('failed_job_replay_not_proven');
+    expect(fullGate).toContain('derived_state_rebuild_not_proven');
+  });
+
+  it('validates kill-switch behavior against the existing canonical server control plane', () => {
+    expect(controlFoundation).toContain('server_supplier_commerce_control_decision_v1');
+    expect(controlFoundation).toContain('scoped_kill_switch');
+    expect(governance).toContain('supplier_kill_switch_active');
+    expect(governance).toContain('provider_kill_switch_active');
+    expect(fullGate).toContain("'kill_switch'");
+  });
+
+  it('does not enable commerce as part of simulator validation', () => {
+    expect(fullGate).not.toContain('enabled=true');
+    expect(fullGate).not.toContain('enabled = true');
+  });
+
+  it('does not turn simulator evidence into a backup/restore PASS claim', () => {
+    expect(contract).toContain('BACKUP EXISTS');
+    expect(contract).toContain('RESTORE PASS');
+    expect(fullGate).toContain("'backupRestorePassClaimed',false");
+  });
+
+  it('keeps Simulator PASS distinct from Pilot PASS', () => {
+    expect(contract).toContain('SIMULATOR PASS');
+    expect(contract).toContain('≠ PILOT PASS');
+    expect(fullGate).toContain("'simulatorPassIsNotPilotPass',true");
+  });
+});

--- a/netlify/functions/__tests__/supplier-simulator-recovery-replay.test.ts
+++ b/netlify/functions/__tests__/supplier-simulator-recovery-replay.test.ts
@@ -1,0 +1,189 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import type { SupplierAdapterContext, SupplierOrderRequest } from '../_shared/supplierAdapter';
+import { createSupplierSimulator, SUPPLIER_SIMULATOR_INTERFACE_VERSION, type SupplierSimulatorScenario } from '../_shared/supplierSimulator';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const foundation = repo('supabase/660_supplier_simulator_recovery_validation.sql');
+const closure = repo('supabase/661_supplier_simulator_recovery_validation_closure.sql');
+const simulatorSource = repo('netlify/functions/_shared/supplierSimulator.ts');
+const contract = repo('docs/canonical/loadify-supplier-commerce-2026-08-19/03_CANONICAL_EXECUTION_CONTRACT_LINES_1251_1750.md');
+
+const context = (key = 'phase-n-idem-1'): SupplierAdapterContext => ({
+  correlationId: '11111111-1111-4111-8111-111111111111',
+  idempotencyKey: key,
+  supplierKey: 'simulated-supplier',
+  territory: 'GB',
+});
+const order: SupplierOrderRequest = { externalOfferRef: 'SIM-OFFER-1', quantity: 2, destinationCountry: 'GB' };
+
+const canonicalScenarios: SupplierSimulatorScenario[] = [
+  'stock_zero','price_change','timeout','provider_500','duplicate_acknowledgement','lost_response_after_accept',
+  'partial_fulfilment','tracking','dispatch','delivery','lost_shipment','cancellation','return','refund','reimbursement',
+];
+
+describe('Phase N supplier simulator + recovery/replay validation', () => {
+  it('is explicitly a simulator/test adapter before supplier production', () => {
+    expect(contract).toContain('SUPPLIER SIMULATOR');
+    expect(contract).toContain('simulator/test adapter');
+    expect(simulatorSource).toContain('never calls a supplier, payment processor, carrier or production webhook');
+    expect(SUPPLIER_SIMULATOR_INTERFACE_VERSION).toBe(1);
+  });
+
+  it('covers every canonical Phase N supplier simulator scenario', () => {
+    for (const scenario of canonicalScenarios) expect(simulatorSource).toContain(`'${scenario}'`);
+    for (const phrase of ['stock available','stock zero','price change','timeout','provider 500','duplicate acknowledgement','lost response after supplier accepted','partial fulfilment','tracking','dispatch','delivery','lost shipment','cancellation','return','refund','reimbursement']) {
+      expect(contract.toLowerCase()).toContain(phrase);
+    }
+  });
+
+  it('simulates stock available and stock zero without inventing sellable stock', async () => {
+    const available = createSupplierSimulator({ scenario: 'happy_path' });
+    const zero = createSupplierSimulator({ scenario: 'stock_zero' });
+    await expect(available.getStock!(context(), ['SIM-VARIANT-1'])).resolves.toMatchObject({ ok: true, data: [{ quantity: 25, availability: 'in_stock' }] });
+    await expect(zero.getStock!(context(), ['SIM-VARIANT-1'])).resolves.toMatchObject({ ok: true, data: [{ quantity: 0, availability: 'out_of_stock' }] });
+  });
+
+  it('simulates price drift as provider evidence rather than changing canonical buyer price', async () => {
+    const adapter = createSupplierSimulator({ scenario: 'price_change', basePriceMinor: 1000 });
+    await expect(adapter.getPrices!(context(), ['SIM-VARIANT-1'])).resolves.toMatchObject({ ok: true, data: [{ amountMinor: 1500, currency: 'GBP' }] });
+    expect(simulatorSource).not.toContain('UPDATE public.products');
+  });
+
+  it('simulates timeout and provider 500 failure classes', async () => {
+    await expect(createSupplierSimulator({ scenario: 'timeout' }).getStock!(context(), ['SIM-VARIANT-1'])).resolves.toMatchObject({ ok: false, errorClass: 'RETRYABLE_FAILURE' });
+    await expect(createSupplierSimulator({ scenario: 'provider_500' }).getPrices!(context(), ['SIM-VARIANT-1'])).resolves.toMatchObject({ ok: false, errorClass: 'RETRYABLE_FAILURE' });
+  });
+
+  it('recovers an accepted order after a lost response using the exact submit idempotency key', async () => {
+    const adapter = createSupplierSimulator({ scenario: 'lost_response_after_accept' });
+    const ctx = context('lost-response-key');
+    const submitted = await adapter.submitOrder!(ctx, order);
+    expect(submitted).toMatchObject({ ok: false, errorClass: 'UNKNOWN_OUTCOME' });
+    const recovered = await adapter.findOrderByIdempotencyKey!(ctx);
+    expect(recovered).toMatchObject({ ok: true, data: { state: 'accepted', supplierOrderRef: 'SIM-ORDER-1' } });
+    expect(adapter.diagnostics()).toMatchObject({ submitCalls: 1, recoveryLookupCalls: 1, acceptedIdempotencyKeys: ['lost-response-key'] });
+  });
+
+  it('does not need a blind duplicate submit after lost-response recovery', async () => {
+    const adapter = createSupplierSimulator({ scenario: 'lost_response_after_accept' });
+    const ctx = context('same-key');
+    await adapter.submitOrder!(ctx, order);
+    await adapter.findOrderByIdempotencyKey!(ctx);
+    expect(adapter.diagnostics().submitCalls).toBe(1);
+    expect(simulatorSource).toContain('recovery is query-before-retry with the exact submit key');
+  });
+
+  it('makes exact submit replay idempotent', async () => {
+    const adapter = createSupplierSimulator({ scenario: 'happy_path' });
+    const ctx = context('exact-replay-key');
+    const first = await adapter.submitOrder!(ctx, order);
+    const replay = await adapter.submitOrder!(ctx, order);
+    expect(first).toEqual(replay);
+    expect(adapter.diagnostics().acceptedIdempotencyKeys).toEqual(['exact-replay-key']);
+  });
+
+  it('fails closed on changed payload under an existing submit idempotency key', async () => {
+    const adapter = createSupplierSimulator({ scenario: 'happy_path' });
+    const ctx = context('collision-key');
+    await adapter.submitOrder!(ctx, order);
+    await expect(adapter.submitOrder!(ctx, { ...order, quantity: 3 })).resolves.toMatchObject({ ok: false, errorClass: 'PERMANENT_REJECTION', message: 'simulator idempotency collision' });
+  });
+
+  it('can emit duplicate acknowledgement/tracking evidence for replay validation', async () => {
+    const adapter = createSupplierSimulator({ scenario: 'duplicate_acknowledgement' });
+    const tracking = await adapter.getTracking!(context(), 'SIM-ORDER-1');
+    expect(tracking).toMatchObject({ ok: true });
+    if (!tracking.ok) throw new Error('expected simulator tracking');
+    expect(tracking.data).toHaveLength(2);
+    expect(tracking.data[0]).toEqual(tracking.data[1]);
+  });
+
+  it('simulates partial fulfilment as limited supplier evidence', async () => {
+    const adapter = createSupplierSimulator({ scenario: 'partial_fulfilment' });
+    await expect(adapter.getStock!(context(), ['SIM-VARIANT-1'])).resolves.toMatchObject({ ok: true, data: [{ quantity: 1, availability: 'limited' }] });
+    expect(adapter.diagnostics().partialFulfilment).toBe(true);
+  });
+
+  it('simulates dispatch, delivery and lost shipment tracking states', async () => {
+    for (const [scenario, terminal] of [['dispatch','dispatched'],['delivery','delivered'],['lost_shipment','lost']] as const) {
+      const adapter = createSupplierSimulator({ scenario });
+      const result = await adapter.getTracking!(context(), 'SIM-ORDER-1');
+      if (!result.ok) throw new Error('expected simulator tracking');
+      expect(result.data.at(-1)?.status).toBe(terminal);
+    }
+  });
+
+  it('simulates cancellation, return and reimbursement', async () => {
+    await expect(createSupplierSimulator({ scenario: 'cancellation' }).cancelOrder!(context(), 'SIM-ORDER-1')).resolves.toMatchObject({ ok: true, data: { cancelled: true } });
+    await expect(createSupplierSimulator({ scenario: 'return' }).requestReturn!(context(), 'SIM-ORDER-1', 'buyer_return')).resolves.toMatchObject({ ok: true, data: { returnRef: 'SIM-RETURN-1' } });
+    await expect(createSupplierSimulator({ scenario: 'reimbursement' }).getReimbursement!(context(), 'SIM-ORDER-1')).resolves.toMatchObject({ ok: true, data: { amountMinor: 1000, currency: 'GBP', state: 'reimbursed' } });
+  });
+
+  it('models refund as a required platform action, not a fake supplier-adapter refund capability', () => {
+    const adapter = createSupplierSimulator({ scenario: 'refund' });
+    expect(adapter.diagnostics().customerRefundRequired).toBe(true);
+    expect(adapter.capabilities).not.toContain('refund');
+  });
+
+  it('stores simulator-only validation evidence separately from canonical commerce truth', () => {
+    expect(foundation).toContain("environment text NOT NULL DEFAULT 'simulator'");
+    expect(foundation).toContain("CHECK (environment='simulator')");
+    expect(foundation).toContain('does not enable Supplier Commerce');
+    expect(foundation).not.toContain('UPDATE public.orders');
+    expect(foundation).not.toContain('UPDATE public.payment_sessions');
+  });
+
+  it('records explicit replay classes for supplier submit acknowledgement tracking refund recovery webhook sync and reconciliation', () => {
+    for (const replayClass of ['supplier_submit','acknowledgement','tracking','refund','supplier_recovery','webhook','sync','reconciliation']) {
+      expect(foundation).toContain(`'${replayClass}'`);
+    }
+  });
+
+  it('makes simulator checks and replay evidence append-only', () => {
+    expect(closure).toContain('supplier simulator validation history is append-only');
+    expect(closure).toContain('trg_guard_supplier_simulator_checks_immutable_v1');
+    expect(closure).toContain('trg_guard_supplier_replay_evidence_immutable_v1');
+  });
+
+  it('prevents a fake simulator PASS when required checks are missing or failures exist', () => {
+    expect(closure).toContain('required_simulator_checks_missing');
+    expect(closure).toContain('simulator_failure_evidence_present');
+    for (const check of ['stock_zero','price_change','timeout','provider_500','duplicate_acknowledgement','lost_response_after_accept','partial_fulfilment','tracking_replay','lost_shipment','cancellation','return','refund','reimbursement','kill_switch','idempotency_collision']) {
+      expect(foundation).toContain(`'${check}'`);
+    }
+  });
+
+  it('requires lost-response recovery and collision blocking before PASS', () => {
+    expect(closure).toContain("e.replay_class='supplier_submit' AND e.result='recovered'");
+    expect(closure).toContain("e.result='blocked_collision'");
+    expect(closure).toContain('lost_response_recovery_not_proven');
+    expect(closure).toContain('idempotency_collision_block_not_proven');
+  });
+
+  it('requires canonical acknowledgement tracking refund and supplier recovery replay proof', () => {
+    expect(closure).toContain("e.replay_class IN ('acknowledgement','tracking','refund','supplier_recovery')");
+    expect(closure).toContain('count(DISTINCT e.replay_class)=4');
+    expect(closure).toContain('canonical_replay_classes_not_proven');
+  });
+
+  it('keeps simulator PASS explicitly distinct from Pilot PASS', () => {
+    expect(contract).toContain('SIMULATOR PASS');
+    expect(contract).toContain('≠ PILOT PASS');
+    expect(closure).toContain("'simulatorPassIsNotPilotPass',true");
+  });
+
+  it('keeps validation tables private and completion active-admin-only', () => {
+    expect(foundation.match(/REVOKE ALL ON TABLE private\./g)?.length).toBeGreaterThanOrEqual(3);
+    expect(closure).toContain('require_active_admin_v1(p_actor_id)');
+    expect(foundation).toContain('require_active_admin_v1(p_actor_id)');
+  });
+
+  it('does not silently claim backup restore PASS from simulator/replay validation', () => {
+    expect(contract).toContain('BACKUP EXISTS');
+    expect(contract).toContain('RESTORE PASS');
+    expect(foundation).not.toContain('restore_pass');
+    expect(closure).not.toContain('restore_pass');
+  });
+});

--- a/netlify/functions/__tests__/supplier-simulator-recovery-replay.test.ts
+++ b/netlify/functions/__tests__/supplier-simulator-recovery-replay.test.ts
@@ -8,7 +8,10 @@ const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8'
 const foundation = repo('supabase/660_supplier_simulator_recovery_validation.sql');
 const closure = repo('supabase/661_supplier_simulator_recovery_validation_closure.sql');
 const simulatorSource = repo('netlify/functions/_shared/supplierSimulator.ts');
-const contract = repo('docs/canonical/loadify-supplier-commerce-2026-08-19/03_CANONICAL_EXECUTION_CONTRACT_LINES_1251_1750.md');
+const contract = [
+  repo('docs/canonical/loadify-supplier-commerce-2026-08-19/03_CANONICAL_EXECUTION_CONTRACT_LINES_1251_1750.md'),
+  repo('docs/canonical/loadify-supplier-commerce-2026-08-19/04_CANONICAL_EXECUTION_CONTRACT_LINES_1751_2210.md'),
+].join('\n');
 
 const context = (key = 'phase-n-idem-1'): SupplierAdapterContext => ({
   correlationId: '11111111-1111-4111-8111-111111111111',

--- a/netlify/functions/_shared/supplierSimulator.ts
+++ b/netlify/functions/_shared/supplierSimulator.ts
@@ -1,0 +1,199 @@
+import type {
+  SupplierAdapterContext,
+  SupplierAdapterResult,
+  SupplierAdapterV1,
+  SupplierOrderAcknowledgement,
+  SupplierOrderRequest,
+  SupplierPriceSnapshot,
+  SupplierStockSnapshot,
+  SupplierTrackingEvent,
+} from './supplierAdapter';
+
+export const SUPPLIER_SIMULATOR_INTERFACE_VERSION = 1 as const;
+
+export type SupplierSimulatorScenario =
+  | 'happy_path'
+  | 'stock_zero'
+  | 'price_change'
+  | 'timeout'
+  | 'provider_500'
+  | 'duplicate_acknowledgement'
+  | 'lost_response_after_accept'
+  | 'partial_fulfilment'
+  | 'tracking'
+  | 'dispatch'
+  | 'delivery'
+  | 'lost_shipment'
+  | 'cancellation'
+  | 'return'
+  | 'refund'
+  | 'reimbursement';
+
+export interface SupplierSimulatorOptions {
+  scenario: SupplierSimulatorScenario;
+  providerKey?: string;
+  supplierOrderRef?: string;
+  externalVariantRef?: string;
+  basePriceMinor?: number;
+  currency?: string;
+  now?: () => string;
+}
+
+export interface SupplierSimulatorDiagnostics {
+  scenario: SupplierSimulatorScenario;
+  submitCalls: number;
+  recoveryLookupCalls: number;
+  acknowledgementCalls: number;
+  trackingCalls: number;
+  cancellationCalls: number;
+  returnCalls: number;
+  reimbursementCalls: number;
+  acceptedIdempotencyKeys: string[];
+  customerRefundRequired: boolean;
+  partialFulfilment: boolean;
+}
+
+const ok = <T>(data: T, externalRef?: string): SupplierAdapterResult<T> => ({ ok: true, data, externalRef });
+const fail = <T>(errorClass: 'AUTH_CONFIGURATION_FAILURE' | 'RATE_LIMITED' | 'RETRYABLE_FAILURE' | 'PERMANENT_REJECTION' | 'UNKNOWN_OUTCOME' | 'MALFORMED_RESPONSE' | 'CAPABILITY_UNAVAILABLE', message: string): SupplierAdapterResult<T> => ({ ok: false, errorClass, message });
+
+const requestFingerprint = (input: SupplierOrderRequest): string => JSON.stringify({
+  externalOfferRef: input.externalOfferRef,
+  quantity: input.quantity,
+  shippingServiceRef: input.shippingServiceRef ?? null,
+  destinationCountry: input.destinationCountry,
+});
+
+/**
+ * Deterministic non-production SupplierAdapterV1 used by Phase N.
+ * It never calls a supplier, payment processor, carrier or production webhook.
+ * Lost-response scenarios persist simulated acceptance by idempotency key so
+ * recovery is query-before-retry with the exact submit key.
+ */
+export function createSupplierSimulator(options: SupplierSimulatorOptions): SupplierAdapterV1 & { diagnostics(): SupplierSimulatorDiagnostics } {
+  const now = options.now ?? (() => '2026-08-21T12:00:00.000Z');
+  const providerKey = options.providerKey ?? 'loadify-supplier-simulator';
+  const supplierOrderRef = options.supplierOrderRef ?? 'SIM-ORDER-1';
+  const externalVariantRef = options.externalVariantRef ?? 'SIM-VARIANT-1';
+  const currency = options.currency ?? 'GBP';
+  const basePriceMinor = options.basePriceMinor ?? 1000;
+  const acceptedByKey = new Map<string, { fingerprint: string; acknowledgement: SupplierOrderAcknowledgement }>();
+  let submitCalls = 0;
+  let recoveryLookupCalls = 0;
+  let acknowledgementCalls = 0;
+  let trackingCalls = 0;
+  let cancellationCalls = 0;
+  let returnCalls = 0;
+  let reimbursementCalls = 0;
+
+  const acceptedAcknowledgement = (): SupplierOrderAcknowledgement => ({
+    supplierOrderRef,
+    state: 'accepted',
+    acknowledgedAt: now(),
+  });
+
+  const adapter: SupplierAdapterV1 & { diagnostics(): SupplierSimulatorDiagnostics } = {
+    interfaceVersion: 1,
+    providerKey,
+    adapterVersion: 'phase-n-simulator-v1',
+    capabilities: ['stock', 'price', 'shipping', 'order_submission', 'acknowledgement', 'tracking', 'cancellation', 'returns', 'reimbursement'],
+
+    async getStock(_context: SupplierAdapterContext, refs: string[]): Promise<SupplierAdapterResult<SupplierStockSnapshot[]>> {
+      if (options.scenario === 'timeout') return fail('RETRYABLE_FAILURE', 'simulated supplier timeout');
+      if (options.scenario === 'provider_500') return fail('RETRYABLE_FAILURE', 'simulated provider 500');
+      return ok(refs.map((ref) => ({
+        externalVariantRef: ref,
+        quantity: options.scenario === 'stock_zero' ? 0 : options.scenario === 'partial_fulfilment' ? 1 : 25,
+        availability: options.scenario === 'stock_zero' ? 'out_of_stock' : options.scenario === 'partial_fulfilment' ? 'limited' : 'in_stock',
+        observedAt: now(),
+      })));
+    },
+
+    async getPrices(_context: SupplierAdapterContext, refs: string[]): Promise<SupplierAdapterResult<SupplierPriceSnapshot[]>> {
+      if (options.scenario === 'timeout') return fail('RETRYABLE_FAILURE', 'simulated supplier timeout');
+      if (options.scenario === 'provider_500') return fail('RETRYABLE_FAILURE', 'simulated provider 500');
+      return ok(refs.map((ref) => ({ externalVariantRef: ref, amountMinor: options.scenario === 'price_change' ? basePriceMinor + 500 : basePriceMinor, currency, observedAt: now() })));
+    },
+
+    async submitOrder(context: SupplierAdapterContext, input: SupplierOrderRequest): Promise<SupplierAdapterResult<SupplierOrderAcknowledgement>> {
+      submitCalls += 1;
+      const fingerprint = requestFingerprint(input);
+      const existing = acceptedByKey.get(context.idempotencyKey);
+      if (existing) {
+        if (existing.fingerprint !== fingerprint) return fail('PERMANENT_REJECTION', 'simulator idempotency collision');
+        return ok(existing.acknowledgement, supplierOrderRef);
+      }
+      if (options.scenario === 'timeout') return fail('UNKNOWN_OUTCOME', 'simulated timeout with unknown outcome');
+      if (options.scenario === 'provider_500') return fail('RETRYABLE_FAILURE', 'simulated provider 500');
+      if (options.scenario === 'stock_zero') return fail('PERMANENT_REJECTION', 'simulated stock unavailable');
+
+      const acknowledgement = acceptedAcknowledgement();
+      acceptedByKey.set(context.idempotencyKey, { fingerprint, acknowledgement });
+      if (options.scenario === 'lost_response_after_accept') {
+        return fail('UNKNOWN_OUTCOME', 'simulated response lost after supplier accepted');
+      }
+      return ok(acknowledgement, supplierOrderRef);
+    },
+
+    async findOrderByIdempotencyKey(context: SupplierAdapterContext): Promise<SupplierAdapterResult<SupplierOrderAcknowledgement>> {
+      recoveryLookupCalls += 1;
+      const existing = acceptedByKey.get(context.idempotencyKey);
+      return existing ? ok(existing.acknowledgement, supplierOrderRef) : fail('UNKNOWN_OUTCOME', 'simulated order not found by idempotency key');
+    },
+
+    async getOrderAcknowledgement(_context: SupplierAdapterContext, ref: string): Promise<SupplierAdapterResult<SupplierOrderAcknowledgement>> {
+      acknowledgementCalls += 1;
+      if (ref !== supplierOrderRef) return fail('PERMANENT_REJECTION', 'unknown simulated supplier order');
+      const acknowledgement = acceptedAcknowledgement();
+      return ok(acknowledgement, supplierOrderRef);
+    },
+
+    async getTracking(_context: SupplierAdapterContext, ref: string): Promise<SupplierAdapterResult<SupplierTrackingEvent[]>> {
+      trackingCalls += 1;
+      if (ref !== supplierOrderRef) return fail('PERMANENT_REJECTION', 'unknown simulated supplier order');
+      const event = (status: string, occurredAt = now()): SupplierTrackingEvent => ({ supplierOrderRef, carrierRef: 'SIM-CARRIER', trackingRef: 'SIM-TRACK-1', status, occurredAt });
+      if (options.scenario === 'lost_shipment') return ok([event('dispatched'), event('in_transit'), event('lost')]);
+      if (options.scenario === 'dispatch') return ok([event('dispatched')]);
+      if (options.scenario === 'delivery') return ok([event('dispatched'), event('in_transit'), event('delivered')]);
+      if (options.scenario === 'duplicate_acknowledgement') return ok([event('in_transit'), event('in_transit')]);
+      return ok([event('in_transit')]);
+    },
+
+    async cancelOrder(_context: SupplierAdapterContext, ref: string) {
+      cancellationCalls += 1;
+      if (ref !== supplierOrderRef) return fail<{ cancelled: boolean }>('PERMANENT_REJECTION', 'unknown simulated supplier order');
+      return ok({ cancelled: options.scenario === 'cancellation' || options.scenario === 'happy_path' });
+    },
+
+    async requestReturn(_context: SupplierAdapterContext, ref: string, _reasonCode: string) {
+      returnCalls += 1;
+      if (ref !== supplierOrderRef) return fail<{ returnRef: string }>('PERMANENT_REJECTION', 'unknown simulated supplier order');
+      return ok({ returnRef: 'SIM-RETURN-1' });
+    },
+
+    async getReimbursement(_context: SupplierAdapterContext, ref: string) {
+      reimbursementCalls += 1;
+      if (ref !== supplierOrderRef) return fail<{ amountMinor?: number; currency?: string; state: string }>('PERMANENT_REJECTION', 'unknown simulated supplier order');
+      if (options.scenario === 'reimbursement') return ok({ amountMinor: basePriceMinor, currency, state: 'reimbursed' });
+      return ok({ state: 'pending' });
+    },
+
+    diagnostics() {
+      return {
+        scenario: options.scenario,
+        submitCalls,
+        recoveryLookupCalls,
+        acknowledgementCalls,
+        trackingCalls,
+        cancellationCalls,
+        returnCalls,
+        reimbursementCalls,
+        acceptedIdempotencyKeys: [...acceptedByKey.keys()],
+        customerRefundRequired: options.scenario === 'refund',
+        partialFulfilment: options.scenario === 'partial_fulfilment',
+      };
+    },
+  };
+
+  void externalVariantRef;
+  return adapter;
+}

--- a/netlify/functions/admin-supplier-simulator.ts
+++ b/netlify/functions/admin-supplier-simulator.ts
@@ -1,0 +1,84 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { jsonResponse, optionsResponse } from './_shared/http';
+
+const METHODS = 'POST, OPTIONS';
+const text = (value: unknown) => typeof value === 'string' ? value.trim() : '';
+const object = (value: unknown): Record<string, unknown> => value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : {};
+const containsSecretMaterial = (value: unknown) => /(?:password|secret[_-]?key|api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key)/i.test(JSON.stringify(value ?? {}));
+
+type Action =
+  | { action: 'start'; runKey: string; simulatorVersion: string; summary?: Record<string, unknown> }
+  | { action: 'record_check'; runId: string; checkKey: string; status: string; attempt?: number; idempotencyKey?: string; canonicalFingerprint?: string; observedFingerprint?: string; evidence?: Record<string, unknown> }
+  | { action: 'record_replay'; runId: string; replayClass: string; idempotencyKey: string; firstFingerprint: string; replayFingerprint: string; result: string; sourceOperation: string; evidence?: Record<string, unknown> }
+  | { action: 'complete'; runId: string; status: 'passed' | 'failed'; summary?: Record<string, unknown> }
+  | { action: 'status'; runId?: string };
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return optionsResponse(METHODS);
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' }, METHODS);
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) return jsonResponse(500, { error: 'Server configuration error' }, METHODS);
+
+  const admin = createClient(supabaseUrl, serviceRoleKey, { auth: { autoRefreshToken: false, persistSession: false } });
+  const auth = await authenticateActiveAccount(event, admin, ['admin']);
+  if (!auth.ok) return jsonResponse(auth.status, { error: 'Unauthorized' }, METHODS);
+
+  let body: Action;
+  try { body = JSON.parse(event.body || '{}') as Action; }
+  catch { return jsonResponse(400, { error: 'Invalid JSON body' }, METHODS); }
+  if (!body || typeof body !== 'object' || !('action' in body)) return jsonResponse(400, { error: 'Unsupported Phase N simulator action' }, METHODS);
+  if (containsSecretMaterial(body)) return jsonResponse(400, { error: 'Raw credentials or secrets are forbidden in simulator evidence' }, METHODS);
+
+  if (body.action === 'start') {
+    if (!text(body.runKey) || !text(body.simulatorVersion)) return jsonResponse(400, { error: 'runKey and simulatorVersion are required' }, METHODS);
+    const { data, error } = await admin.rpc('server_admin_start_supplier_simulator_run_v1', {
+      p_actor_id: auth.actor.id, p_run_key: text(body.runKey), p_simulator_version: text(body.simulatorVersion), p_summary: object(body.summary),
+    });
+    if (error) return jsonResponse(400, { error: 'Unable to start simulator validation run' }, METHODS);
+    return jsonResponse(200, { ok: true, runId: data }, METHODS);
+  }
+
+  if (body.action === 'record_check') {
+    if (!text(body.runId) || !text(body.checkKey) || !text(body.status)) return jsonResponse(400, { error: 'Complete simulator check evidence is required' }, METHODS);
+    const { data, error } = await admin.rpc('server_record_supplier_simulator_check_v1', {
+      p_run_id: text(body.runId), p_check_key: text(body.checkKey), p_status: text(body.status), p_attempt: Number.isInteger(body.attempt) ? body.attempt : 1,
+      p_idempotency_key: text(body.idempotencyKey) || null, p_canonical_fingerprint: text(body.canonicalFingerprint) || null,
+      p_observed_fingerprint: text(body.observedFingerprint) || null, p_evidence: object(body.evidence),
+    });
+    if (error) return jsonResponse(400, { error: 'Unable to record simulator check' }, METHODS);
+    return jsonResponse(200, { ok: true, checkId: data }, METHODS);
+  }
+
+  if (body.action === 'record_replay') {
+    if (![body.runId, body.replayClass, body.idempotencyKey, body.firstFingerprint, body.replayFingerprint, body.result, body.sourceOperation].every((v) => text(v))) {
+      return jsonResponse(400, { error: 'Complete replay evidence is required' }, METHODS);
+    }
+    const { data, error } = await admin.rpc('server_record_supplier_replay_validation_v1', {
+      p_run_id: text(body.runId), p_replay_class: text(body.replayClass), p_idempotency_key: text(body.idempotencyKey),
+      p_first_fingerprint: text(body.firstFingerprint), p_replay_fingerprint: text(body.replayFingerprint), p_result: text(body.result),
+      p_source_operation: text(body.sourceOperation), p_evidence: object(body.evidence),
+    });
+    if (error) return jsonResponse(400, { error: 'Unable to record replay validation evidence' }, METHODS);
+    return jsonResponse(200, { ok: true, replayEvidenceId: data }, METHODS);
+  }
+
+  if (body.action === 'complete') {
+    if (!text(body.runId) || !['passed', 'failed'].includes(body.status)) return jsonResponse(400, { error: 'runId and terminal status are required' }, METHODS);
+    const { data, error } = await admin.rpc('server_admin_complete_supplier_simulator_run_v1', {
+      p_actor_id: auth.actor.id, p_run_id: text(body.runId), p_status: body.status, p_summary: object(body.summary),
+    });
+    if (error) return jsonResponse(400, { error: 'Unable to complete simulator validation run' }, METHODS);
+    return jsonResponse(200, { ok: true, result: data }, METHODS);
+  }
+
+  if (body.action === 'status') {
+    const { data, error } = await admin.rpc('server_admin_supplier_simulator_status_v1', { p_actor_id: auth.actor.id, p_run_id: text(body.runId) || null });
+    if (error) return jsonResponse(500, { error: 'Unable to read simulator validation status' }, METHODS);
+    return jsonResponse(200, { ok: true, result: data }, METHODS);
+  }
+
+  return jsonResponse(400, { error: 'Unsupported Phase N simulator action' }, METHODS);
+};

--- a/supabase/660_supplier_simulator_recovery_validation.sql
+++ b/supabase/660_supplier_simulator_recovery_validation.sql
@@ -1,0 +1,143 @@
+-- 660_supplier_simulator_recovery_validation.sql
+-- Phase N — Supplier Simulator + Recovery/Replay Validation.
+-- This migration records simulator validation evidence only. It does not enable Supplier Commerce,
+-- contact any real supplier, alter customer orders, move money, or rewrite canonical commerce history.
+
+CREATE SCHEMA IF NOT EXISTS private;
+
+CREATE TABLE IF NOT EXISTS private.supplier_simulator_validation_runs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_key text NOT NULL UNIQUE,
+  simulator_version text NOT NULL,
+  contract_version integer NOT NULL DEFAULT 1 CHECK (contract_version > 0),
+  environment text NOT NULL DEFAULT 'simulator',
+  status text NOT NULL DEFAULT 'running',
+  required_checks text[] NOT NULL DEFAULT ARRAY[
+    'stock_zero','price_change','timeout','provider_500','duplicate_acknowledgement',
+    'lost_response_after_accept','partial_fulfilment','tracking_replay','lost_shipment',
+    'cancellation','return','refund','reimbursement','kill_switch','idempotency_collision'
+  ]::text[],
+  started_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  started_at timestamptz NOT NULL DEFAULT now(),
+  finished_at timestamptz,
+  summary jsonb NOT NULL DEFAULT '{}'::jsonb,
+  CONSTRAINT supplier_simulator_environment_check CHECK (environment='simulator'),
+  CONSTRAINT supplier_simulator_run_status_check CHECK (status IN ('running','passed','failed')),
+  CONSTRAINT supplier_simulator_summary_check CHECK (jsonb_typeof(summary)='object'),
+  CONSTRAINT supplier_simulator_finished_check CHECK ((status='running' AND finished_at IS NULL) OR (status IN ('passed','failed') AND finished_at IS NOT NULL))
+);
+
+CREATE TABLE IF NOT EXISTS private.supplier_simulator_validation_checks (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id uuid NOT NULL REFERENCES private.supplier_simulator_validation_runs(id) ON DELETE RESTRICT,
+  check_key text NOT NULL,
+  status text NOT NULL,
+  attempt integer NOT NULL DEFAULT 1 CHECK (attempt > 0),
+  idempotency_key text,
+  canonical_fingerprint text,
+  observed_fingerprint text,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_simulator_check_status_check CHECK (status IN ('pass','fail','blocked')),
+  CONSTRAINT supplier_simulator_check_key_check CHECK (check_key IN (
+    'stock_available','stock_zero','price_change','timeout','provider_500','duplicate_acknowledgement',
+    'lost_response_after_accept','partial_fulfilment','tracking','tracking_replay','dispatch','delivery',
+    'lost_shipment','cancellation','return','refund','reimbursement','kill_switch','idempotency_collision'
+  )),
+  CONSTRAINT supplier_simulator_check_evidence_check CHECK (jsonb_typeof(evidence)='object')
+);
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_simulator_check_attempt_unique
+  ON private.supplier_simulator_validation_checks(run_id,check_key,attempt);
+CREATE INDEX IF NOT EXISTS supplier_simulator_check_run_idx
+  ON private.supplier_simulator_validation_checks(run_id,created_at);
+
+CREATE TABLE IF NOT EXISTS private.supplier_replay_validation_evidence (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id uuid NOT NULL REFERENCES private.supplier_simulator_validation_runs(id) ON DELETE RESTRICT,
+  replay_class text NOT NULL,
+  idempotency_key text NOT NULL,
+  first_fingerprint text NOT NULL,
+  replay_fingerprint text NOT NULL,
+  result text NOT NULL,
+  source_operation text NOT NULL,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_replay_class_check CHECK (replay_class IN ('supplier_submit','acknowledgement','tracking','refund','supplier_recovery','webhook','sync','reconciliation')),
+  CONSTRAINT supplier_replay_result_check CHECK (result IN ('exact_replay','recovered','blocked_collision','blocked_by_control','failed')),
+  CONSTRAINT supplier_replay_evidence_check CHECK (jsonb_typeof(evidence)='object')
+);
+CREATE INDEX IF NOT EXISTS supplier_replay_validation_run_idx
+  ON private.supplier_replay_validation_evidence(run_id,replay_class,created_at);
+
+REVOKE ALL ON TABLE private.supplier_simulator_validation_runs FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_simulator_validation_checks FROM PUBLIC, anon, authenticated, service_role;
+REVOKE ALL ON TABLE private.supplier_replay_validation_evidence FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_start_supplier_simulator_run_v1(
+  p_actor_id uuid,p_run_key text,p_simulator_version text,p_summary jsonb DEFAULT '{}'::jsonb
+)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_id uuid;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF NULLIF(BTRIM(p_run_key),'') IS NULL OR NULLIF(BTRIM(p_simulator_version),'') IS NULL OR jsonb_typeof(COALESCE(p_summary,'{}'::jsonb))<>'object' THEN
+    RAISE EXCEPTION 'complete simulator run identity is required';
+  END IF;
+  INSERT INTO private.supplier_simulator_validation_runs(run_key,simulator_version,started_by,summary)
+  VALUES(BTRIM(p_run_key),BTRIM(p_simulator_version),p_actor_id,COALESCE(p_summary,'{}'::jsonb))
+  RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_start_supplier_simulator_run_v1(uuid,text,text,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_start_supplier_simulator_run_v1(uuid,text,text,jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_record_supplier_simulator_check_v1(
+  p_run_id uuid,p_check_key text,p_status text,p_attempt integer,p_idempotency_key text,
+  p_canonical_fingerprint text,p_observed_fingerprint text,p_evidence jsonb
+)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_id uuid;
+BEGIN
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_simulator_validation_runs r WHERE r.id=p_run_id AND r.status='running') THEN
+    RAISE EXCEPTION 'simulator run must exist and be running';
+  END IF;
+  INSERT INTO private.supplier_simulator_validation_checks(
+    run_id,check_key,status,attempt,idempotency_key,canonical_fingerprint,observed_fingerprint,evidence
+  ) VALUES(
+    p_run_id,lower(BTRIM(p_check_key)),lower(BTRIM(p_status)),COALESCE(p_attempt,1),NULLIF(BTRIM(p_idempotency_key),''),
+    NULLIF(BTRIM(p_canonical_fingerprint),''),NULLIF(BTRIM(p_observed_fingerprint),''),COALESCE(p_evidence,'{}'::jsonb)
+  ) RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_record_supplier_simulator_check_v1(uuid,text,text,integer,text,text,text,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_record_supplier_simulator_check_v1(uuid,text,text,integer,text,text,text,jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_record_supplier_replay_validation_v1(
+  p_run_id uuid,p_replay_class text,p_idempotency_key text,p_first_fingerprint text,p_replay_fingerprint text,
+  p_result text,p_source_operation text,p_evidence jsonb
+)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_id uuid;
+BEGIN
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_simulator_validation_runs r WHERE r.id=p_run_id AND r.status='running') THEN
+    RAISE EXCEPTION 'simulator run must exist and be running';
+  END IF;
+  IF NULLIF(BTRIM(p_idempotency_key),'') IS NULL OR NULLIF(BTRIM(p_first_fingerprint),'') IS NULL OR NULLIF(BTRIM(p_replay_fingerprint),'') IS NULL OR NULLIF(BTRIM(p_source_operation),'') IS NULL THEN
+    RAISE EXCEPTION 'complete replay evidence is required';
+  END IF;
+  INSERT INTO private.supplier_replay_validation_evidence(
+    run_id,replay_class,idempotency_key,first_fingerprint,replay_fingerprint,result,source_operation,evidence
+  ) VALUES(
+    p_run_id,lower(BTRIM(p_replay_class)),BTRIM(p_idempotency_key),BTRIM(p_first_fingerprint),BTRIM(p_replay_fingerprint),
+    lower(BTRIM(p_result)),BTRIM(p_source_operation),COALESCE(p_evidence,'{}'::jsonb)
+  ) RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_record_supplier_replay_validation_v1(uuid,text,text,text,text,text,text,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_record_supplier_replay_validation_v1(uuid,text,text,text,text,text,text,jsonb) TO service_role;
+
+COMMENT ON TABLE private.supplier_simulator_validation_runs IS 'Phase N simulator-only validation evidence. Simulator PASS is not Pilot PASS.';
+COMMENT ON TABLE private.supplier_replay_validation_evidence IS 'Phase N recovery/replay proof. This records validation evidence and never rewrites canonical commerce history.';

--- a/supabase/661_supplier_simulator_recovery_validation_closure.sql
+++ b/supabase/661_supplier_simulator_recovery_validation_closure.sql
@@ -1,0 +1,111 @@
+-- 661_supplier_simulator_recovery_validation_closure.sql
+-- Phase N Branch Guard closure: simulator evidence is append-only and PASS cannot be
+-- declared until every required recovery/replay scenario has explicit passing evidence.
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_simulator_history_immutable_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  RAISE EXCEPTION 'supplier simulator validation history is append-only';
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_simulator_checks_immutable_v1 ON private.supplier_simulator_validation_checks;
+CREATE TRIGGER trg_guard_supplier_simulator_checks_immutable_v1 BEFORE UPDATE OR DELETE ON private.supplier_simulator_validation_checks
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_simulator_history_immutable_v1();
+DROP TRIGGER IF EXISTS trg_guard_supplier_replay_evidence_immutable_v1 ON private.supplier_replay_validation_evidence;
+CREATE TRIGGER trg_guard_supplier_replay_evidence_immutable_v1 BEFORE UPDATE OR DELETE ON private.supplier_replay_validation_evidence
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_simulator_history_immutable_v1();
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_simulator_run_history_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  IF OLD.status IN ('passed','failed') THEN
+    RAISE EXCEPTION 'terminal supplier simulator run is immutable';
+  END IF;
+  IF OLD.environment IS DISTINCT FROM NEW.environment OR OLD.run_key IS DISTINCT FROM NEW.run_key
+     OR OLD.simulator_version IS DISTINCT FROM NEW.simulator_version OR OLD.contract_version IS DISTINCT FROM NEW.contract_version
+     OR OLD.required_checks IS DISTINCT FROM NEW.required_checks OR OLD.started_by IS DISTINCT FROM NEW.started_by
+     OR OLD.started_at IS DISTINCT FROM NEW.started_at THEN
+    RAISE EXCEPTION 'supplier simulator run identity is immutable';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_simulator_run_history_v1 ON private.supplier_simulator_validation_runs;
+CREATE TRIGGER trg_guard_supplier_simulator_run_history_v1 BEFORE UPDATE OR DELETE ON private.supplier_simulator_validation_runs
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_simulator_run_history_v1();
+
+CREATE OR REPLACE FUNCTION public.server_admin_complete_supplier_simulator_run_v1(
+  p_actor_id uuid,p_run_id uuid,p_status text,p_summary jsonb DEFAULT '{}'::jsonb
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_run private.supplier_simulator_validation_runs%ROWTYPE;
+  v_status text:=lower(BTRIM(COALESCE(p_status,'')));
+  v_missing text[]:='{}';
+  v_required text;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF v_status NOT IN ('passed','failed') OR jsonb_typeof(COALESCE(p_summary,'{}'::jsonb))<>'object' THEN
+    RAISE EXCEPTION 'terminal simulator status and summary are required';
+  END IF;
+  SELECT * INTO v_run FROM private.supplier_simulator_validation_runs WHERE id=p_run_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','simulator_run_not_found','interfaceVersion',1); END IF;
+  IF v_run.status<>'running' THEN RAISE EXCEPTION 'simulator run is already terminal'; END IF;
+
+  IF v_status='passed' THEN
+    FOREACH v_required IN ARRAY v_run.required_checks LOOP
+      IF NOT EXISTS(
+        SELECT 1 FROM private.supplier_simulator_validation_checks c
+         WHERE c.run_id=p_run_id AND c.check_key=v_required AND c.status='pass'
+      ) THEN v_missing:=array_append(v_missing,v_required); END IF;
+    END LOOP;
+    IF cardinality(v_missing)>0 THEN
+      RETURN jsonb_build_object('ok',false,'reason','required_simulator_checks_missing','missingChecks',to_jsonb(v_missing),'interfaceVersion',1);
+    END IF;
+    IF EXISTS(SELECT 1 FROM private.supplier_simulator_validation_checks c WHERE c.run_id=p_run_id AND c.status='fail') THEN
+      RETURN jsonb_build_object('ok',false,'reason','simulator_failure_evidence_present','interfaceVersion',1);
+    END IF;
+    IF NOT EXISTS(
+      SELECT 1 FROM private.supplier_replay_validation_evidence e
+       WHERE e.run_id=p_run_id AND e.replay_class='supplier_submit' AND e.result='recovered'
+    ) THEN RETURN jsonb_build_object('ok',false,'reason','lost_response_recovery_not_proven','interfaceVersion',1); END IF;
+    IF NOT EXISTS(
+      SELECT 1 FROM private.supplier_replay_validation_evidence e
+       WHERE e.run_id=p_run_id AND e.result='blocked_collision'
+    ) THEN RETURN jsonb_build_object('ok',false,'reason','idempotency_collision_block_not_proven','interfaceVersion',1); END IF;
+    IF NOT EXISTS(
+      SELECT 1 FROM private.supplier_replay_validation_evidence e
+       WHERE e.run_id=p_run_id AND e.replay_class IN ('acknowledgement','tracking','refund','supplier_recovery') AND e.result='exact_replay'
+       GROUP BY e.run_id HAVING count(DISTINCT e.replay_class)=4
+    ) THEN RETURN jsonb_build_object('ok',false,'reason','canonical_replay_classes_not_proven','interfaceVersion',1); END IF;
+  END IF;
+
+  UPDATE private.supplier_simulator_validation_runs SET
+    status=v_status,finished_at=now(),summary=COALESCE(p_summary,'{}'::jsonb)
+  WHERE id=p_run_id RETURNING * INTO v_run;
+
+  RETURN jsonb_build_object('ok',true,'runId',v_run.id,'status',v_run.status,'simulatorVersion',v_run.simulator_version,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_complete_supplier_simulator_run_v1(uuid,uuid,text,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_complete_supplier_simulator_run_v1(uuid,uuid,text,jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_supplier_simulator_status_v1(p_actor_id uuid,p_run_id uuid DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  RETURN jsonb_build_object(
+    'runs',(SELECT COALESCE(jsonb_agg(to_jsonb(r) ORDER BY r.started_at DESC),'[]'::jsonb) FROM (
+      SELECT r.* FROM private.supplier_simulator_validation_runs r WHERE p_run_id IS NULL OR r.id=p_run_id ORDER BY r.started_at DESC LIMIT 25
+    ) r),
+    'checks',(SELECT COALESCE(jsonb_agg(to_jsonb(c) ORDER BY c.created_at),'[]'::jsonb) FROM private.supplier_simulator_validation_checks c WHERE p_run_id IS NOT NULL AND c.run_id=p_run_id),
+    'replayEvidence',(SELECT COALESCE(jsonb_agg(to_jsonb(e) ORDER BY e.created_at),'[]'::jsonb) FROM private.supplier_replay_validation_evidence e WHERE p_run_id IS NOT NULL AND e.run_id=p_run_id),
+    'simulatorPassIsNotPilotPass',true,
+    'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_supplier_simulator_status_v1(uuid,uuid) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_supplier_simulator_status_v1(uuid,uuid) TO service_role;
+
+COMMENT ON FUNCTION public.server_admin_complete_supplier_simulator_run_v1(uuid,uuid,text,jsonb) IS 'Phase N fail-closed completion gate. PASS requires the full canonical simulator scenario set plus lost-response recovery, collision blocking and acknowledgement/tracking/refund/recovery replay proof.';

--- a/supabase/662_supplier_simulator_full_replay_gate.sql
+++ b/supabase/662_supplier_simulator_full_replay_gate.sql
@@ -1,0 +1,96 @@
+-- 662_supplier_simulator_full_replay_gate.sql
+-- Phase N Branch Guard closure: no fake PASS. Require every canonical simulator scenario
+-- and the complete replay/reprocessing classes from the disaster-recovery contract.
+
+ALTER TABLE private.supplier_simulator_validation_runs
+  ALTER COLUMN required_checks SET DEFAULT ARRAY[
+    'stock_available','stock_zero','price_change','timeout','provider_500','duplicate_acknowledgement',
+    'lost_response_after_accept','partial_fulfilment','tracking','tracking_replay','dispatch','delivery',
+    'lost_shipment','cancellation','return','refund','reimbursement','kill_switch','idempotency_collision'
+  ]::text[];
+
+ALTER TABLE private.supplier_replay_validation_evidence
+  DROP CONSTRAINT IF EXISTS supplier_replay_class_check;
+ALTER TABLE private.supplier_replay_validation_evidence
+  ADD CONSTRAINT supplier_replay_class_check CHECK (replay_class IN (
+    'supplier_submit','acknowledgement','tracking','refund','supplier_recovery',
+    'event','webhook','failed_job','sync','reconciliation','derived_state'
+  ));
+
+CREATE OR REPLACE FUNCTION public.server_admin_complete_supplier_simulator_run_v1(
+  p_actor_id uuid,p_run_id uuid,p_status text,p_summary jsonb DEFAULT '{}'::jsonb
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_run private.supplier_simulator_validation_runs%ROWTYPE;
+  v_status text:=lower(BTRIM(COALESCE(p_status,'')));
+  v_missing text[]:='{}';
+  v_required text;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF v_status NOT IN ('passed','failed') OR jsonb_typeof(COALESCE(p_summary,'{}'::jsonb))<>'object' THEN
+    RAISE EXCEPTION 'terminal simulator status and summary are required';
+  END IF;
+  SELECT * INTO v_run FROM private.supplier_simulator_validation_runs WHERE id=p_run_id FOR UPDATE;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ok',false,'reason','simulator_run_not_found','interfaceVersion',1); END IF;
+  IF v_run.status<>'running' THEN RAISE EXCEPTION 'simulator run is already terminal'; END IF;
+
+  IF v_status='passed' THEN
+    FOREACH v_required IN ARRAY v_run.required_checks LOOP
+      IF NOT EXISTS(
+        SELECT 1 FROM private.supplier_simulator_validation_checks c
+         WHERE c.run_id=p_run_id AND c.check_key=v_required AND c.status='pass'
+      ) THEN v_missing:=array_append(v_missing,v_required); END IF;
+    END LOOP;
+    IF cardinality(v_missing)>0 THEN
+      RETURN jsonb_build_object('ok',false,'reason','required_simulator_checks_missing','missingChecks',to_jsonb(v_missing),'interfaceVersion',1);
+    END IF;
+    IF EXISTS(SELECT 1 FROM private.supplier_simulator_validation_checks c WHERE c.run_id=p_run_id AND c.status='fail') THEN
+      RETURN jsonb_build_object('ok',false,'reason','simulator_failure_evidence_present','interfaceVersion',1);
+    END IF;
+
+    -- Accepted-but-response-lost must be recovered by query-before-retry under the same submit idempotency key.
+    IF NOT EXISTS(
+      SELECT 1 FROM private.supplier_replay_validation_evidence e
+       WHERE e.run_id=p_run_id AND e.replay_class='supplier_submit' AND e.result='recovered'
+         AND e.first_fingerprint=e.replay_fingerprint
+    ) THEN RETURN jsonb_build_object('ok',false,'reason','lost_response_recovery_not_proven','interfaceVersion',1); END IF;
+
+    -- Changed canonical evidence under the same key must be blocked, never laundered as an exact replay.
+    IF NOT EXISTS(
+      SELECT 1 FROM private.supplier_replay_validation_evidence e
+       WHERE e.run_id=p_run_id AND e.result='blocked_collision' AND e.first_fingerprint<>e.replay_fingerprint
+    ) THEN RETURN jsonb_build_object('ok',false,'reason','idempotency_collision_block_not_proven','interfaceVersion',1); END IF;
+
+    -- Canonical event families must prove exact replay.
+    IF NOT EXISTS(
+      SELECT 1 FROM private.supplier_replay_validation_evidence e
+       WHERE e.run_id=p_run_id
+         AND e.replay_class IN ('acknowledgement','tracking','refund','supplier_recovery','event','webhook','sync','reconciliation')
+         AND e.result='exact_replay' AND e.first_fingerprint=e.replay_fingerprint
+       GROUP BY e.run_id HAVING count(DISTINCT e.replay_class)=8
+    ) THEN RETURN jsonb_build_object('ok',false,'reason','canonical_replay_classes_not_proven','interfaceVersion',1); END IF;
+
+    -- Failed jobs must prove deterministic recovery/reprocessing and derived state must be rebuildable from canonical truth.
+    IF NOT EXISTS(
+      SELECT 1 FROM private.supplier_replay_validation_evidence e
+       WHERE e.run_id=p_run_id AND e.replay_class='failed_job' AND e.result='recovered'
+    ) THEN RETURN jsonb_build_object('ok',false,'reason','failed_job_replay_not_proven','interfaceVersion',1); END IF;
+    IF NOT EXISTS(
+      SELECT 1 FROM private.supplier_replay_validation_evidence e
+       WHERE e.run_id=p_run_id AND e.replay_class='derived_state' AND e.result='recovered'
+    ) THEN RETURN jsonb_build_object('ok',false,'reason','derived_state_rebuild_not_proven','interfaceVersion',1); END IF;
+  END IF;
+
+  UPDATE private.supplier_simulator_validation_runs SET
+    status=v_status,finished_at=now(),summary=COALESCE(p_summary,'{}'::jsonb)
+  WHERE id=p_run_id RETURNING * INTO v_run;
+
+  RETURN jsonb_build_object('ok',true,'runId',v_run.id,'status',v_run.status,'simulatorVersion',v_run.simulator_version,
+    'simulatorPassIsNotPilotPass',true,'backupRestorePassClaimed',false,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_complete_supplier_simulator_run_v1(uuid,uuid,text,jsonb) FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_complete_supplier_simulator_run_v1(uuid,uuid,text,jsonb) TO service_role;
+
+COMMENT ON FUNCTION public.server_admin_complete_supplier_simulator_run_v1(uuid,uuid,text,jsonb) IS 'Phase N full no-fake-pass gate: all simulator scenarios, replay/reprocessing classes, lost-response recovery, collision blocking and derived-state rebuild evidence are mandatory. This does not claim backup restore PASS or Pilot PASS.';


### PR DESCRIPTION
Implements canonical Phase N — Supplier Simulator + Recovery/Replay Validation. Includes simulator adapter scenarios, admin boundary, simulator-only validation evidence, append-only recovery/replay proof, full replay/no-fake-pass gate, and contract-aligned tests. PowerShell validation on exact head c743e45e0f80da2efb2c346cdd32663de9e6e44b: Phase N dedicated PASS (39/39), upstream C-M PASS, TypeScript PASS, lint PASS, build PASS. Full suite remains on known baseline only; no new Phase N regression. Supplier Commerce is not enabled and simulator PASS remains distinct from Pilot PASS.