### PR TITLE
Sync public navbar with live marketplace inventory

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -8,6 +8,7 @@ import { useAuthStore } from "@/store";
 import MobileDrawer from "@/components/MobileDrawer";
 import { useCategories } from "@/hooks/useCategories";
 import type { CategoryNode } from "@/hooks/useCategories";
+import { useLiveCategoryAvailability } from "@/hooks/useLiveCategoryAvailability";
 import { supabase } from "@/lib/supabase";
 
 const Header = () => {
@@ -19,6 +20,10 @@ const Header = () => {
   const { user, logout } = useAuthStore();
   const navigate = useNavigate();
   const { categories } = useCategories();
+  const { liveCategoryIds, liveRootCategoryIds } = useLiveCategoryAvailability();
+
+  const liveCategoryIdSet = new Set(liveCategoryIds);
+  const liveRootCategoryIdSet = new Set(liveRootCategoryIds);
 
   const scheduleClose = useCallback(() => {
     closeTimerRef.current = setTimeout(() => setHoveredCat(null), 80);
@@ -47,21 +52,12 @@ const Header = () => {
     navigate("/login", { replace: true });
   };
 
-  const PRIORITY_SLUGS = [
-    "electronics",
-    "clothing-fashion",
-    "home-garden",
-    "health-beauty",
-    "sports-fitness",
-    "automotive",
-  ];
-
-  const priorityCategories = PRIORITY_SLUGS
-    .map((slug) => categories.find((c) => c.slug === slug))
-    .filter((c): c is NonNullable<typeof c> => c !== undefined);
-
-  const displayCategories =
-    priorityCategories.length > 0 ? priorityCategories : categories.slice(0, 6);
+  // Public nav only promotes root categories that currently contain sellable,
+  // approved marketplace inventory. The full taxonomy remains available via
+  // Shop All / More so the header never advertises empty categories as featured.
+  const displayCategories = categories
+    .filter((category) => liveRootCategoryIdSet.has(category.id))
+    .slice(0, 6);
 
   const navLinks = [
     { to: "/", label: "HOME", catSlug: null as string | null },
@@ -196,7 +192,8 @@ const Header = () => {
                 const catNode: CategoryNode | undefined = link.catSlug
                   ? categories.find((c) => c.slug === link.catSlug)
                   : undefined;
-                const hasChildren = !!catNode && catNode.children.length > 0;
+                const liveChildren = catNode?.children.filter((child) => liveCategoryIdSet.has(child.id)) ?? [];
+                const hasChildren = liveChildren.length > 0;
                 const isHovered = hoveredCat === link.to;
                 return (
                   <div
@@ -221,7 +218,7 @@ const Header = () => {
                         onMouseEnter={cancelClose}
                         onMouseLeave={scheduleClose}
                       >
-                        {catNode.children.map((child) => (
+                        {liveChildren.map((child) => (
                           <Link
                             key={child.id}
                             to={`/category/${child.slug}`}
@@ -250,6 +247,8 @@ const Header = () => {
         user={user}
         dashboardPath={dashboardPath}
         onLogout={handleLogout}
+        liveCategoryIds={liveCategoryIds}
+        liveRootCategoryIds={liveRootCategoryIds}
       />
     </header>
   );

--- a/src/components/MobileDrawer.tsx
+++ b/src/components/MobileDrawer.tsx
@@ -30,6 +30,8 @@ interface MobileDrawerProps {
   user: User | null;
   dashboardPath: string;
   onLogout: () => void;
+  liveCategoryIds: string[];
+  liveRootCategoryIds: string[];
 }
 
 interface MainScreenProps {
@@ -39,6 +41,8 @@ interface MainScreenProps {
   onClose: () => void;
   closeBtnRef: React.RefObject<HTMLButtonElement | null>;
   categories: CategoryNode[];
+  liveCategoryIds: string[];
+  liveRootCategoryIds: string[];
   expandedSlug: string | null;
   onCategoryExpand: (slug: string | null) => void;
 }
@@ -59,19 +63,24 @@ const ICON_MAP: Record<string, LucideIcon> = {
 };
 
 const DEFAULT_ICON = Briefcase;
-const FEATURED_SLUGS = ["handmade", "toys-games", "toys", "health-beauty", "electronics", "clothing-fashion", "home-garden", "sports-fitness", "automotive"];
 
-function chooseDrawerCategories(categories: CategoryNode[]) {
-  const preferred = FEATURED_SLUGS
-    .map((slug) => categories.find((category) => category.slug === slug))
-    .filter((category): category is CategoryNode => Boolean(category));
-  const used = new Set(preferred.map((category) => category.id));
-  const fallback = categories.filter((category) => !used.has(category.id));
-  return [...preferred, ...fallback].slice(0, 8);
-}
-
-const MainScreen = ({ user, dashboardPath, onLogout, onClose, closeBtnRef, categories, expandedSlug, onCategoryExpand }: MainScreenProps) => {
-  const visibleCategories = chooseDrawerCategories(categories);
+const MainScreen = ({
+  user,
+  dashboardPath,
+  onLogout,
+  onClose,
+  closeBtnRef,
+  categories,
+  liveCategoryIds,
+  liveRootCategoryIds,
+  expandedSlug,
+  onCategoryExpand,
+}: MainScreenProps) => {
+  const liveCategoryIdSet = new Set(liveCategoryIds);
+  const liveRootCategoryIdSet = new Set(liveRootCategoryIds);
+  const visibleCategories = categories
+    .filter((category) => liveRootCategoryIdSet.has(category.id))
+    .slice(0, 8);
 
   return (
     <div className="flex flex-col h-full">
@@ -104,12 +113,13 @@ const MainScreen = ({ user, dashboardPath, onLogout, onClose, closeBtnRef, categ
           </Link>
         </div>
 
-        <nav aria-label="Featured product categories">
+        <nav aria-label="Live product categories">
           {visibleCategories.map((cat) => {
             const Icon = ICON_MAP[cat.slug] ?? DEFAULT_ICON;
             const isOpen = expandedSlug === cat.slug;
             const categoryUrl = `/catalog?category=${encodeURIComponent(cat.name)}`;
-            const hasChildren = cat.children.length > 0;
+            const liveChildren = cat.children.filter((child) => liveCategoryIdSet.has(child.id));
+            const hasChildren = liveChildren.length > 0;
 
             return (
               <div key={cat.slug}>
@@ -133,7 +143,7 @@ const MainScreen = ({ user, dashboardPath, onLogout, onClose, closeBtnRef, categ
 
                 {isOpen && hasChildren && (
                   <div className="bg-white/[0.045] border-b border-white/[0.07]">
-                    {cat.children.slice(0, 6).map((sub) => (
+                    {liveChildren.slice(0, 6).map((sub) => (
                       <Link
                         key={sub.slug}
                         to={`/catalog?category=${encodeURIComponent(cat.name)}&q=${encodeURIComponent(sub.name)}`}
@@ -143,7 +153,7 @@ const MainScreen = ({ user, dashboardPath, onLogout, onClose, closeBtnRef, categ
                         <span className="text-[14px] font-medium text-white/75">{sub.name}</span>
                       </Link>
                     ))}
-                    {cat.children.length > 6 && (
+                    {liveChildren.length > 6 && (
                       <Link to={categoryUrl} onClick={onClose} className="flex h-[42px] items-center px-8 text-[13px] font-bold text-[#F5A300] hover:bg-white/[0.07]">
                         View all {cat.name}
                       </Link>
@@ -174,7 +184,15 @@ const MainScreen = ({ user, dashboardPath, onLogout, onClose, closeBtnRef, categ
   );
 };
 
-const MobileDrawer = ({ open, onClose, user, dashboardPath, onLogout }: MobileDrawerProps) => {
+const MobileDrawer = ({
+  open,
+  onClose,
+  user,
+  dashboardPath,
+  onLogout,
+  liveCategoryIds,
+  liveRootCategoryIds,
+}: MobileDrawerProps) => {
   const [expandedSlug, setExpandedSlug] = useState<string | null>(null);
   const closeBtnRef = useRef<HTMLButtonElement>(null);
   const panelRef = useRef<HTMLDivElement>(null);
@@ -249,6 +267,8 @@ const MobileDrawer = ({ open, onClose, user, dashboardPath, onLogout }: MobileDr
           onClose={onClose}
           closeBtnRef={closeBtnRef}
           categories={categories}
+          liveCategoryIds={liveCategoryIds}
+          liveRootCategoryIds={liveRootCategoryIds}
           expandedSlug={expandedSlug}
           onCategoryExpand={setExpandedSlug}
         />

--- a/src/hooks/useLiveCategoryAvailability.ts
+++ b/src/hooks/useLiveCategoryAvailability.ts
@@ -1,0 +1,139 @@
+import { useEffect, useState } from 'react';
+import { supabase } from '@/lib/supabase';
+
+interface AvailabilitySnapshot {
+  liveCategoryIds: string[];
+  liveRootCategoryIds: string[];
+}
+
+interface CategoryRow {
+  id: string;
+  parentId: string | null;
+}
+
+let _cache: AvailabilitySnapshot | null = null;
+let _pending: Promise<AvailabilitySnapshot> | null = null;
+
+async function loadAvailability(): Promise<AvailabilitySnapshot> {
+  if (_cache) return _cache;
+  if (_pending) return _pending;
+
+  _pending = (async () => {
+    const { data: products, error: productsError } = await supabase
+      .from('products')
+      .select('categoryId')
+      .eq('isActive', true)
+      .eq('isApproved', true)
+      .eq('listingStatus', 'active')
+      .or('listingContext.eq.service,stockQuantity.gt.0')
+      .not('categoryId', 'is', null)
+      .order('createdAt', { ascending: false });
+
+    if (productsError) throw productsError;
+
+    const productCategoryIds = Array.from(
+      new Set(
+        (products ?? [])
+          .map((row: { categoryId?: string | null }) => row.categoryId)
+          .filter((id): id is string => Boolean(id)),
+      ),
+    );
+
+    if (productCategoryIds.length === 0) {
+      const empty = { liveCategoryIds: [], liveRootCategoryIds: [] };
+      _cache = empty;
+      return empty;
+    }
+
+    const { data: categories, error: categoriesError } = await supabase
+      .from('categories')
+      .select('id, parentId')
+      .eq('isActive', true);
+
+    if (categoriesError) throw categoriesError;
+
+    const byId = new Map<string, CategoryRow>();
+    (categories ?? []).forEach((row: CategoryRow) => byId.set(row.id, row));
+
+    const liveCategoryIds = new Set<string>();
+    const liveRootCategoryIds = new Set<string>();
+
+    for (const productCategoryId of productCategoryIds) {
+      let currentId: string | null = productCategoryId;
+      let rootId: string | null = null;
+      const visited = new Set<string>();
+
+      while (currentId && !visited.has(currentId)) {
+        visited.add(currentId);
+        liveCategoryIds.add(currentId);
+
+        const current = byId.get(currentId);
+        if (!current) {
+          rootId = currentId;
+          break;
+        }
+
+        if (!current.parentId) {
+          rootId = current.id;
+          break;
+        }
+
+        currentId = current.parentId;
+      }
+
+      if (rootId) liveRootCategoryIds.add(rootId);
+    }
+
+    const snapshot = {
+      liveCategoryIds: Array.from(liveCategoryIds),
+      liveRootCategoryIds: Array.from(liveRootCategoryIds),
+    };
+
+    _cache = snapshot;
+    return snapshot;
+  })().finally(() => {
+    _pending = null;
+  });
+
+  return _pending;
+}
+
+export function useLiveCategoryAvailability() {
+  const [snapshot, setSnapshot] = useState<AvailabilitySnapshot>(
+    _cache ?? { liveCategoryIds: [], liveRootCategoryIds: [] },
+  );
+  const [loading, setLoading] = useState(_cache === null);
+  const [failed, setFailed] = useState(false);
+
+  useEffect(() => {
+    if (_cache) return;
+
+    let cancelled = false;
+    loadAvailability()
+      .then((next) => {
+        if (!cancelled) {
+          setSnapshot(next);
+          setFailed(false);
+          setLoading(false);
+        }
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          console.error('[useLiveCategoryAvailability] Failed to load live category availability:', error);
+          setSnapshot({ liveCategoryIds: [], liveRootCategoryIds: [] });
+          setFailed(true);
+          setLoading(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return {
+    ...snapshot,
+    loading,
+    failed,
+  };
+}


### PR DESCRIPTION
## Purpose
Keep the public Loadify navbar aligned with the actual marketplace state after PR #529 merged.

## Behaviour
- Desktop category navigation promotes only root categories that currently contain active + approved + sellable products.
- Desktop category dropdowns show only live child categories.
- Mobile drawer uses the same live-category truth.
- Full taxonomy remains reachable via Shop All / More / Browse all categories.
- Search, cart, auth-aware dashboard routing, Sell, Help, Inbox, Profile and existing routes are unchanged.

## Scope
Exactly 3 files:
- `src/components/Header.tsx`
- `src/components/MobileDrawer.tsx`
- `src/hooks/useLiveCategoryAvailability.ts`

No Workspace/Admin/Super Admin visual changes. No Supplier Commerce controls changed.

## Branch Guard
Based on current `main` merge SHA `5f3df39e6e73e50e0c39951d5775e901906c358a`; behind 0.

This closes the navbar truth gap identified during the #529 audit: empty taxonomy categories are no longer promoted as if they contain live inventory.