### PR TITLE
Align original main homepage with Loadify colour system

### DIFF
--- a/src/components/FeaturedProducts.tsx
+++ b/src/components/FeaturedProducts.tsx
@@ -39,18 +39,22 @@ const FeaturedProducts = () => {
 
   if (loading) {
     return (
-      <section className="relative" aria-label="Marketplace products">
+      <section
+        className="relative bg-[#0A234F]"
+        style={{ backgroundImage: 'radial-gradient(circle at 100% 0%, rgba(29,87,216,0.25), transparent 40%)' }}
+        aria-label="Marketplace products"
+      >
         <div className="w-full max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 py-8">
-          <div className="h-4 w-44 bg-white/10 rounded mb-1 animate-pulse" />
-          <div className="h-3 w-56 bg-white/10 rounded mb-4 animate-pulse" />
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-px bg-white/10">
+          <div className="h-4 w-44 bg-white/12 rounded mb-1 animate-pulse" />
+          <div className="h-3 w-56 bg-white/12 rounded mb-4 animate-pulse" />
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
             {Array.from({ length: 10 }).map((_, i) => (
-              <div key={i} className="bg-[#0B2F6B]">
-                <div className="aspect-square bg-white/10 animate-pulse" />
+              <div key={i} className="overflow-hidden rounded-[18px] bg-white">
+                <div className="aspect-square bg-[#0A234F]/8 animate-pulse" />
                 <div className="px-2.5 py-2.5 space-y-1.5">
-                  <div className="h-2.5 w-16 bg-white/10 rounded animate-pulse" />
-                  <div className="h-2.5 w-full bg-white/10 rounded animate-pulse" />
-                  <div className="h-3.5 w-12 bg-white/10 rounded animate-pulse" />
+                  <div className="h-2.5 w-16 bg-[#0A234F]/10 rounded animate-pulse" />
+                  <div className="h-2.5 w-full bg-[#0A234F]/10 rounded animate-pulse" />
+                  <div className="h-3.5 w-12 bg-[#0A234F]/10 rounded animate-pulse" />
                 </div>
               </div>
             ))}
@@ -61,14 +65,18 @@ const FeaturedProducts = () => {
   }
 
   return (
-    <section className="relative" aria-label="Marketplace products">
+    <section
+      className="relative bg-[#0A234F]"
+      style={{ backgroundImage: 'radial-gradient(circle at 100% 0%, rgba(29,87,216,0.25), transparent 40%)' }}
+      aria-label="Marketplace products"
+    >
       <div className="relative z-10 w-full max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 py-8">
         <div className="flex items-center justify-between mb-4">
           <div>
             <h2 className="text-[13px] font-black text-white uppercase tracking-widest">
               Marketplace Products
             </h2>
-            <p className="text-[11px] text-white/60 mt-0.5">
+            <p className="text-[11px] text-white/65 mt-0.5">
               Listed by verified UK trade suppliers
             </p>
           </div>
@@ -83,7 +91,7 @@ const FeaturedProducts = () => {
         </div>
 
         {products.length > 0 ? (
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-px bg-white/10">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-3">
             {products.map((item) => {
               const img =
                 Array.isArray(item.images) && item.images.length > 0
@@ -94,9 +102,9 @@ const FeaturedProducts = () => {
                 <Link
                   key={item.id}
                   to={href}
-                  className="group flex flex-col bg-[#0B2F6B] hover:bg-[#123F82] hover:shadow-md hover:scale-[1.02] transition-all duration-200"
+                  className="group flex flex-col overflow-hidden rounded-[18px] bg-white hover:shadow-[0_18px_38px_rgba(10,35,79,0.24)] hover:scale-[1.02] transition-all duration-200"
                 >
-                  <div className="aspect-square bg-[#0B2F6B] overflow-hidden">
+                  <div className="aspect-square bg-[#F2F4F7] overflow-hidden">
                     {img ? (
                       <img
                         src={img}
@@ -111,22 +119,22 @@ const FeaturedProducts = () => {
                         }}
                       />
                     ) : (
-                      <div className="w-full h-full bg-[#123F82] flex items-center justify-center">
-                        <span className="text-white/55 text-xs">No image</span>
+                      <div className="w-full h-full bg-[#1D57D8]/8 flex items-center justify-center">
+                        <span className="text-[#0A234F]/55 text-xs">No image</span>
                       </div>
                     )}
                   </div>
 
-                  <div className="px-2.5 py-2.5 flex flex-col gap-0.5 flex-1 border-t border-white/10">
+                  <div className="px-2.5 py-2.5 flex flex-col gap-0.5 flex-1 border-t border-[#0A234F]/8">
                     {item.category && (
-                      <span className="text-[10px] font-bold text-[#F5A300] uppercase tracking-wide line-clamp-1">
+                      <span className="text-[10px] font-bold text-[#1D57D8] uppercase tracking-wide line-clamp-1">
                         {item.category.name}
                       </span>
                     )}
-                    <p className="text-xs font-semibold text-white leading-snug line-clamp-2 flex-1">
+                    <p className="text-xs font-semibold text-[#0A234F] leading-snug line-clamp-2 flex-1">
                       {item.title}
                     </p>
-                    <p className="text-sm font-black text-white mt-1">
+                    <p className="text-sm font-black text-[#0A234F] mt-1">
                       £{item.price.toLocaleString("en-GB", {
                         minimumFractionDigits: 2,
                         maximumFractionDigits: 2,
@@ -138,11 +146,11 @@ const FeaturedProducts = () => {
             })}
           </div>
         ) : (
-          <div className="border border-white/10 bg-[#0B2F6B] px-6 py-10">
-            <p className="text-sm font-semibold text-white">
+          <div className="border border-[#0A234F]/10 bg-white px-6 py-10 text-[#0A234F]">
+            <p className="text-sm font-semibold">
               No listings available yet.
             </p>
-            <p className="text-xs text-white/60 mt-1.5 mb-6 max-w-md leading-relaxed">
+            <p className="text-xs text-[#0A234F]/60 mt-1.5 mb-6 max-w-md leading-relaxed">
               We are currently onboarding verified UK trade suppliers.
               Be among the first to list products on Loadify Market.
             </p>

--- a/src/components/FeaturedProducts.tsx
+++ b/src/components/FeaturedProducts.tsx
@@ -41,16 +41,16 @@ const FeaturedProducts = () => {
     return (
       <section className="relative" aria-label="Marketplace products">
         <div className="w-full max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 py-8">
-          <div className="h-4 w-44 bg-gray-100 rounded mb-1 animate-pulse" />
-          <div className="h-3 w-56 bg-gray-100 rounded mb-4 animate-pulse" />
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-px bg-white/5">
+          <div className="h-4 w-44 bg-white/10 rounded mb-1 animate-pulse" />
+          <div className="h-3 w-56 bg-white/10 rounded mb-4 animate-pulse" />
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-px bg-white/10">
             {Array.from({ length: 10 }).map((_, i) => (
-              <div key={i} className="bg-surface">
-                <div className="aspect-square bg-gray-100 animate-pulse" />
+              <div key={i} className="bg-[#0B2F6B]">
+                <div className="aspect-square bg-white/10 animate-pulse" />
                 <div className="px-2.5 py-2.5 space-y-1.5">
-                  <div className="h-2.5 w-16 bg-gray-100 rounded animate-pulse" />
-                  <div className="h-2.5 w-full bg-gray-100 rounded animate-pulse" />
-                  <div className="h-3.5 w-12 bg-gray-100 rounded animate-pulse" />
+                  <div className="h-2.5 w-16 bg-white/10 rounded animate-pulse" />
+                  <div className="h-2.5 w-full bg-white/10 rounded animate-pulse" />
+                  <div className="h-3.5 w-12 bg-white/10 rounded animate-pulse" />
                 </div>
               </div>
             ))}
@@ -63,20 +63,19 @@ const FeaturedProducts = () => {
   return (
     <section className="relative" aria-label="Marketplace products">
       <div className="relative z-10 w-full max-w-[1280px] mx-auto px-4 sm:px-6 lg:px-10 py-8">
-
         <div className="flex items-center justify-between mb-4">
           <div>
-              <h2 className="text-[13px] font-black text-white uppercase tracking-widest">
-                Marketplace Products
-              </h2>
-              <p className="text-[11px] text-slate-400 mt-0.5">
-                Listed by verified UK trade suppliers
-              </p>
+            <h2 className="text-[13px] font-black text-white uppercase tracking-widest">
+              Marketplace Products
+            </h2>
+            <p className="text-[11px] text-white/60 mt-0.5">
+              Listed by verified UK trade suppliers
+            </p>
           </div>
           {products.length > 0 && (
             <Link
               to="/catalog"
-              className="text-[11px] font-bold text-primary uppercase tracking-wide hover:underline flex items-center gap-1"
+              className="text-[11px] font-bold text-[#F5A300] uppercase tracking-wide hover:text-white flex items-center gap-1"
             >
               Browse All <ArrowRight className="h-3 w-3" />
             </Link>
@@ -84,8 +83,7 @@ const FeaturedProducts = () => {
         </div>
 
         {products.length > 0 ? (
-          /* Product grid — gap-px hairline borders */
-          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-px bg-white/5">
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-px bg-white/10">
             {products.map((item) => {
               const img =
                 Array.isArray(item.images) && item.images.length > 0
@@ -96,10 +94,9 @@ const FeaturedProducts = () => {
                 <Link
                   key={item.id}
                   to={href}
-                  className="group flex flex-col bg-surface hover:bg-elevated hover:shadow-md hover:scale-[1.02] transition-all duration-200"
+                  className="group flex flex-col bg-[#0B2F6B] hover:bg-[#123F82] hover:shadow-md hover:scale-[1.02] transition-all duration-200"
                 >
-                  {/* Square thumbnail */}
-                  <div className="aspect-square bg-surface overflow-hidden">
+                  <div className="aspect-square bg-[#0B2F6B] overflow-hidden">
                     {img ? (
                       <img
                         src={img}
@@ -114,23 +111,22 @@ const FeaturedProducts = () => {
                         }}
                       />
                     ) : (
-                      <div className="w-full h-full bg-elevated flex items-center justify-center">
-                        <span className="text-slate-400 text-xs">No image</span>
+                      <div className="w-full h-full bg-[#123F82] flex items-center justify-center">
+                        <span className="text-white/55 text-xs">No image</span>
                       </div>
                     )}
                   </div>
 
-                  {/* Product info */}
-                  <div className="px-2.5 py-2.5 flex flex-col gap-0.5 flex-1 border-t border-white/5">
+                  <div className="px-2.5 py-2.5 flex flex-col gap-0.5 flex-1 border-t border-white/10">
                     {item.category && (
-                      <span className="text-[10px] font-bold text-secondary uppercase tracking-wide line-clamp-1">
+                      <span className="text-[10px] font-bold text-[#F5A300] uppercase tracking-wide line-clamp-1">
                         {item.category.name}
                       </span>
                     )}
                     <p className="text-xs font-semibold text-white leading-snug line-clamp-2 flex-1">
                       {item.title}
                     </p>
-                    <p className="text-sm font-black text-secondary mt-1">
+                    <p className="text-sm font-black text-white mt-1">
                       £{item.price.toLocaleString("en-GB", {
                         minimumFractionDigits: 2,
                         maximumFractionDigits: 2,
@@ -142,24 +138,22 @@ const FeaturedProducts = () => {
             })}
           </div>
         ) : (
-          /* Professional empty state — no fake listings */
-          <div className="border border-white/10 bg-surface px-6 py-10">
+          <div className="border border-white/10 bg-[#0B2F6B] px-6 py-10">
             <p className="text-sm font-semibold text-white">
               No listings available yet.
             </p>
-            <p className="text-xs text-slate-400 mt-1.5 mb-6 max-w-md leading-relaxed">
+            <p className="text-xs text-white/60 mt-1.5 mb-6 max-w-md leading-relaxed">
               We are currently onboarding verified UK trade suppliers.
               Be among the first to list products on Loadify Market.
             </p>
             <Link
               to="/register?type=seller"
-              className="inline-flex items-center gap-2 px-6 py-2.5 bg-primary text-black text-xs font-bold uppercase tracking-wide hover:bg-primary-hover transition-colors"
+              className="inline-flex items-center gap-2 px-6 py-2.5 bg-[#F5A300] text-[#0A234F] text-xs font-bold uppercase tracking-wide hover:bg-[#E69500] transition-colors"
             >
               Register as Supplier <ArrowRight className="h-3.5 w-3.5" />
             </Link>
           </div>
         )}
-
       </div>
     </section>
   );

--- a/src/components/FeaturesGrid.tsx
+++ b/src/components/FeaturesGrid.tsx
@@ -38,67 +38,58 @@ const features: Feature[] = [
 
 export default function FeaturesGrid() {
   return (
-    <div className="sm:flex-1 sm:rounded-2xl sm:border sm:border-white/5 sm:bg-elevated sm:p-6 lg:p-8 sm:flex sm:flex-col">
-
-      {/* Section heading */}
-      <h2
-        className="text-[17px] sm:text-xl font-semibold text-white mb-3 sm:mb-1"
-      >
+    <div className="sm:flex-1 sm:rounded-2xl sm:border sm:border-white/10 sm:bg-[#0B2F6B] sm:p-6 lg:p-8 sm:flex sm:flex-col">
+      <h2 className="text-[17px] sm:text-xl font-semibold text-white mb-3 sm:mb-1">
         Everything you need to{' '}
-        <span className="text-primary sm:text-primary">buy and sell</span>
+        <span className="text-[#F5A300]">buy and sell</span>
       </h2>
 
-      {/* ── Mobile: spec-exact card list ────────────────────────────── */}
       <div className="flex flex-col sm:hidden" style={{ gap: '12px', marginTop: '12px' }}>
         {features.map((feature) => {
           const Icon = feature.icon;
           return (
             <div
               key={feature.title}
+              className="bg-[#0B2F6B]"
               style={{
                 display: 'flex',
                 alignItems: 'center',
                 gap: '14px',
                 minHeight: '72px',
-                
-                border: '1px solid rgba(255,255,255,0.08)',
+                border: '1px solid rgba(255,255,255,0.10)',
                 borderRadius: '16px',
                 padding: '16px',
               }}
             >
-              {/* Icon box */}
               <div
                 style={{
                   width: '40px',
                   height: '40px',
                   borderRadius: '12px',
-                  background: 'rgba(212,175,55,0.1)',
-                  border: '1px solid rgba(212,175,55,0.2)',
+                  background: 'rgba(245,163,0,0.10)',
+                  border: '1px solid rgba(245,163,0,0.22)',
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
                   flexShrink: 0,
                 }}
               >
-                <Icon style={{ width: '18px', height: '18px' }} className="text-primary" aria-hidden="true" />
+                <Icon style={{ width: '18px', height: '18px' }} className="text-[#F5A300]" aria-hidden="true" />
               </div>
-              {/* Text */}
               <div style={{ flex: 1, minWidth: 0 }}>
                 <p style={{ fontSize: '14px', fontWeight: 600, lineHeight: 1.2 }} className="text-white">
                   {feature.title}
                 </p>
-                <p style={{ fontSize: '12px', lineHeight: 1.4, marginTop: '3px' }} className="text-muted-foreground">
+                <p style={{ fontSize: '12px', lineHeight: 1.4, marginTop: '3px' }} className="text-white/62">
                   {feature.description}
                 </p>
               </div>
-              {/* Chevron */}
-              <ChevronRight style={{ width: '16px', height: '16px', flexShrink: 0 }} className="text-muted-foreground" aria-hidden="true" />
+              <ChevronRight style={{ width: '16px', height: '16px', flexShrink: 0 }} className="text-white/48" aria-hidden="true" />
             </div>
           );
         })}
       </div>
 
-      {/* ── Desktop: 2×2 grid ─────────────────────────────────────────── */}
       <div className="hidden sm:grid grid-cols-2 gap-6 flex-1 mt-4">
         {features.map((feature) => {
           const Icon = feature.icon;
@@ -106,19 +97,15 @@ export default function FeaturesGrid() {
             <div
               key={feature.title}
               data-parallax
-              className="flex flex-col gap-3 rounded-2xl border border-white/5 bg-elevated p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_25px_rgba(212,175,55,0.15)] hover:border-primary/40"
+              className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-[#0A234F] p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_25px_rgba(29,87,216,0.22)] hover:border-[#F5A300]/40"
             >
-              <Icon
-                className="w-7 h-7 text-primary shrink-0 icon-pulse"
-                aria-hidden="true"
-              />
+              <Icon className="w-7 h-7 text-[#F5A300] shrink-0 icon-pulse" aria-hidden="true" />
               <p className="text-base font-semibold text-white leading-tight">{feature.title}</p>
-              <p className="text-sm text-slate-400 leading-relaxed">{feature.description}</p>
+              <p className="text-sm text-white/62 leading-relaxed">{feature.description}</p>
             </div>
           );
         })}
       </div>
-
     </div>
   );
 }

--- a/src/components/FeaturesGrid.tsx
+++ b/src/components/FeaturesGrid.tsx
@@ -38,7 +38,10 @@ const features: Feature[] = [
 
 export default function FeaturesGrid() {
   return (
-    <div className="sm:flex-1 sm:rounded-2xl sm:border sm:border-white/10 sm:bg-[#0B2F6B] sm:p-6 lg:p-8 sm:flex sm:flex-col">
+    <div
+      className="sm:flex-1 sm:rounded-2xl sm:border sm:border-white/10 sm:bg-[#0A234F] sm:p-6 lg:p-8 sm:flex sm:flex-col"
+      style={{ backgroundImage: 'radial-gradient(circle at 100% 0%, rgba(29,87,216,0.24), transparent 42%)' }}
+    >
       <h2 className="text-[17px] sm:text-xl font-semibold text-white mb-3 sm:mb-1">
         Everything you need to{' '}
         <span className="text-[#F5A300]">buy and sell</span>
@@ -50,7 +53,7 @@ export default function FeaturesGrid() {
           return (
             <div
               key={feature.title}
-              className="bg-[#0B2F6B]"
+              className="bg-[#0A234F]"
               style={{
                 display: 'flex',
                 alignItems: 'center',
@@ -59,6 +62,7 @@ export default function FeaturesGrid() {
                 border: '1px solid rgba(255,255,255,0.10)',
                 borderRadius: '16px',
                 padding: '16px',
+                backgroundImage: 'radial-gradient(circle at 100% 0%, rgba(29,87,216,0.22), transparent 48%)',
               }}
             >
               <div
@@ -66,8 +70,8 @@ export default function FeaturesGrid() {
                   width: '40px',
                   height: '40px',
                   borderRadius: '12px',
-                  background: 'rgba(245,163,0,0.10)',
-                  border: '1px solid rgba(245,163,0,0.22)',
+                  background: 'rgba(255,255,255,0.07)',
+                  border: '1px solid rgba(255,255,255,0.10)',
                   display: 'flex',
                   alignItems: 'center',
                   justifyContent: 'center',
@@ -97,7 +101,7 @@ export default function FeaturesGrid() {
             <div
               key={feature.title}
               data-parallax
-              className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-[#0A234F] p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_25px_rgba(29,87,216,0.22)] hover:border-[#F5A300]/40"
+              className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/[0.045] p-6 transition-all duration-300 hover:-translate-y-1 hover:bg-white/[0.07] hover:shadow-[0_0_25px_rgba(29,87,216,0.22)] hover:border-[#F5A300]/40"
             >
               <Icon className="w-7 h-7 text-[#F5A300] shrink-0 icon-pulse" aria-hidden="true" />
               <p className="text-base font-semibold text-white leading-tight">{feature.title}</p>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -22,9 +22,12 @@ const FooterLink = ({ to, children }: { to: string; children: React.ReactNode })
 
 const Footer = () => {
   return (
-    <footer className="bg-[#0A234F] text-white/68 border-t border-white/10">
+    <footer
+      className="bg-[#0A234F] text-white/68 border-t border-white/10"
+      style={{ backgroundImage: 'radial-gradient(circle at 100% 0%, rgba(29,87,216,0.26), transparent 42%)' }}
+    >
       <div
-        className="sm:hidden flex flex-col items-center gap-3 bg-[#0A234F]"
+        className="sm:hidden flex flex-col items-center gap-3 bg-transparent"
         style={{ padding: '20px 16px' }}
       >
         <div className="flex items-center gap-5 flex-wrap justify-center">
@@ -37,7 +40,7 @@ const Footer = () => {
         </p>
       </div>
 
-      <div className="hidden sm:block border-b border-white/10 bg-[#0B2F6B]/45">
+      <div className="hidden sm:block border-b border-white/10 bg-white/[0.045]">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5 flex flex-col sm:flex-row items-center justify-between gap-4">
           <div className="flex flex-wrap items-center justify-center sm:justify-start gap-6">
             <div className="flex items-center gap-2 text-sm font-medium text-white/68">
@@ -160,7 +163,7 @@ const Footer = () => {
         </div>
       </div>
 
-      <div className="hidden sm:block border-t border-white/10 bg-[#0B2F6B]/35">
+      <div className="hidden sm:block border-t border-white/10 bg-white/[0.045]">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5 flex flex-col lg:flex-row items-start lg:items-center justify-between gap-3">
           <p className="text-[12px] text-white/55">
             &copy; 2021 XDrive Logistics Ltd (Company No. 13171804). All rights reserved.

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -3,10 +3,8 @@ import { ShieldCheck, Store, Truck, Facebook, Twitter, Instagram, Linkedin } fro
 import SocialCard from "@/components/ui/SocialCard";
 import TikTokIcon from "@/components/ui/TikTokIcon";
 
-// ─── helpers ────────────────────────────────────────────────────────────────
-
 const ColHeading = ({ children }: { children: React.ReactNode }) => (
-  <p className="text-[11px] font-bold tracking-widest uppercase text-primary mb-4">
+  <p className="text-[11px] font-bold tracking-widest uppercase text-[#F5A300] mb-4">
     {children}
   </p>
 );
@@ -15,98 +13,88 @@ const FooterLink = ({ to, children }: { to: string; children: React.ReactNode })
   <li>
     <Link
       to={to}
-      className="text-[13px] text-muted-foreground hover:text-primary transition-colors duration-150"
+      className="text-[13px] text-white/68 hover:text-[#F5A300] transition-colors duration-150"
     >
       {children}
     </Link>
   </li>
 );
 
-// ─── Footer ──────────────────────────────────────────────────────────────────
-
 const Footer = () => {
   return (
-    <footer className="bg-surface text-muted-foreground border-t border-white/[0.06]">
-
-      {/* ── Mobile: compact footer ───────────────────────────────────────── */}
+    <footer className="bg-[#0A234F] text-white/68 border-t border-white/10">
       <div
-        className="sm:hidden flex flex-col items-center gap-3 bg-surface"
+        className="sm:hidden flex flex-col items-center gap-3 bg-[#0A234F]"
         style={{ padding: '20px 16px' }}
       >
         <div className="flex items-center gap-5 flex-wrap justify-center">
-          <Link to="/terms"   style={{ fontSize: '13px', textDecoration: 'none' }} className="text-white/70">Terms</Link>
-          <Link to="/privacy" style={{ fontSize: '13px', textDecoration: 'none' }} className="text-white/70">Privacy</Link>
-          <Link to="/contact" style={{ fontSize: '13px', textDecoration: 'none' }} className="text-white/70">Support</Link>
+          <Link to="/terms" style={{ fontSize: '13px', textDecoration: 'none' }} className="text-white/75">Terms</Link>
+          <Link to="/privacy" style={{ fontSize: '13px', textDecoration: 'none' }} className="text-white/75">Privacy</Link>
+          <Link to="/contact" style={{ fontSize: '13px', textDecoration: 'none' }} className="text-white/75">Support</Link>
         </div>
-        <p style={{ fontSize: '12px', textAlign: 'center' }} className="text-white/45">
+        <p style={{ fontSize: '12px', textAlign: 'center' }} className="text-white/52">
           &copy; {new Date().getFullYear()} Loadify Market
         </p>
       </div>
 
-      {/* ── Trust row (desktop only) ─────────────────────────────────────── */}
-      <div className="hidden sm:block border-b border-white/[0.07]">
+      <div className="hidden sm:block border-b border-white/10 bg-[#0B2F6B]/45">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5 flex flex-col sm:flex-row items-center justify-between gap-4">
           <div className="flex flex-wrap items-center justify-center sm:justify-start gap-6">
-            <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              <ShieldCheck className="h-5 w-5 text-primary shrink-0" />
+            <div className="flex items-center gap-2 text-sm font-medium text-white/68">
+              <ShieldCheck className="h-5 w-5 text-[#F5A300] shrink-0" />
               Registered Sellers
             </div>
-            <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              <ShieldCheck className="h-5 w-5 text-primary shrink-0" />
+            <div className="flex items-center gap-2 text-sm font-medium text-white/68">
+              <ShieldCheck className="h-5 w-5 text-[#F5A300] shrink-0" />
               Secure Platform
             </div>
-            <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              <Truck className="h-5 w-5 text-primary shrink-0" />
+            <div className="flex items-center gap-2 text-sm font-medium text-white/68">
+              <Truck className="h-5 w-5 text-[#F5A300] shrink-0" />
               UK Delivery Support
             </div>
-            <div className="flex items-center gap-2 text-sm font-medium text-muted-foreground">
-              <Store className="h-5 w-5 text-primary shrink-0" />
+            <div className="flex items-center gap-2 text-sm font-medium text-white/68">
+              <Store className="h-5 w-5 text-[#F5A300] shrink-0" />
               UK-Based Marketplace
             </div>
           </div>
 
           <div className="flex items-center gap-3">
-            <SocialCard href="https://www.facebook.com/profile.php?id=61583570176707" label="Loadify Market on Facebook"   Icon={Facebook}  platform="facebook"  size="footer" />
-            <SocialCard href="https://www.twitter.com/loadifymarket"           label="Loadify Market on X / Twitter" Icon={Twitter}   platform="twitter"   size="footer" />
-            <SocialCard href="https://www.instagram.com/loadifymarket"         label="Loadify Market on Instagram"   Icon={Instagram} platform="instagram" size="footer" />
-            <SocialCard href="https://www.tiktok.com/@loadifymarket"           label="Loadify Market on TikTok"      Icon={TikTokIcon} platform="tiktok"   size="footer" />
-            <SocialCard href="https://www.linkedin.com/company/loadify-market"  label="Loadify Market on LinkedIn"    Icon={Linkedin}  platform="linkedin"  size="footer" />
+            <SocialCard href="https://www.facebook.com/profile.php?id=61583570176707" label="Loadify Market on Facebook" Icon={Facebook} platform="facebook" size="footer" />
+            <SocialCard href="https://www.twitter.com/loadifymarket" label="Loadify Market on X / Twitter" Icon={Twitter} platform="twitter" size="footer" />
+            <SocialCard href="https://www.instagram.com/loadifymarket" label="Loadify Market on Instagram" Icon={Instagram} platform="instagram" size="footer" />
+            <SocialCard href="https://www.tiktok.com/@loadifymarket" label="Loadify Market on TikTok" Icon={TikTokIcon} platform="tiktok" size="footer" />
+            <SocialCard href="https://www.linkedin.com/company/loadify-market" label="Loadify Market on LinkedIn" Icon={Linkedin} platform="linkedin" size="footer" />
           </div>
         </div>
       </div>
 
-      {/* ── Main columns (desktop only) ─────────────────────────────────── */}
       <div className="hidden sm:block max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8 lg:py-12">
-
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-6 gap-6">
-
-          {/* Col 1 — About (spans 2 columns on lg) */}
           <div className="col-span-2 sm:col-span-3 lg:col-span-2">
-            <p className="text-lg font-bold text-foreground mb-3">Loadify Market</p>
-            <p className="text-[13px] text-muted-foreground leading-relaxed mb-4">
-              Loadify Market is operated by <strong className="text-muted-foreground">XDrive Logistics Ltd</strong>.
+            <p className="text-lg font-bold text-white mb-3">Loadify Market</p>
+            <p className="text-[13px] text-white/68 leading-relaxed mb-4">
+              Loadify Market is operated by <strong className="text-white/80">XDrive Logistics Ltd</strong>.
               We are a UK-based marketplace that connects buyers with independent sellers in the UK and approved international sellers that comply with UK and Stripe requirements.
               Loadify Market does not own, stock, sell, or ship any products — all orders are
               fulfilled directly by the independent seller.
             </p>
-            <ul className="space-y-1 text-[12px] text-muted-foreground/75">
+            <ul className="space-y-1 text-[12px] text-white/55">
               <li>Company No. 13171804</li>
               <li>VAT GB375949535</li>
               <li>101 Cornelian Street, Blackburn BB1 9QL, UK</li>
               <li>
-                <a href="mailto:contact@loadifymarket.co.uk" className="hover:text-white/70 transition-colors">
+                <a href="mailto:contact@loadifymarket.co.uk" className="hover:text-[#F5A300] transition-colors">
                   contact@loadifymarket.co.uk
                 </a>
               </li>
               <li>
-                <a href="tel:+447423272138" className="hover:text-white/70 transition-colors">
+                <a href="tel:+447423272138" className="hover:text-[#F5A300] transition-colors">
                   +44 7423 272138
                 </a>
               </li>
             </ul>
           </div>
 
-          {/* Col 2 — For Buyers */}
           <div>
             <ColHeading>For Buyers</ColHeading>
             <ul className="space-y-2.5">
@@ -120,7 +108,6 @@ const Footer = () => {
             </ul>
           </div>
 
-          {/* Col 3 — For Sellers */}
           <div>
             <ColHeading>For Sellers</ColHeading>
             <ul className="space-y-2.5">
@@ -134,7 +121,6 @@ const Footer = () => {
             </ul>
           </div>
 
-          {/* Col 4 — Marketplace + Company */}
           <div>
             <ColHeading>Marketplace</ColHeading>
             <ul className="space-y-2.5">
@@ -144,7 +130,7 @@ const Footer = () => {
               <FooterLink to="/contact">Report a Problem</FooterLink>
             </ul>
 
-            <p className="text-[11px] font-bold tracking-widest uppercase text-primary mt-7 mb-4">
+            <p className="text-[11px] font-bold tracking-widest uppercase text-[#F5A300] mt-7 mb-4">
               Company
             </p>
             <ul className="space-y-2.5">
@@ -154,7 +140,6 @@ const Footer = () => {
             </ul>
           </div>
 
-          {/* Col 5 — Legal */}
           <div>
             <ColHeading>Legal</ColHeading>
             <ul className="space-y-2.5">
@@ -172,28 +157,23 @@ const Footer = () => {
               <FooterLink to="/seller-terms">Seller Terms</FooterLink>
             </ul>
           </div>
-
         </div>
       </div>
 
-      {/* ── Bottom bar (desktop only) ────────────────────────────────────── */}
-      <div className="hidden sm:block border-t border-white/[0.07]">
+      <div className="hidden sm:block border-t border-white/10 bg-[#0B2F6B]/35">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-5 flex flex-col lg:flex-row items-start lg:items-center justify-between gap-3">
-
-          <p className="text-[12px] text-muted-foreground/65">
+          <p className="text-[12px] text-white/55">
             &copy; 2021 XDrive Logistics Ltd (Company No. 13171804). All rights reserved.
             Loadify Market is a trading name of XDrive Logistics Ltd, registered in England &amp; Wales.
           </p>
 
-          <p className="text-[12px] text-muted-foreground/65 lg:text-right">
+          <p className="text-[12px] text-white/55 lg:text-right">
             Payments secured by Stripe · Independent sellers fulfil all orders ·
             Loadify Market is not a seller or retailer.
           </p>
-
         </div>
 
-        {/* Quick legal links bar */}
-        <div className="border-t border-white/[0.05]">
+        <div className="border-t border-white/[0.08]">
           <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 flex flex-wrap gap-x-5 gap-y-1">
             {[
               { to: "/terms", label: "Terms" },
@@ -210,7 +190,7 @@ const Footer = () => {
               <Link
                 key={l.to}
                 to={l.to}
-                className="text-[11px] text-muted-foreground/60 hover:text-muted-foreground/85 transition-colors"
+                className="text-[11px] text-white/52 hover:text-[#F5A300] transition-colors"
               >
                 {l.label}
               </Link>
@@ -218,7 +198,6 @@ const Footer = () => {
           </div>
         </div>
       </div>
-
     </footer>
   );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -10,18 +10,6 @@ import { useCategories } from "@/hooks/useCategories";
 import type { CategoryNode } from "@/hooks/useCategories";
 import { supabase } from "@/lib/supabase";
 
-/**
- * Marketplace-style desktop header — always renders with the opaque dark-navy background.
- * Fixed at top-0 on every public-marketplace page.
- * Row 1 (h-16): Hamburger (LEFT, all sizes) | Logo | Search | Cart + auth actions
- * Row 2 (h-12): Category quick-links
- *
- * On mobile viewports (< 768 px) this header is always hidden via `hidden md:block`.
- * Each mobile page provides its own mobile-specific header (MobileAppHeader, back-button
- * bar, etc.).  The MobileAppLayout shell (used automatically by MainLayout on mobile)
- * provides MobileBottomNav for in-app navigation.
- */
-
 const Header = () => {
   const [query, setQuery] = useState("");
   const [mobileOpen, setMobileOpen] = useState(false);
@@ -89,12 +77,12 @@ const Header = () => {
 
   return (
     <header
-      className="fixed top-0 left-0 right-0 z-40 bg-surface border-b border-white/[0.06] shadow-[0_8px_25px_rgba(0,0,0,0.35)] hidden md:block"
+      className="fixed top-0 left-0 right-0 z-40 bg-[#0A234F] border-b border-white/10 shadow-[0_8px_25px_rgba(10,35,79,0.32)] hidden md:block"
       style={{ willChange: "transform", paddingTop: "env(safe-area-inset-top, 0px)" }}
     >
       <div className="w-full px-4 sm:px-6 lg:px-8 h-[60px] md:h-[72px] flex items-center gap-4">
         <button
-          className="p-2.5 text-muted-foreground bg-white/[0.10] hover:text-primary hover:bg-white/[0.18] active:bg-white/[0.22] rounded-xl transition-all shrink-0 ring-1 ring-white/20"
+          className="p-2.5 text-white/75 bg-[#0B2F6B] hover:text-[#F5A300] hover:bg-[#123F82] active:bg-[#123F82] rounded-xl transition-all shrink-0 ring-1 ring-white/20"
           onClick={() => setMobileOpen(true)}
           aria-label="Open navigation menu"
           aria-expanded={mobileOpen}
@@ -107,24 +95,24 @@ const Header = () => {
           <img src={logo} alt="" aria-hidden="true" className="h-9 w-9" />
           <span className="flex flex-col leading-tight">
             <span className="font-display text-[15px] font-bold text-white tracking-tight">Loadify</span>
-            <span className="hidden sm:block font-display text-[13px] font-bold text-primary tracking-tight">Market</span>
+            <span className="hidden sm:block font-display text-[13px] font-bold text-[#F5A300] tracking-tight">Market</span>
           </span>
         </Link>
 
         <form onSubmit={handleSearch} className="hidden md:flex flex-1 max-w-2xl mx-auto min-w-0">
           <div className="relative flex items-center w-full">
-            <Search className="absolute left-3.5 h-4 w-4 sm:left-4 sm:h-[18px] sm:w-[18px] text-white/35 pointer-events-none" aria-hidden="true" />
+            <Search className="absolute left-3.5 h-4 w-4 sm:left-4 sm:h-[18px] sm:w-[18px] text-white/55 pointer-events-none" aria-hidden="true" />
             <input
               type="search"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
               placeholder="Search products, categories, sellers..."
               aria-label="Search marketplace"
-              className="w-full h-11 sm:h-[46px] pl-9 sm:pl-11 pr-10 sm:pr-28 bg-[rgba(15,23,42,0.85)] border border-white/[0.08] rounded-2xl text-xs sm:text-sm text-white placeholder:text-muted-foreground focus:outline-none focus:border-primary/40 focus:ring-2 focus:ring-primary/10 transition-all duration-200"
+              className="w-full h-11 sm:h-[46px] pl-9 sm:pl-11 pr-10 sm:pr-28 bg-[#0B2F6B] border border-white/15 rounded-2xl text-xs sm:text-sm text-white placeholder:text-white/55 focus:outline-none focus:border-[#F5A300]/50 focus:ring-2 focus:ring-[#F5A300]/15 transition-all duration-200"
             />
             <button
               type="submit"
-              className="absolute right-1.5 top-1/2 -translate-y-1/2 h-8 sm:h-[34px] px-3 sm:px-5 bg-primary hover:bg-primary-hover hover:-translate-y-0.5 hover:shadow-[0_0_18px_rgba(212,175,55,0.25)] text-black text-xs sm:text-[13px] font-bold rounded-xl transition-all duration-250"
+              className="absolute right-1.5 top-1/2 -translate-y-1/2 h-8 sm:h-[34px] px-3 sm:px-5 bg-[#F5A300] hover:bg-[#E69500] hover:-translate-y-0.5 hover:shadow-[0_0_18px_rgba(245,163,0,0.25)] text-[#0A234F] text-xs sm:text-[13px] font-bold rounded-xl transition-all duration-250"
               aria-label="Search"
             >
               <span className="hidden sm:inline">Search</span>
@@ -135,32 +123,32 @@ const Header = () => {
 
         <Link
           to="/cart"
-          className="lg:hidden relative p-2.5 text-muted-foreground hover:text-primary hover:-translate-y-0.5 hover:drop-shadow-[0_0_7px_rgba(212,175,55,0.35)] hover:bg-white/10 rounded-xl transition-all shrink-0"
+          className="lg:hidden relative p-2.5 text-white/75 hover:text-[#F5A300] hover:-translate-y-0.5 hover:drop-shadow-[0_0_7px_rgba(245,163,0,0.30)] hover:bg-white/10 rounded-xl transition-all shrink-0"
           aria-label="Shopping cart"
         >
           <ShoppingCart className="h-5 w-5" />
           {cartCount > 0 && (
-            <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] rounded-full bg-primary text-white text-[10px] font-bold flex items-center justify-center px-0.5">
+            <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] rounded-full bg-[#F5A300] text-[#0A234F] text-[10px] font-bold flex items-center justify-center px-0.5">
               {cartCount}
             </span>
           )}
         </Link>
 
         <div className="hidden lg:flex items-center gap-1.5 shrink-0">
-          <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-primary hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
+          <Button variant="ghost" size="sm" className="text-white/70 hover:text-[#F5A300] hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
             <Link to="/register?type=seller">Sell Stock</Link>
           </Button>
-          <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-primary hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
+          <Button variant="ghost" size="sm" className="text-white/70 hover:text-[#F5A300] hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
             <Link to="/shipping-policy">Shipping Policy</Link>
           </Button>
           <Link
             to="/cart"
-            className="relative p-2.5 text-muted-foreground hover:text-primary hover:-translate-y-0.5 hover:drop-shadow-[0_0_7px_rgba(212,175,55,0.35)] hover:bg-white/10 rounded-xl transition-all"
+            className="relative p-2.5 text-white/75 hover:text-[#F5A300] hover:-translate-y-0.5 hover:drop-shadow-[0_0_7px_rgba(245,163,0,0.30)] hover:bg-white/10 rounded-xl transition-all"
             aria-label="Shopping cart"
           >
             <ShoppingCart className="h-5 w-5" />
             {cartCount > 0 && (
-              <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] rounded-full bg-primary text-white text-[10px] font-bold flex items-center justify-center px-0.5">
+              <span className="absolute -top-0.5 -right-0.5 min-w-[18px] h-[18px] rounded-full bg-[#F5A300] text-[#0A234F] text-[10px] font-bold flex items-center justify-center px-0.5">
                 {cartCount}
               </span>
             )}
@@ -168,33 +156,33 @@ const Header = () => {
 
           {user ? (
             <>
-              <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-primary hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
+              <Button variant="ghost" size="sm" className="text-white/70 hover:text-[#F5A300] hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
                 <Link to={dashboardPath}>
                   <LayoutDashboard className="h-4 w-4 mr-1.5" aria-hidden="true" />
                   {user.role === "admin" ? "Admin Hub" : "Dashboard"}
                 </Link>
               </Button>
-              <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-primary hover:bg-white/10 font-medium rounded-xl transition-all" onClick={handleLogout}>
+              <Button variant="ghost" size="sm" className="text-white/70 hover:text-[#F5A300] hover:bg-white/10 font-medium rounded-xl transition-all" onClick={handleLogout}>
                 <LogOut className="h-4 w-4 mr-1.5" aria-hidden="true" /> Sign Out
               </Button>
             </>
           ) : (
             <>
-              <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-primary hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
+              <Button variant="ghost" size="sm" className="text-white/70 hover:text-[#F5A300] hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
                 <Link to="/#how-it-works-buyers">For Buyers</Link>
               </Button>
-              <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-primary hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
+              <Button variant="ghost" size="sm" className="text-white/70 hover:text-[#F5A300] hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
                 <Link to="/#how-it-works-sellers">For Sellers</Link>
               </Button>
-              <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-primary hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
+              <Button variant="ghost" size="sm" className="text-white/70 hover:text-[#F5A300] hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
                 <Link to="/help">Help</Link>
               </Button>
-              <Button variant="ghost" size="sm" className="text-muted-foreground hover:text-primary hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
+              <Button variant="ghost" size="sm" className="text-white/70 hover:text-[#F5A300] hover:bg-white/10 font-medium rounded-xl transition-all" asChild>
                 <Link to="/login">Sign In</Link>
               </Button>
               <Button
                 size="sm"
-                className="h-9 bg-primary hover:bg-primary-hover border border-[rgba(212,175,55,0.35)] text-black font-bold px-5 rounded-xl shadow-[0_6px_16px_rgba(212,175,55,0.25)] hover:-translate-y-0.5 hover:shadow-[0_0_22px_rgba(212,175,55,0.28),0_10px_24px_rgba(0,0,0,0.40)] transition-all duration-250 ml-1"
+                className="h-9 bg-[#F5A300] hover:bg-[#E69500] border border-[#F5A300]/40 text-[#0A234F] font-bold px-5 rounded-xl shadow-[0_6px_16px_rgba(245,163,0,0.24)] hover:-translate-y-0.5 hover:shadow-[0_0_22px_rgba(245,163,0,0.28),0_10px_24px_rgba(10,35,79,0.32)] transition-all duration-250 ml-1"
                 asChild
               >
                 <Link to="/register">Register</Link>
@@ -204,7 +192,7 @@ const Header = () => {
         </div>
       </div>
 
-      <nav aria-label="Category navigation" className="hidden md:block border-t border-white/[0.08]">
+      <nav aria-label="Category navigation" className="hidden md:block border-t border-white/10 bg-[#0A234F]">
         <div className="w-full px-4 sm:px-6 lg:px-8">
           <div className="h-[50px] overflow-x-auto scrollbar-none">
             <div className="grid grid-flow-col auto-cols-fr items-center justify-between min-w-[980px] lg:min-w-0 gap-x-8 h-full">
@@ -224,16 +212,16 @@ const Header = () => {
                     <Link
                       to={link.to}
                       className={[
-                        "nav-cat-link text-[13px] font-semibold text-foreground/80 hover:text-primary hover:-translate-y-px hover:[text-shadow:0_0_8px_rgba(212,175,55,0.25)] hover:bg-white/[0.08] px-3 py-2 rounded-lg transition-all duration-200 whitespace-nowrap text-center w-full",
-                        isHovered ? "bg-white/[0.08] text-primary" : "",
+                        "nav-cat-link text-[13px] font-semibold text-white/82 hover:text-[#F5A300] hover:-translate-y-px hover:[text-shadow:0_0_8px_rgba(245,163,0,0.22)] hover:bg-white/[0.08] px-3 py-2 rounded-lg transition-all duration-200 whitespace-nowrap text-center w-full",
+                        isHovered ? "bg-white/[0.08] text-[#F5A300]" : "",
                       ].join(" ")}
                     >
                       {link.label}
                     </Link>
                     {hasChildren && isHovered && (
                       <div
-                        className="absolute top-full left-0 z-50 min-w-[180px] rounded-xl border border-white/[0.12] shadow-2xl overflow-hidden"
-                        style={{ background: "rgba(14,21,32,1)", marginTop: "2px" }}
+                        className="absolute top-full left-0 z-50 min-w-[180px] rounded-xl border border-white/15 shadow-2xl overflow-hidden"
+                        style={{ background: "#0B2F6B", marginTop: "2px" }}
                         onMouseEnter={cancelClose}
                         onMouseLeave={scheduleClose}
                       >
@@ -241,12 +229,12 @@ const Header = () => {
                           <Link
                             key={child.id}
                             to={`/category/${child.slug}`}
-                            className="flex items-center justify-between px-4 py-2.5 text-[13px] font-medium text-white/75 hover:text-white hover:bg-white/[0.08] transition-colors"
+                            className="flex items-center justify-between px-4 py-2.5 text-[13px] font-medium text-white/78 hover:text-white hover:bg-[#1D57D8]/20 transition-colors"
                             onClick={() => setHoveredCat(null)}
                           >
                             {child.name}
                             {child.children?.length > 0 && (
-                              <ChevronRight className="h-3.5 w-3.5 text-white/40 shrink-0" />
+                              <ChevronRight className="h-3.5 w-3.5 text-white/48 shrink-0" />
                             )}
                           </Link>
                         ))}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -4,7 +4,7 @@ import PaymentCard from '@/components/ui/PaymentCard';
 const HeroSection = () => (
   <section
     aria-label="Loadify Market UK Online Marketplace"
-    className="relative w-full min-h-[75vh] bg-background"
+    className="relative w-full min-h-[75vh] bg-[#0A234F]"
   >
     <picture>
       <source srcSet="/hero-gold.webp" type="image/webp" />
@@ -20,23 +20,23 @@ const HeroSection = () => (
 
     <div
       className="absolute inset-0 pointer-events-none"
-      style={{ background: 'linear-gradient(90deg, rgba(10,14,26,0.86) 0%, rgba(10,14,26,0.58) 42%, rgba(10,14,26,0.12) 100%)' }}
+      style={{ background: 'linear-gradient(90deg, rgba(10,35,79,0.92) 0%, rgba(10,35,79,0.72) 42%, rgba(29,87,216,0.16) 100%)' }}
       aria-hidden="true"
     />
 
     <div className="absolute inset-0 flex items-center">
       <div className="w-full px-4 sm:px-6 lg:pl-8 xl:pl-10 pt-[122px] pb-8 lg:pt-36 lg:pb-12">
         <div className="flex flex-col text-center sm:text-left items-center sm:items-start max-w-[540px]">
-          <div className="inline-flex items-center bg-primary text-black text-sm font-bold rounded-full px-4 py-1.5 tracking-wide uppercase mb-5">
+          <div className="inline-flex items-center bg-[#F5A300] text-[#0A234F] text-sm font-bold rounded-full px-4 py-1.5 tracking-wide uppercase mb-5">
             0% Seller Commission Until 31 December 2026
           </div>
 
-          <h1 className="text-[2.7rem] sm:text-5xl font-extrabold leading-[1.2] text-foreground mb-5">
+          <h1 className="text-[2.7rem] sm:text-5xl font-extrabold leading-[1.2] text-white mb-5">
             Sell in the UK with<br />
-            <span className="text-primary">0% Commission</span>
+            <span className="text-[#F5A300]">0% Commission</span>
           </h1>
 
-          <p className="text-lg text-muted-foreground mb-7">
+          <p className="text-lg text-white/78 mb-7">
             List products for free, sell at fixed prices, and get paid securely through Stripe. Buyers can shop trusted UK sellers with confidence.
           </p>
 
@@ -44,7 +44,7 @@ const HeroSection = () => (
             <Link
               to="/register?type=seller"
               data-magnetic
-              className="w-full sm:w-auto bg-primary hover:bg-primary-hover text-black font-semibold px-7 py-3.5 rounded-lg text-center transition-colors text-sm"
+              className="w-full sm:w-auto bg-[#F5A300] hover:bg-[#E69500] text-[#0A234F] font-semibold px-7 py-3.5 rounded-lg text-center transition-colors text-sm"
             >
               Create Free Seller Account
             </Link>
@@ -57,14 +57,14 @@ const HeroSection = () => (
             </Link>
           </div>
 
-          <div className="flex flex-wrap justify-center sm:justify-start gap-2 mt-4 text-[11px] font-bold uppercase tracking-wide text-white/80">
-            <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1">Free listings</span>
-            <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1">Fixed prices</span>
-            <span className="rounded-full border border-white/15 bg-white/5 px-3 py-1">Stripe payouts</span>
+          <div className="flex flex-wrap justify-center sm:justify-start gap-2 mt-4 text-[11px] font-bold uppercase tracking-wide text-white/82">
+            <span className="rounded-full border border-white/15 bg-[#1D57D8]/15 px-3 py-1">Free listings</span>
+            <span className="rounded-full border border-white/15 bg-[#1D57D8]/15 px-3 py-1">Fixed prices</span>
+            <span className="rounded-full border border-white/15 bg-[#1D57D8]/15 px-3 py-1">Stripe payouts</span>
           </div>
 
           <div className="flex flex-col items-center sm:items-start gap-2.5 mt-4">
-            <span className="text-[11px] font-bold tracking-[0.10em] uppercase text-muted-foreground">
+            <span className="text-[11px] font-bold tracking-[0.10em] uppercase text-white/65">
               Secure Payments Powered By
             </span>
             <div className="flex items-center gap-3 flex-wrap">

--- a/src/components/HowItWorksSection.tsx
+++ b/src/components/HowItWorksSection.tsx
@@ -48,7 +48,7 @@ function StepCard({ step }: { step: Step }) {
   return (
     <div
       data-parallax
-      className="rounded-2xl border border-white/10 bg-[#0A234F] p-6 flex flex-col gap-3 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_25px_rgba(29,87,216,0.22)] hover:border-[#F5A300]/40"
+      className="rounded-2xl border border-white/10 bg-white/[0.045] p-6 flex flex-col gap-3 transition-all duration-300 hover:-translate-y-1 hover:bg-white/[0.07] hover:shadow-[0_0_25px_rgba(29,87,216,0.22)] hover:border-[#F5A300]/40"
     >
       <Icon className="w-7 h-7 text-[#F5A300] shrink-0 icon-pulse" aria-hidden="true" />
       <p className="text-base font-semibold text-white leading-tight">{step.title}</p>
@@ -59,7 +59,11 @@ function StepCard({ step }: { step: Step }) {
 
 function StepsPanel({ id, title, steps }: { id: string; title: string; steps: Step[] }) {
   return (
-    <div id={id} className="w-full rounded-2xl border border-white/10 bg-[#0B2F6B] p-6 lg:p-8">
+    <div
+      id={id}
+      className="w-full rounded-2xl border border-white/10 bg-[#0A234F] p-6 lg:p-8"
+      style={{ backgroundImage: 'radial-gradient(circle at 100% 0%, rgba(29,87,216,0.24), transparent 42%)' }}
+    >
       <h2 className="text-xl font-semibold text-white mb-4">{title}</h2>
       <div className="grid grid-cols-3 gap-6">
         {steps.map((step) => (

--- a/src/components/HowItWorksSection.tsx
+++ b/src/components/HowItWorksSection.tsx
@@ -48,21 +48,18 @@ function StepCard({ step }: { step: Step }) {
   return (
     <div
       data-parallax
-      className="rounded-2xl border border-white/5 bg-elevated p-6 flex flex-col gap-3 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_25px_rgba(212,175,55,0.15)] hover:border-primary/40"
+      className="rounded-2xl border border-white/10 bg-[#0A234F] p-6 flex flex-col gap-3 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_25px_rgba(29,87,216,0.22)] hover:border-[#F5A300]/40"
     >
-      <Icon
-        className="w-7 h-7 text-primary shrink-0 icon-pulse"
-        aria-hidden="true"
-      />
+      <Icon className="w-7 h-7 text-[#F5A300] shrink-0 icon-pulse" aria-hidden="true" />
       <p className="text-base font-semibold text-white leading-tight">{step.title}</p>
-      <p className="text-sm text-slate-400 leading-relaxed">{step.description}</p>
+      <p className="text-sm text-white/62 leading-relaxed">{step.description}</p>
     </div>
   );
 }
 
 function StepsPanel({ id, title, steps }: { id: string; title: string; steps: Step[] }) {
   return (
-    <div id={id} className="w-full rounded-2xl border border-white/5 bg-elevated p-6 lg:p-8">
+    <div id={id} className="w-full rounded-2xl border border-white/10 bg-[#0B2F6B] p-6 lg:p-8">
       <h2 className="text-xl font-semibold text-white mb-4">{title}</h2>
       <div className="grid grid-cols-3 gap-6">
         {steps.map((step) => (

--- a/src/components/MobileAppHeader.tsx
+++ b/src/components/MobileAppHeader.tsx
@@ -72,143 +72,121 @@ export default function MobileAppHeader() {
 
   return (
     <>
-    <header
-      style={{
-        paddingTop: 'calc(0.75rem + env(safe-area-inset-top, 0px))',
-        paddingBottom: '0.75rem',
-        paddingLeft: 16,
-        paddingRight: 16,
-      }}
-      className="bg-background"
-    >
-      {/* ── Row 1: logo + brand name (left) | bell (right) ─── */}
-      <div className="flex items-center justify-between">
-        {/* Left: logo + brand */}
-        <div className="flex items-center gap-2.5" style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
-          {/* Logo */}
-          <img
-            src={logo}
-            alt=""
-            aria-hidden="true"
-            width={38}
-            height={38}
-            style={{ width: 38, height: 38, flexShrink: 0 }}
-          />
+      <header
+        style={{
+          paddingTop: 'calc(0.75rem + env(safe-area-inset-top, 0px))',
+          paddingBottom: '0.75rem',
+          paddingLeft: 16,
+          paddingRight: 16,
+        }}
+        className="bg-[#0A234F]"
+      >
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2.5" style={{ flex: 1, minWidth: 0, overflow: 'hidden' }}>
+            <img
+              src={logo}
+              alt=""
+              aria-hidden="true"
+              width={38}
+              height={38}
+              style={{ width: 38, height: 38, flexShrink: 0 }}
+            />
 
-          {/* Brand text */}
-          <div className="flex flex-col leading-none" style={{ minWidth: 0, gap: 2 }}>
-            <span
-              className="text-foreground"
-              style={{
-                fontSize: 'clamp(14px, 4.2vw, 19px)',
-                fontWeight: 800,
-                letterSpacing: 'clamp(0.5px, 0.2vw, 1px)',
-                lineHeight: 1,
-                fontFamily: 'var(--font-display)',
-                whiteSpace: 'nowrap',
-              }}
-            >
-              Loadify
-            </span>
-            <span
-              style={{
-                fontSize: 'clamp(10px, 2.8vw, 13px)',
-                fontWeight: 800,
-                letterSpacing: 'clamp(0.5px, 0.3vw, 1.5px)',
-                lineHeight: 1,
-                fontFamily: 'var(--font-display)',
-                whiteSpace: 'nowrap',
-              }}
-              className="text-primary"
-            >
-              MARKET
-            </span>
+            <div className="flex flex-col leading-none" style={{ minWidth: 0, gap: 2 }}>
+              <span
+                className="text-white"
+                style={{
+                  fontSize: 'clamp(14px, 4.2vw, 19px)',
+                  fontWeight: 800,
+                  letterSpacing: 'clamp(0.5px, 0.2vw, 1px)',
+                  lineHeight: 1,
+                  fontFamily: 'var(--font-display)',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                Loadify
+              </span>
+              <span
+                style={{
+                  fontSize: 'clamp(10px, 2.8vw, 13px)',
+                  fontWeight: 800,
+                  letterSpacing: 'clamp(0.5px, 0.3vw, 1.5px)',
+                  lineHeight: 1,
+                  fontFamily: 'var(--font-display)',
+                  whiteSpace: 'nowrap',
+                }}
+                className="text-[#F5A300]"
+              >
+                MARKET
+              </span>
+            </div>
           </div>
+
+          <button
+            onClick={() => navigate('/profile/notifications')}
+            aria-label={`Notifications${unread > 0 ? `, ${unread} unread` : ''}`}
+            className="relative h-11 w-11 shrink-0 cursor-pointer border-0 bg-transparent p-0 flex items-center justify-center"
+          >
+            <Bell style={{ width: 22, height: 22 }} className="text-white" aria-hidden="true" />
+            {unread > 0 && (
+              <span
+                aria-hidden="true"
+                style={{
+                  position: 'absolute',
+                  top: 4,
+                  right: 4,
+                  minWidth: 17,
+                  height: 17,
+                  borderRadius: 9999,
+                  fontSize: 9,
+                  fontWeight: 700,
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  paddingLeft: 2,
+                  paddingRight: 2,
+                }}
+                className="bg-[#F5A300] text-[#0A234F]"
+              >
+                {unread > 9 ? '9+' : unread}
+              </span>
+            )}
+          </button>
         </div>
 
-        {/* Right: bell */}
-        <button
-          onClick={() => navigate('/profile/notifications')}
-          aria-label={`Notifications${unread > 0 ? `, ${unread} unread` : ''}`}
-          className="relative h-11 w-11 shrink-0 cursor-pointer border-0 bg-transparent p-0 flex items-center justify-center"
-        >
-          <Bell
-            style={{ width: 22, height: 22 }} className="text-white"
-            aria-hidden="true"
-          />
-          {unread > 0 && (
-            <span
-              aria-hidden="true"
-              style={{
-                position: 'absolute',
-                top: 4,
-                right: 4,
-                minWidth: 17,
-                height: 17,
-                borderRadius: 9999,
-                fontSize: 9,
-                fontWeight: 700,
-                display: 'flex',
-                alignItems: 'center',
-                justifyContent: 'center',
-                paddingLeft: 2,
-                paddingRight: 2,
-              }}
-              className="bg-primary text-black"
-            >
-              {unread > 9 ? '9+' : unread}
-            </span>
-          )}
-        </button>
-      </div>
-
-      {/* ── Row 2: search bar + filter button ─── */}
-      <div className="flex items-center gap-2" style={{ marginTop: 10 }}>
-        {/* Search bar — taps open full-screen overlay */}
-        <button
-          onClick={() => setSearchOpen(true)}
-          aria-label="Search for items or members"
-          className="h-11 flex-1 rounded-xl border border-white/10 bg-white/[0.07] px-3.5 text-left flex items-center gap-2.5 cursor-pointer"
-        >
-          <Search
-            style={{ width: 18, height: 18, flexShrink: 0 }} className="text-white/45"
-            aria-hidden="true"
-          />
-          <span
-            className="text-foreground/55"
-            style={{
-              fontSize: 14,
-              whiteSpace: 'nowrap',
-              overflow: 'hidden',
-              textOverflow: 'ellipsis',
-              flex: 1,
-            }}
+        <div className="flex items-center gap-2" style={{ marginTop: 10 }}>
+          <button
+            onClick={() => setSearchOpen(true)}
+            aria-label="Search for items or members"
+            className="h-11 flex-1 rounded-xl border border-white/15 bg-[#0B2F6B] px-3.5 text-left flex items-center gap-2.5 cursor-pointer"
           >
-            Search for items or members
-          </span>
-          <Camera
-            style={{ width: 18, height: 18, flexShrink: 0 }} className="text-white/45"
-            aria-hidden="true"
-          />
-        </button>
+            <Search style={{ width: 18, height: 18, flexShrink: 0 }} className="text-white/62" aria-hidden="true" />
+            <span
+              className="text-white/65"
+              style={{
+                fontSize: 14,
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+                flex: 1,
+              }}
+            >
+              Search for items or members
+            </span>
+            <Camera style={{ width: 18, height: 18, flexShrink: 0 }} className="text-white/62" aria-hidden="true" />
+          </button>
 
-        {/* Filter button */}
-        <button
-          aria-label="Filter"
-          onClick={() => navigate('/catalog')}
-          className="h-11 w-11 shrink-0 rounded-xl border border-[#f2b84b66] bg-[#1c1400] flex items-center justify-center cursor-pointer"
-        >
-          <Filter
-            style={{ width: 18, height: 18 }}
-            className="text-primary"
-            aria-hidden="true"
-          />
-        </button>
-      </div>
-    </header>
+          <button
+            aria-label="Filter"
+            onClick={() => navigate('/catalog')}
+            className="h-11 w-11 shrink-0 rounded-xl border border-[#F5A300]/40 bg-[#0B2F6B] flex items-center justify-center cursor-pointer"
+          >
+            <Filter style={{ width: 18, height: 18 }} className="text-[#F5A300]" aria-hidden="true" />
+          </button>
+        </div>
+      </header>
 
-    {/* Full-screen search overlay — rendered outside the header flow */}
-    {searchOpen && <MobileSearchOverlay onClose={() => setSearchOpen(false)} />}
-  </>
+      {searchOpen && <MobileSearchOverlay onClose={() => setSearchOpen(false)} />}
+    </>
   );
 }

--- a/src/components/MobileBottomNav.tsx
+++ b/src/components/MobileBottomNav.tsx
@@ -17,8 +17,6 @@ import { useAuthStore } from '@/store';
 import { useAuthPromptStore } from '@/store/authPromptStore';
 import { supabase } from '@/lib/supabase';
 
-// ── Generic nav item ──────────────────────────────────────────────────────────
-
 function NavItem({
   to,
   icon: Icon,
@@ -32,7 +30,7 @@ function NavItem({
   isActive: boolean;
   exact?: boolean;
 }) {
-  void exact; // consumed by parent logic
+  void exact;
   return (
     <Link
       to={to}
@@ -41,20 +39,18 @@ function NavItem({
       aria-current={isActive ? 'page' : undefined}
     >
       <Icon
-        className={`h-[22px] w-[22px] transition-colors ${isActive ? 'text-primary' : 'text-white/45'}`}
+        className={`h-[22px] w-[22px] transition-colors ${isActive ? 'text-[#F5A300]' : 'text-white/58'}`}
         strokeWidth={isActive ? 2.2 : 1.8}
         aria-hidden="true"
       />
       <span
-        className={`max-w-[52px] overflow-hidden text-ellipsis whitespace-nowrap text-[10px] leading-none transition-colors ${isActive ? 'font-bold text-primary' : 'font-normal text-white/40'}`}
+        className={`max-w-[52px] overflow-hidden text-ellipsis whitespace-nowrap text-[10px] leading-none transition-colors ${isActive ? 'font-bold text-[#F5A300]' : 'font-normal text-white/52'}`}
       >
         {label}
       </span>
     </Link>
   );
 }
-
-// ── Messages button with unread badge ────────────────────────────────────────
 
 function MessagesNavButton({ isActive }: { isActive: boolean }) {
   const { user } = useAuthStore();
@@ -91,14 +87,14 @@ function MessagesNavButton({ isActive }: { isActive: boolean }) {
     >
       <div className="relative">
         <Mail
-          className={`h-[22px] w-[22px] transition-colors ${isActive ? 'text-primary' : 'text-white/45'}`}
+          className={`h-[22px] w-[22px] transition-colors ${isActive ? 'text-[#F5A300]' : 'text-white/58'}`}
           strokeWidth={isActive ? 2.2 : 1.8}
           aria-hidden="true"
         />
         {unread > 0 && (
           <span
             aria-hidden="true"
-            className="bg-primary flex items-center justify-center"
+            className="flex items-center justify-center bg-[#F5A300] text-[#0A234F]"
             style={{
               position: 'absolute',
               top: '-4px',
@@ -116,15 +112,13 @@ function MessagesNavButton({ isActive }: { isActive: boolean }) {
         )}
       </div>
       <span
-        className={`max-w-[52px] overflow-hidden text-ellipsis whitespace-nowrap text-[10px] leading-none ${isActive ? 'font-bold text-primary' : 'font-normal text-white/40'}`}
+        className={`max-w-[52px] overflow-hidden text-ellipsis whitespace-nowrap text-[10px] leading-none ${isActive ? 'font-bold text-[#F5A300]' : 'font-normal text-white/52'}`}
       >
         Inbox
       </span>
     </button>
   );
 }
-
-// ── Bottom nav ────────────────────────────────────────────────────────────────
 
 export default function MobileBottomNav() {
   const location = useLocation();
@@ -139,7 +133,6 @@ export default function MobileBottomNav() {
     navigate('/sell');
   };
 
-  // Exact match for home ("/"), prefix match for everything else
   const isHomeActive = location.pathname === '/';
   const isActive = (to: string) =>
     location.pathname === to || location.pathname.startsWith(to + '/');
@@ -147,51 +140,43 @@ export default function MobileBottomNav() {
   return (
     <nav
       aria-label="Main navigation"
-      className="fixed bottom-0 left-0 right-0 z-[9997] md:hidden bg-background/[0.97]"
+      className="fixed bottom-0 left-0 right-0 z-[9997] bg-[#0A234F]/[0.98] md:hidden"
       style={{
         backdropFilter: 'blur(18px)',
         WebkitBackdropFilter: 'blur(18px)',
-        borderTop: '1px solid rgba(255,255,255,0.07)',
+        borderTop: '1px solid rgba(245,163,0,0.20)',
+        boxShadow: '0 -10px 28px rgba(10,35,79,0.18)',
         paddingBottom: 'env(safe-area-inset-bottom, 0px)',
       }}
     >
       <div style={{ minHeight: '60px', display: 'flex', alignItems: 'center', justifyContent: 'space-around', paddingTop: '4px', paddingBottom: '4px' }}>
-
-        {/* Home */}
         <NavItem to="/" icon={Home} label="Home" isActive={isHomeActive} exact />
-
-        {/* Search */}
         <NavItem to="/categories" icon={Search} label="Search" isActive={isActive('/categories')} />
 
-        {/* Sell — elevated large gold circle */}
         <button
           onClick={handleSell}
           style={{ display: 'flex', flexDirection: 'column', alignItems: 'center', gap: '2px', padding: '0 8px', background: 'none', border: 'none', cursor: 'pointer' }}
           aria-label="Sell an item"
         >
           <div
-            className="bg-primary flex items-center justify-center"
+            className="flex items-center justify-center bg-[#F5A300] text-[#0A234F]"
             style={{
               width: '52px',
               height: '52px',
               borderRadius: '50%',
               marginTop: '-26px',
-              boxShadow: '0 0 24px rgba(200,134,10,0.50), 0 6px 16px rgba(0,0,0,0.65)',
+              boxShadow: '0 0 24px rgba(245,163,0,0.38), 0 6px 16px rgba(10,35,79,0.36)',
             }}
           >
             <Plus className="h-6 w-6" strokeWidth={2.5} aria-hidden="true" />
           </div>
-          <span style={{ fontSize: '10px', fontWeight: 600, lineHeight: 1, marginTop: '1px' }}>
+          <span className="text-white" style={{ fontSize: '10px', fontWeight: 700, lineHeight: 1, marginTop: '1px' }}>
             Sell
           </span>
         </button>
 
-        {/* Messages */}
         <MessagesNavButton isActive={isActive('/inbox')} />
-
-        {/* Profile */}
         <NavItem to={profilePath} icon={User} label="Profile" isActive={isActive(profilePath)} />
-
       </div>
     </nav>
   );

--- a/src/components/MobileCategoryShortcuts.tsx
+++ b/src/components/MobileCategoryShortcuts.tsx
@@ -12,7 +12,6 @@ interface Category {
   id: string;
   label: string;
   to: string;
-  /** URL fragment to match for active detection (e.g. "/category/electrical") */
   match: string;
 }
 
@@ -31,7 +30,6 @@ const CATEGORIES: Category[] = [
 export default function MobileCategoryShortcuts() {
   const { pathname } = useLocation();
 
-  // "All" is active when on the home page or catalog root
   const activePill =
     pathname === '/' || pathname === '/catalog'
       ? 'all'
@@ -57,7 +55,7 @@ export default function MobileCategoryShortcuts() {
                 key={id}
                 to={to}
                 aria-label={`Browse ${label}`}
-              className={`${active ? 'bg-primary/[0.12] border-primary text-primary font-semibold' : 'bg-white/[0.06] border-white/[0.14] text-foreground/85 font-medium'}`}
+                className={`${active ? 'bg-[#F5A300]/[0.13] border-[#F5A300] text-[#F5A300] font-semibold' : 'bg-[#0B2F6B] border-white/15 text-white/85 font-medium'}`}
                 style={{
                   textDecoration: 'none',
                   display: 'flex',
@@ -79,11 +77,7 @@ export default function MobileCategoryShortcuts() {
               </Link>
             );
           })}
-          {/* Trailing spacer so last pill clears the container edge */}
-          <div
-            style={{ minWidth: 'var(--mob-side, 16px)', flexShrink: 0 }}
-            aria-hidden="true"
-          />
+          <div style={{ minWidth: 'var(--mob-side, 16px)', flexShrink: 0 }} aria-hidden="true" />
         </div>
       </div>
     </section>

--- a/src/components/MobileCategoryShortcuts.tsx
+++ b/src/components/MobileCategoryShortcuts.tsx
@@ -55,7 +55,7 @@ export default function MobileCategoryShortcuts() {
                 key={id}
                 to={to}
                 aria-label={`Browse ${label}`}
-                className={`${active ? 'bg-[#F5A300]/[0.13] border-[#F5A300] text-[#F5A300] font-semibold' : 'bg-[#0B2F6B] border-white/15 text-white/85 font-medium'}`}
+                className={`${active ? 'bg-[#F5A300]/[0.13] border-[#F5A300] text-[#8A5A00] font-semibold' : 'bg-white border-[#0A234F]/15 text-[#0A234F]/85 font-medium'}`}
                 style={{
                   textDecoration: 'none',
                   display: 'flex',

--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -21,7 +21,6 @@ import DrawerCTACards from "@/components/mobile/DrawerCTACards";
 import logo from "@/assets/loadify-logo.svg";
 import type { User } from "@/types";
 import { useCategories } from "@/hooks/useCategories";
-
 import type { CategoryNode } from "@/hooks/useCategories";
 
 interface MobileDrawerProps {
@@ -44,20 +43,20 @@ interface MainScreenProps {
 }
 
 const ICON_MAP: Record<string, { icon: LucideIcon; iconColor: string }> = {
-  "electronics":       { icon: Smartphone,    iconColor: "text-cyan-400"   },
-  "home-garden":       { icon: Home,          iconColor: "text-success"  },
-  "clothing-fashion":  { icon: Shirt,         iconColor: "text-blue-400"   },
-  "toys-games":        { icon: Gamepad2,      iconColor: "text-purple-400" },
-  "sports-fitness":    { icon: Dumbbell,      iconColor: "text-primary" },
-  "automotive":        { icon: Car,           iconColor: "text-slate-300"  },
-  "health-beauty":     { icon: HeartPulse,    iconColor: "text-rose-400"   },
-  "pets":              { icon: PawPrint,      iconColor: "text-orange-400" },
-  "pet-supplies":      { icon: PawPrint,      iconColor: "text-primary"  },
-  "food-drink":        { icon: UtensilsCrossed, iconColor: "text-danger"  },
-  "office-business":   { icon: Briefcase,     iconColor: "text-sky-400"    },
+  "electronics":       { icon: Smartphone,      iconColor: "text-[#F5A300]" },
+  "home-garden":       { icon: Home,            iconColor: "text-[#F5A300]" },
+  "clothing-fashion":  { icon: Shirt,           iconColor: "text-[#F5A300]" },
+  "toys-games":        { icon: Gamepad2,        iconColor: "text-[#F5A300]" },
+  "sports-fitness":    { icon: Dumbbell,        iconColor: "text-[#F5A300]" },
+  "automotive":        { icon: Car,             iconColor: "text-[#F5A300]" },
+  "health-beauty":     { icon: HeartPulse,      iconColor: "text-[#F5A300]" },
+  "pets":              { icon: PawPrint,        iconColor: "text-[#F5A300]" },
+  "pet-supplies":      { icon: PawPrint,        iconColor: "text-[#F5A300]" },
+  "food-drink":        { icon: UtensilsCrossed, iconColor: "text-[#F5A300]" },
+  "office-business":   { icon: Briefcase,       iconColor: "text-[#F5A300]" },
 };
 
-const DEFAULT_ICON = { icon: Briefcase, iconColor: "text-white/75" };
+const DEFAULT_ICON = { icon: Briefcase, iconColor: "text-[#F5A300]" };
 
 const MainScreen = ({
   user,
@@ -69,25 +68,25 @@ const MainScreen = ({
   expandedSlug,
   onCategoryExpand,
 }: MainScreenProps) => (
-  <div className="flex flex-col h-full">
-    <div className="h-14 px-4 flex items-center justify-between border-b border-white/[0.12] shrink-0">
+  <div className="flex flex-col h-full bg-[#0A234F]">
+    <div className="h-14 px-4 flex items-center justify-between border-b border-white/10 shrink-0 bg-[#0A234F]">
       <Link to="/" onClick={onClose} className="flex items-center gap-2" aria-label="Loadify Market — Home">
         <img src={logo} alt="" aria-hidden="true" className="h-7 w-7" />
         <span className="font-display text-base font-bold text-white leading-none">
-          Loadify <span className="text-primary">Market</span>
+          Loadify <span className="text-[#F5A300]">Market</span>
         </span>
       </Link>
       <button
         ref={closeBtnRef}
         onClick={onClose}
-        className="p-2 text-white/80 hover:text-white transition-colors rounded-lg hover:bg-white/10"
+        className="p-2 text-white/80 hover:text-white transition-colors rounded-lg hover:bg-[#1D57D8]/20"
         aria-label="Close menu"
       >
         <X className="h-5 w-5" />
       </button>
     </div>
 
-    <div className="flex-1 overflow-y-auto">
+    <div className="flex-1 overflow-y-auto bg-[#0A234F]">
       <DrawerAccountBlock
         user={user}
         dashboardPath={dashboardPath}
@@ -98,7 +97,7 @@ const MainScreen = ({
       <div className="h-px bg-white/10 mx-4" />
 
       <div className="pt-4">
-        <p className="px-4 pb-2 text-[11px] font-bold uppercase tracking-widest text-white/40">
+        <p className="px-4 pb-2 text-[11px] font-bold uppercase tracking-widest text-white/45">
           Quick Actions
         </p>
         <DrawerCTACards onClose={onClose} />
@@ -106,7 +105,7 @@ const MainScreen = ({
 
       <div className="h-px bg-white/10 mx-4" />
 
-      <p className="px-4 pt-4 pb-2 text-[11px] font-bold uppercase tracking-widest text-white/40">
+      <p className="px-4 pt-4 pb-2 text-[11px] font-bold uppercase tracking-widest text-white/45">
         Browse Categories
       </p>
       <nav aria-label="Product categories">
@@ -122,10 +121,10 @@ const MainScreen = ({
                 onMouseEnter={() => onCategoryExpand(cat.slug)}
                 aria-expanded={isOpen}
                 className={[
-                  "w-full flex items-center gap-3 px-4 h-[52px] transition-colors border-b border-white/[0.05]",
+                  "w-full flex items-center gap-3 px-4 h-[52px] transition-colors border-b border-white/[0.07]",
                   isOpen
-                    ? "bg-white/[0.09] hover:bg-white/[0.11]"
-                    : "hover:bg-white/[0.07] active:bg-white/10",
+                    ? "bg-[#1D57D8]/20 hover:bg-[#1D57D8]/25"
+                    : "hover:bg-[#1D57D8]/15 active:bg-[#1D57D8]/20",
                 ].join(" ")}
               >
                 <Icon className={`h-[18px] w-[18px] shrink-0 ${iconColor}`} aria-hidden="true" />
@@ -134,7 +133,7 @@ const MainScreen = ({
                 </span>
                 <ChevronDown
                   className={[
-                    "h-4 w-4 text-white/30 shrink-0 transition-transform duration-200",
+                    "h-4 w-4 text-white/40 shrink-0 transition-transform duration-200",
                     isOpen ? "rotate-180" : "",
                   ].join(" ")}
                   aria-hidden="true"
@@ -142,13 +141,13 @@ const MainScreen = ({
               </button>
 
               {isOpen && (
-                <div className="bg-white/[0.04] border-b border-white/[0.07]">
+                <div className="bg-[#0B2F6B] border-b border-white/10">
                   <Link
                     to={categoryUrl}
                     onClick={onClose}
-                    className="flex items-center px-6 h-[46px] border-b border-white/[0.06] hover:bg-white/[0.07] active:bg-white/10 transition-colors"
+                    className="flex items-center px-6 h-[46px] border-b border-white/[0.08] hover:bg-[#1D57D8]/18 active:bg-[#1D57D8]/22 transition-colors"
                   >
-                    <span className="text-[14px] font-semibold text-primary">
+                    <span className="text-[14px] font-semibold text-[#F5A300]">
                       View All {cat.name}
                     </span>
                   </Link>
@@ -158,7 +157,7 @@ const MainScreen = ({
                       key={sub.slug}
                       to={`/catalog?category=${encodeURIComponent(cat.name)}&q=${encodeURIComponent(sub.name)}`}
                       onClick={onClose}
-                      className="flex items-center px-8 h-[44px] hover:bg-white/[0.07] active:bg-white/10 transition-colors border-b border-white/[0.04] last:border-b-0"
+                      className="flex items-center px-8 h-[44px] hover:bg-[#1D57D8]/15 active:bg-[#1D57D8]/20 transition-colors border-b border-white/[0.05] last:border-b-0"
                     >
                       <span className="text-[14px] font-medium text-white/75">
                         {sub.name}
@@ -175,41 +174,11 @@ const MainScreen = ({
       <div className="h-px bg-white/10 mx-4 mt-2" />
 
       <nav aria-label="Support links" className="flex flex-col py-2">
-        <Link
-          to="/register?type=seller"
-          onClick={onClose}
-          className="px-4 h-11 flex items-center text-sm font-medium text-muted-foreground hover:text-primary hover:bg-[rgba(212,175,55,0.08)] transition-colors"
-        >
-          Sell Stock
-        </Link>
-        <Link
-          to="/shipping-policy"
-          onClick={onClose}
-          className="px-4 h-11 flex items-center text-sm font-medium text-muted-foreground hover:text-primary hover:bg-[rgba(212,175,55,0.08)] transition-colors"
-        >
-          Shipping Policy
-        </Link>
-        <Link
-          to="/wholesale-info"
-          onClick={onClose}
-          className="px-4 h-11 flex items-center text-sm font-medium text-muted-foreground hover:text-primary hover:bg-[rgba(212,175,55,0.08)] transition-colors"
-        >
-          Marketplace Information
-        </Link>
-        <Link
-          to="/blog"
-          onClick={onClose}
-          className="px-4 h-11 flex items-center text-sm font-medium text-muted-foreground hover:text-primary hover:bg-[rgba(212,175,55,0.08)] transition-colors"
-        >
-          Blog
-        </Link>
-        <Link
-          to="/about"
-          onClick={onClose}
-          className="px-4 h-11 flex items-center text-sm font-medium text-muted-foreground hover:text-primary hover:bg-[rgba(212,175,55,0.08)] transition-colors"
-        >
-          About Us
-        </Link>
+        <Link to="/register?type=seller" onClick={onClose} className="px-4 h-11 flex items-center text-sm font-medium text-white/65 hover:text-[#F5A300] hover:bg-[#1D57D8]/15 transition-colors">Sell Stock</Link>
+        <Link to="/shipping-policy" onClick={onClose} className="px-4 h-11 flex items-center text-sm font-medium text-white/65 hover:text-[#F5A300] hover:bg-[#1D57D8]/15 transition-colors">Shipping Policy</Link>
+        <Link to="/wholesale-info" onClick={onClose} className="px-4 h-11 flex items-center text-sm font-medium text-white/65 hover:text-[#F5A300] hover:bg-[#1D57D8]/15 transition-colors">Marketplace Information</Link>
+        <Link to="/blog" onClick={onClose} className="px-4 h-11 flex items-center text-sm font-medium text-white/65 hover:text-[#F5A300] hover:bg-[#1D57D8]/15 transition-colors">Blog</Link>
+        <Link to="/about" onClick={onClose} className="px-4 h-11 flex items-center text-sm font-medium text-white/65 hover:text-[#F5A300] hover:bg-[#1D57D8]/15 transition-colors">About Us</Link>
       </nav>
 
       <div style={{ height: "env(safe-area-inset-bottom, 16px)" }} />
@@ -290,7 +259,7 @@ const MobileDrawer = ({ open, onClose, user, dashboardPath, onLogout }: MobileDr
         ref={panelRef}
         className={[
           "fixed top-0 left-0 z-[9999] h-[100dvh] w-[85vw] max-w-[380px]",
-          "bg-background border-r border-white/[0.12] shadow-2xl flex flex-col",
+          "bg-[#0A234F] border-r border-white/12 shadow-2xl flex flex-col",
           "transition-transform duration-300 ease-in-out",
           open ? "translate-x-0" : "-translate-x-full",
         ].join(" ")}

--- a/src/components/MobileGridCard.tsx
+++ b/src/components/MobileGridCard.tsx
@@ -15,7 +15,6 @@ interface MobileGridCardProps {
   price: number;
   image?: string;
   location?: string;
-  /** Set to true for above-the-fold cards to avoid lazy-loading the LCP image. */
   priority?: boolean;
 }
 
@@ -38,12 +37,12 @@ export default function MobileGridCard({ id, title, price, image, location, prio
   return (
     <Link
       to={`/product/${id}`}
-      style={{ display: 'block', textDecoration: 'none' }}
+      className="block rounded-2xl border border-white/10 bg-[#0B2F6B] p-2.5 shadow-[0_12px_28px_rgba(10,35,79,0.18)]"
+      style={{ textDecoration: 'none' }}
       aria-label={title}
     >
-      {/* Image */}
       <div
-        className="bg-white/[0.05]"
+        className="bg-white/[0.07]"
         style={{
           width: '100%',
           aspectRatio: '1 / 1',
@@ -63,10 +62,9 @@ export default function MobileGridCard({ id, title, price, image, location, prio
         />
       </div>
 
-      {/* Info */}
       <div style={{ paddingTop: 8, paddingBottom: 4 }}>
         <p
-          className="text-foreground/90"
+          className="text-white/90"
           style={{
             fontSize: 'clamp(12px, 3.2vw, 13px)',
             fontWeight: 500,
@@ -81,7 +79,7 @@ export default function MobileGridCard({ id, title, price, image, location, prio
           {title}
         </p>
         <p
-          className="text-foreground"
+          className="text-[#F5A300]"
           style={{
             fontSize: 'clamp(13px, 3.8vw, 15px)',
             fontWeight: 700,
@@ -92,7 +90,7 @@ export default function MobileGridCard({ id, title, price, image, location, prio
         </p>
         {location && (
           <p
-            className="text-foreground/50"
+            className="text-white/52"
             style={{
               fontSize: 11,
               margin: '3px 0 0',

--- a/src/components/MobileGridCard.tsx
+++ b/src/components/MobileGridCard.tsx
@@ -18,7 +18,7 @@ interface MobileGridCardProps {
   priority?: boolean;
 }
 
-const darkPlaceholder = (
+const lightPlaceholder = (
   <div
     aria-hidden="true"
     style={{
@@ -29,7 +29,7 @@ const darkPlaceholder = (
       justifyContent: 'center',
     }}
   >
-    <ProductImagePlaceholder theme="dark" />
+    <ProductImagePlaceholder theme="light" />
   </div>
 );
 
@@ -37,12 +37,12 @@ export default function MobileGridCard({ id, title, price, image, location, prio
   return (
     <Link
       to={`/product/${id}`}
-      className="block rounded-2xl border border-white/10 bg-[#0B2F6B] p-2.5 shadow-[0_12px_28px_rgba(10,35,79,0.18)]"
+      className="block rounded-2xl border border-[#0A234F]/10 bg-white p-2.5 shadow-[0_12px_28px_rgba(10,35,79,0.14)]"
       style={{ textDecoration: 'none' }}
       aria-label={title}
     >
       <div
-        className="bg-white/[0.07]"
+        className="bg-[#F2F4F7]"
         style={{
           width: '100%',
           aspectRatio: '1 / 1',
@@ -58,13 +58,13 @@ export default function MobileGridCard({ id, title, price, image, location, prio
           fetchPriority={priority ? 'high' : undefined}
           decoding={priority ? 'auto' : 'async'}
           style={{ width: '100%', height: '100%', objectFit: 'cover', display: 'block' }}
-          fallback={darkPlaceholder}
+          fallback={lightPlaceholder}
         />
       </div>
 
       <div style={{ paddingTop: 8, paddingBottom: 4 }}>
         <p
-          className="text-white/90"
+          className="text-[#0A234F]/90"
           style={{
             fontSize: 'clamp(12px, 3.2vw, 13px)',
             fontWeight: 500,
@@ -79,7 +79,7 @@ export default function MobileGridCard({ id, title, price, image, location, prio
           {title}
         </p>
         <p
-          className="text-[#F5A300]"
+          className="text-[#1D57D8]"
           style={{
             fontSize: 'clamp(13px, 3.8vw, 15px)',
             fontWeight: 700,
@@ -90,7 +90,7 @@ export default function MobileGridCard({ id, title, price, image, location, prio
         </p>
         {location && (
           <p
-            className="text-white/52"
+            className="text-[#0A234F]/52"
             style={{
               fontSize: 11,
               margin: '3px 0 0',

--- a/src/components/MobileHeroBanner.tsx
+++ b/src/components/MobileHeroBanner.tsx
@@ -36,9 +36,9 @@ export default function MobileHeroBanner() {
       }}
     >
       <div
-        className="bg-[#0B2F6B]"
+        className="bg-[#0A234F]"
         style={{
-          border: '1px solid rgba(255,255,255,0.10)',
+          border: '1px solid rgba(10,35,79,0.10)',
           borderRadius: 16,
           padding: 'clamp(16px, 5vw, 24px)',
           display: 'flex',
@@ -46,7 +46,8 @@ export default function MobileHeroBanner() {
           alignItems: 'center',
           justifyContent: 'space-between',
           gap: 16,
-          boxShadow: '0 16px 36px rgba(10,35,79,0.24)',
+          boxShadow: '0 16px 36px rgba(10,35,79,0.20)',
+          backgroundImage: 'radial-gradient(circle at 100% 0%, rgba(29,87,216,0.25), transparent 46%)',
         }}
       >
         <div style={{ flex: 1, minWidth: 0 }}>

--- a/src/components/MobileHeroBanner.tsx
+++ b/src/components/MobileHeroBanner.tsx
@@ -36,9 +36,9 @@ export default function MobileHeroBanner() {
       }}
     >
       <div
-        className="bg-white/[0.04]"
+        className="bg-[#0B2F6B]"
         style={{
-          border: '1px solid rgba(255,255,255,0.08)',
+          border: '1px solid rgba(255,255,255,0.10)',
           borderRadius: 16,
           padding: 'clamp(16px, 5vw, 24px)',
           display: 'flex',
@@ -46,12 +46,12 @@ export default function MobileHeroBanner() {
           alignItems: 'center',
           justifyContent: 'space-between',
           gap: 16,
+          boxShadow: '0 16px 36px rgba(10,35,79,0.24)',
         }}
       >
-        {/* Text */}
         <div style={{ flex: 1, minWidth: 0 }}>
           <p
-            className="text-primary"
+            className="text-[#F5A300]"
             style={{
               fontSize: 'clamp(11px, 3vw, 13px)',
               fontWeight: 600,
@@ -65,7 +65,7 @@ export default function MobileHeroBanner() {
             0% commission until 31 December 2026
           </p>
           <h2
-            className="text-foreground"
+            className="text-white"
             style={{
               fontSize: 'clamp(18px, 5.2vw, 24px)',
               fontWeight: 800,
@@ -77,7 +77,7 @@ export default function MobileHeroBanner() {
             Sell on Loadify Market
           </h2>
           <p
-            className="text-foreground/55"
+            className="text-white/65"
             style={{
               fontSize: 'clamp(12px, 3.4vw, 14px)',
               margin: '6px 0 0',
@@ -87,7 +87,6 @@ export default function MobileHeroBanner() {
             Free listings. Fixed prices. Stripe payouts.
           </p>
 
-          {/* CTAs */}
           <div style={{ display: 'flex', alignItems: 'center', gap: 12, marginTop: 16 }}>
             <button
               onClick={handleSell}
@@ -101,13 +100,15 @@ export default function MobileHeroBanner() {
                 fontSize: 'clamp(13px, 3.6vw, 14px)',
                 fontWeight: 700,
                 whiteSpace: 'nowrap',
+                background: '#F5A300',
+                color: '#0A234F',
               }}
             >
               Start selling
             </button>
             <button
               onClick={() => navigate('/help')}
-              className="text-foreground/50"
+              className="text-white/62"
               style={{
                 height: 40,
                 paddingLeft: 0,

--- a/src/components/SecurityTrust.tsx
+++ b/src/components/SecurityTrust.tsx
@@ -32,7 +32,10 @@ const items: TrustItem[] = [
 
 export default function SecurityTrust() {
   return (
-    <div className="flex-1 rounded-2xl border border-white/10 bg-[#0B2F6B] p-6 lg:p-8 flex flex-col">
+    <div
+      className="flex-1 rounded-2xl border border-white/10 bg-[#0A234F] p-6 lg:p-8 flex flex-col"
+      style={{ backgroundImage: 'radial-gradient(circle at 100% 0%, rgba(29,87,216,0.24), transparent 42%)' }}
+    >
       <h2 className="text-xl font-semibold text-white mb-4">
         Security &amp; Trust You Can Rely On
       </h2>
@@ -43,7 +46,7 @@ export default function SecurityTrust() {
             <div
               key={item.title}
               data-parallax
-              className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-[#0A234F] p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_25px_rgba(29,87,216,0.22)] hover:border-[#F5A300]/40"
+              className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-white/[0.045] p-6 transition-all duration-300 hover:-translate-y-1 hover:bg-white/[0.07] hover:shadow-[0_0_25px_rgba(29,87,216,0.22)] hover:border-[#F5A300]/40"
             >
               <Icon className="w-7 h-7 text-[#F5A300] shrink-0 icon-pulse" aria-hidden="true" />
               <p className="text-base font-semibold text-white leading-tight">{item.title}</p>

--- a/src/components/SecurityTrust.tsx
+++ b/src/components/SecurityTrust.tsx
@@ -32,7 +32,7 @@ const items: TrustItem[] = [
 
 export default function SecurityTrust() {
   return (
-    <div className="flex-1 rounded-2xl border border-white/5 bg-elevated p-6 lg:p-8 flex flex-col">
+    <div className="flex-1 rounded-2xl border border-white/10 bg-[#0B2F6B] p-6 lg:p-8 flex flex-col">
       <h2 className="text-xl font-semibold text-white mb-4">
         Security &amp; Trust You Can Rely On
       </h2>
@@ -43,14 +43,11 @@ export default function SecurityTrust() {
             <div
               key={item.title}
               data-parallax
-              className="flex flex-col gap-3 rounded-2xl border border-white/5 bg-elevated p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_25px_rgba(212,175,55,0.15)] hover:border-primary/40"
+              className="flex flex-col gap-3 rounded-2xl border border-white/10 bg-[#0A234F] p-6 transition-all duration-300 hover:-translate-y-1 hover:shadow-[0_0_25px_rgba(29,87,216,0.22)] hover:border-[#F5A300]/40"
             >
-              <Icon
-                className="w-7 h-7 text-primary shrink-0 icon-pulse"
-                aria-hidden="true"
-              />
+              <Icon className="w-7 h-7 text-[#F5A300] shrink-0 icon-pulse" aria-hidden="true" />
               <p className="text-base font-semibold text-white leading-tight">{item.title}</p>
-              <p className="text-sm text-slate-400 leading-relaxed">{item.description}</p>
+              <p className="text-sm text-white/62 leading-relaxed">{item.description}</p>
             </div>
           );
         })}

--- a/src/components/SellerCTA.tsx
+++ b/src/components/SellerCTA.tsx
@@ -2,32 +2,27 @@ import { Link } from "react-router-dom";
 
 export default function SellerCTA() {
   return (
-    <section
-      className="sm:bg-surface sm:border-y sm:border-primary/40 bg-surface"
-    >
-      {/* ── Mobile: card with margin/radius ───────────────────────── */}
+    <section className="sm:bg-[#0A234F] sm:border-y sm:border-[#F5A300]/40 bg-[#0A234F]">
       <div className="sm:hidden" style={{ padding: '24px 16px' }}>
         <div
           style={{
-            background: 'rgba(12,10,0,1)',
-            border: '1px solid rgba(212,175,55,0.2)',
+            background: '#0B2F6B',
+            border: '1px solid rgba(245,163,0,0.24)',
             borderRadius: '20px',
             padding: '20px',
             textAlign: 'center',
+            boxShadow: '0 18px 42px rgba(10,35,79,0.22)',
           }}
         >
-          {/* Heading */}
           <p style={{ fontWeight: 800, fontSize: '24px', lineHeight: 1.2, marginBottom: '10px' }} className="text-white">
             Start Selling for{' '}
-            <span className="text-primary" style={{}}>FREE</span>
+            <span className="text-[#F5A300]">FREE</span>
           </p>
 
-          {/* Subtext */}
-          <p style={{ fontSize: '14px', lineHeight: 1.55, marginBottom: '22px' }} className="text-muted-foreground">
+          <p style={{ fontSize: '14px', lineHeight: 1.55, marginBottom: '22px' }} className="text-white/68">
             List products free, sell at fixed prices, and keep more from every order.
           </p>
 
-          {/* Gold CTA button */}
           <Link
             to="/register?type=seller"
             style={{
@@ -35,8 +30,8 @@ export default function SellerCTA() {
               alignItems: 'center',
               justifyContent: 'center',
               height: '52px',
-              background: 'rgba(212,175,55,1)',
-              color: 'rgba(18,26,43,1)',
+              background: '#F5A300',
+              color: '#0A234F',
               fontWeight: 700,
               fontSize: '16px',
               borderRadius: '14px',
@@ -47,33 +42,31 @@ export default function SellerCTA() {
             Open Your Seller Account
           </Link>
 
-          <p style={{ fontSize: '12px' }} className="text-muted-foreground">
+          <p style={{ fontSize: '12px' }} className="text-white/62">
             0% seller commission until 31 December 2026.
           </p>
         </div>
       </div>
 
-      {/* ── Desktop layout — unchanged ────────────────────────────── */}
       <div className="hidden sm:block px-8 py-8">
         <div className="flex flex-col sm:flex-row items-center justify-between gap-4">
-          <p className="text-foreground font-medium text-base text-center sm:text-left">
+          <p className="text-white font-medium text-base text-center sm:text-left">
             List products free, sell at fixed prices, and keep more from every order with 0% seller commission until 31 December 2026.
           </p>
           <div className="flex flex-col sm:flex-row items-center gap-4 shrink-0">
             <Link
               to="/register?type=seller"
               data-magnetic
-              className="bg-primary hover:shadow-[0_0_22px_rgba(212,175,55,0.25)] hover:-translate-y-0.5 text-background font-bold px-6 py-2.5 rounded-xl transition-all duration-300 text-sm whitespace-nowrap"
+              className="bg-[#F5A300] hover:bg-[#E69500] hover:shadow-[0_0_22px_rgba(245,163,0,0.25)] hover:-translate-y-0.5 text-[#0A234F] font-bold px-6 py-2.5 rounded-xl transition-all duration-300 text-sm whitespace-nowrap"
             >
               Open Your Free Seller Account
             </Link>
-            <p className="text-muted-foreground/80 text-sm whitespace-nowrap">
+            <p className="text-white/65 text-sm whitespace-nowrap">
               Stripe payments. Fixed prices. No monthly fee.
             </p>
           </div>
         </div>
       </div>
-
     </section>
   );
 }

--- a/src/components/SellerCTA.tsx
+++ b/src/components/SellerCTA.tsx
@@ -2,11 +2,14 @@ import { Link } from "react-router-dom";
 
 export default function SellerCTA() {
   return (
-    <section className="sm:bg-[#0A234F] sm:border-y sm:border-[#F5A300]/40 bg-[#0A234F]">
+    <section
+      className="sm:bg-[#0A234F] sm:border-y sm:border-[#F5A300]/40 bg-[#F7F9FC]"
+      style={{ backgroundImage: 'radial-gradient(circle at 100% 0%, rgba(29,87,216,0.24), transparent 42%)' }}
+    >
       <div className="sm:hidden" style={{ padding: '24px 16px' }}>
         <div
           style={{
-            background: '#0B2F6B',
+            background: 'radial-gradient(circle at 100% 0%, rgba(29,87,216,0.26), transparent 44%), #0A234F',
             border: '1px solid rgba(245,163,0,0.24)',
             borderRadius: '20px',
             padding: '20px',

--- a/src/components/TrustStrip.tsx
+++ b/src/components/TrustStrip.tsx
@@ -40,12 +40,13 @@ const TrustStrip = () => (
         className={[
           "flex items-center gap-2.5 sm:gap-3",
           "rounded-2xl",
-          "bg-[#0B2F6B]",
+          "bg-[#0A234F]",
           "border border-white/10",
           "p-[14px] sm:px-5 sm:py-4",
           "transition-all duration-300",
           "sm:hover:-translate-y-1 sm:hover:shadow-[0_0_25px_rgba(29,87,216,0.24)] sm:hover:border-[#F5A300]/40",
         ].join(" ")}
+        style={{ backgroundImage: 'radial-gradient(circle at 100% 0%, rgba(29,87,216,0.24), transparent 46%)' }}
       >
         <span className="w-8 h-8 sm:w-10 sm:h-10 flex items-center justify-center shrink-0 overflow-hidden">
           {flag

--- a/src/components/TrustStrip.tsx
+++ b/src/components/TrustStrip.tsx
@@ -1,7 +1,6 @@
 import { ShieldCheck, BadgeCheck, Percent } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 
-/* UK flag SVG inline — no external dep */
 const UKFlag = () => (
   <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 60 30" className="h-[18px] sm:h-5 w-auto" aria-label="UK flag">
     <clipPath id="a"><path d="M0 0v30h60V0z"/></clipPath>
@@ -39,19 +38,13 @@ const TrustStrip = () => (
       <div
         key={label}
         className={[
-          /* layout */
           "flex items-center gap-2.5 sm:gap-3",
-          /* shape — mobile: 16px radius; desktop: 2xl */
           "rounded-2xl",
-          /* background — mobile: #12121A solid; desktop: gradient */
-          "bg-surface sm:bg-elevated",
-          /* border — mobile: faint white; desktop: same then hover changes it */
-          "border border-white/[0.07] sm:border-white/5",
-          /* padding — mobile: 14px; desktop: px-5 py-4 */
+          "bg-[#0B2F6B]",
+          "border border-white/10",
           "p-[14px] sm:px-5 sm:py-4",
-          /* desktop hover */
           "transition-all duration-300",
-          "sm:hover:-translate-y-1 sm:hover:shadow-[0_0_25px_rgba(212,175,55,0.15)] sm:hover:border-primary/40",
+          "sm:hover:-translate-y-1 sm:hover:shadow-[0_0_25px_rgba(29,87,216,0.24)] sm:hover:border-[#F5A300]/40",
         ].join(" ")}
       >
         <span className="w-8 h-8 sm:w-10 sm:h-10 flex items-center justify-center shrink-0 overflow-hidden">
@@ -59,8 +52,8 @@ const TrustStrip = () => (
             ? <UKFlag />
             : Icon && (
                 <Icon
-                  className="h-[18px] w-[18px] sm:h-6 sm:w-6 text-primary sm:text-primary"
-                  style={{ filter: 'drop-shadow(0 0 6px rgba(212,175,55,0.4))' }}
+                  className="h-[18px] w-[18px] sm:h-6 sm:w-6 text-[#F5A300]"
+                  style={{ filter: 'drop-shadow(0 0 6px rgba(245,163,0,0.32))' }}
                   aria-hidden="true"
                 />
               )
@@ -68,7 +61,7 @@ const TrustStrip = () => (
         </span>
         <div className="min-w-0">
           <p className="text-[13px] sm:text-sm font-semibold text-white leading-tight">{label}</p>
-          <p className="text-[11px] sm:text-xs text-muted-foreground sm:text-slate-400 leading-tight mt-0.5">{sub}</p>
+          <p className="text-[11px] sm:text-xs text-white/62 leading-tight mt-0.5">{sub}</p>
         </div>
       </div>
     ))}

--- a/src/components/mobile/DrawerCTACards.tsx
+++ b/src/components/mobile/DrawerCTACards.tsx
@@ -6,67 +6,27 @@ interface DrawerCTACardsProps {
 }
 
 const CTA_CARDS = [
-  {
-    icon: Tag,
-    label: "Insights",
-    route: "/catalog?filter=price-crunch",
-    iconClass: "text-primary",
-  },
-  {
-    icon: RefreshCw,
-    label: "Back in Stock",
-    route: "/catalog?filter=back-in-stock",
-    iconClass: "text-sky-400",
-  },
-  {
-    icon: TrendingUp,
-    label: "Best Sellers",
-    route: "/catalog?filter=best-sellers",
-    iconClass: "text-primary",
-  },
-  {
-    icon: Clock,
-    label: "Latest Products",
-    route: "/catalog?filter=latest",
-    iconClass: "text-violet-400",
-  },
-  {
-    icon: Package,
-    label: "Add Products",
-    route: "/catalog?filter=pallet-deals",
-    iconClass: "text-orange-400",
-  },
-  {
-    icon: XCircle,
-    label: "Inactive Products",
-    route: "/catalog?filter=delisted",
-    iconClass: "text-danger",
-  },
-  {
-    icon: ShoppingBag,
-    label: "Multi Buy",
-    route: "/catalog?filter=multi-buy",
-    iconClass: "text-pink-400",
-  },
-  {
-    icon: Store,
-    label: "Shop by Brand",
-    route: "/catalog?filter=brand",
-    iconClass: "text-teal-400",
-  },
+  { icon: Tag, label: "Insights", route: "/catalog?filter=price-crunch" },
+  { icon: RefreshCw, label: "Back in Stock", route: "/catalog?filter=back-in-stock" },
+  { icon: TrendingUp, label: "Best Sellers", route: "/catalog?filter=best-sellers" },
+  { icon: Clock, label: "Latest Products", route: "/catalog?filter=latest" },
+  { icon: Package, label: "Add Products", route: "/catalog?filter=pallet-deals" },
+  { icon: XCircle, label: "Inactive Products", route: "/catalog?filter=delisted" },
+  { icon: ShoppingBag, label: "Multi Buy", route: "/catalog?filter=multi-buy" },
+  { icon: Store, label: "Shop by Brand", route: "/catalog?filter=brand" },
 ] as const;
 
 const DrawerCTACards = ({ onClose }: DrawerCTACardsProps) => (
   <div className="px-4 pb-4 grid grid-cols-2 gap-2">
-    {CTA_CARDS.map(({ icon: Icon, label, route, iconClass }) => (
+    {CTA_CARDS.map(({ icon: Icon, label, route }) => (
       <Link
         key={label}
         to={route}
         onClick={onClose}
-        className="bg-surface border border-white/5 rounded-xl p-3 flex flex-col items-start gap-1.5 h-[68px] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[0_0_20px_rgba(212,175,55,0.15)] hover:border-primary/40 active:scale-[0.97]"
+        className="bg-[#0B2F6B] border border-white/10 rounded-xl p-3 flex flex-col items-start gap-1.5 h-[68px] transition-all duration-300 hover:-translate-y-0.5 hover:shadow-[0_0_20px_rgba(29,87,216,0.22)] hover:border-[#F5A300]/40 active:scale-[0.97]"
       >
-        <Icon className={`h-5 w-5 ${iconClass}`} aria-hidden="true" />
-        <span className="text-xs font-semibold text-white/80 leading-tight">{label}</span>
+        <Icon className="h-5 w-5 text-[#F5A300]" aria-hidden="true" />
+        <span className="text-xs font-semibold text-white/82 leading-tight">{label}</span>
       </Link>
     ))}
   </div>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -30,9 +30,9 @@ function SkeletonGridCard() {
         gap: 8,
       }}
     >
-      <div className="rounded-xl animate-pulse flex flex-col gap-2 w-full aspect-square bg-white/[0.10]" />
-      <div className="h-3 rounded-md bg-white/[0.10] w-[80%]" />
-      <div className="h-3.5 rounded-md bg-white/[0.10] w-[50%]" />
+      <div className="rounded-xl animate-pulse flex flex-col gap-2 w-full aspect-square bg-[#0A234F]/10" />
+      <div className="h-3 rounded-md bg-[#0A234F]/10 w-[80%]" />
+      <div className="h-3.5 rounded-md bg-[#0A234F]/10 w-[50%]" />
     </div>
   );
 }
@@ -53,7 +53,7 @@ function MobileHome() {
   }, [loadMore]);
 
   return (
-    <div className="md:hidden min-h-screen bg-[#0A234F]">
+    <div className="md:hidden min-h-screen bg-[#F7F9FC]">
       <MobileAppHeader />
       <MobileCategoryShortcuts />
       <MobileHeroBanner />
@@ -122,11 +122,11 @@ export default function Home() {
       <main id="main-content">
         <MobileHome />
 
-        <div className="hidden md:block bg-[#0A234F]">
+        <div className="hidden md:block bg-[#F7F9FC]">
           <HeroSection />
 
           <section
-            className="bg-[#0A234F] py-6 px-8"
+            className="bg-[#F7F9FC] py-6 px-8"
             aria-label="Platform overview"
           >
             <TrustStrip />

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -30,9 +30,9 @@ function SkeletonGridCard() {
         gap: 8,
       }}
     >
-      <div className="rounded-xl animate-pulse flex flex-col gap-2 w-full aspect-square bg-white/[0.06]" />
-      <div className="h-3 rounded-md bg-white/[0.06] w-[80%]" />
-      <div className="h-3.5 rounded-md bg-white/[0.06] w-[50%]" />
+      <div className="rounded-xl animate-pulse flex flex-col gap-2 w-full aspect-square bg-white/[0.10]" />
+      <div className="h-3 rounded-md bg-white/[0.10] w-[80%]" />
+      <div className="h-3.5 rounded-md bg-white/[0.10] w-[50%]" />
     </div>
   );
 }
@@ -53,7 +53,7 @@ function MobileHome() {
   }, [loadMore]);
 
   return (
-    <div className="md:hidden min-h-screen bg-background">
+    <div className="md:hidden min-h-screen bg-[#0A234F]">
       <MobileAppHeader />
       <MobileCategoryShortcuts />
       <MobileHeroBanner />
@@ -122,11 +122,11 @@ export default function Home() {
       <main id="main-content">
         <MobileHome />
 
-        <div className="hidden md:block">
+        <div className="hidden md:block bg-[#0A234F]">
           <HeroSection />
 
           <section
-            className="bg-background py-6 px-8"
+            className="bg-[#0A234F] py-6 px-8"
             aria-label="Platform overview"
           >
             <TrustStrip />


### PR DESCRIPTION
## Purpose
Apply the Loadify homepage colour system established during PR #529 review to the original homepage from `main`, without importing PR #529 structure or changing homepage functionality.

## Colour contract
- Navy: `#0A234F`
- Royal blue: `#1D57D8` / controlled supporting navy-blue surfaces
- Orange/gold: `#F5A300`
- White / light neutral only where needed for contrast

## Scope guard
Colour/surface treatment only for the original public homepage and its directly opened public navigation surfaces.

Preserved unchanged:
- original homepage section order and structure;
- original copy and commercial wording;
- product data/fetching logic;
- routes and links;
- auth/cart/search behaviour;
- buyer/seller logic;
- Workspace/Admin/Super Admin UI.

## Branch Guard
Branch starts from current `main` at `50302455a6c8afcd52da45150f7de6f0ce91d942` and is currently `behind 0`.

This is a visual review PR. Do not merge until preview review is complete.