### PR TITLE
Phase O: add fail-closed controlled pilot gate

### DIFF
--- a/netlify/functions/__tests__/supplier-controlled-pilot-adapter-readiness.test.ts
+++ b/netlify/functions/__tests__/supplier-controlled-pilot-adapter-readiness.test.ts
@@ -1,0 +1,36 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const closure = repo('supabase/667_supplier_controlled_pilot_adapter_readiness_closure.sql');
+
+describe('Phase O unified adapter readiness closure', () => {
+  it('requires one active verified interface-v1 adapter registration', () => {
+    expect(closure).toContain("a.status='active'");
+    expect(closure).toContain('a.interface_version=1');
+    expect(closure).toContain('a.verified_at IS NOT NULL');
+    expect(closure).toContain('a.verified_by IS NOT NULL');
+    expect(closure).toContain("NULLIF(BTRIM(a.config_ref),'') IS NOT NULL");
+  });
+
+  it('requires the complete pilot capability set on that same adapter row', () => {
+    for (const capability of ['catalog','stock','price','shipping','order_submission','acknowledgement','tracking','cancellation','returns','reimbursement']) {
+      expect(closure).toContain(`'${capability}'`);
+    }
+    expect(closure).toContain('a.capabilities @> v_required_capabilities');
+    expect(closure).toContain("'single_verified_full_capability_adapter'");
+  });
+
+  it('returns the exact adapter identity used by the readiness decision', () => {
+    for (const key of ['adapterId','adapterKey','adapterVersion']) expect(closure).toContain(`'${key}'`);
+  });
+
+  it('still requires provider source evidence, product-set bounds, catalog readiness and fresh stock/price truth', () => {
+    expect(closure).toContain('jsonb_array_length(c.official_source_refs)>0');
+    expect(closure).toContain('v_offer_count<v_pilot.minimum_product_count');
+    expect(closure).toContain('server_supplier_catalog_decision_v1');
+    expect(closure).toContain('server_supplier_stock_price_decision_v1');
+    expect(closure).toContain("'simulatorPassIsNotPilotPass',true");
+  });
+});

--- a/netlify/functions/__tests__/supplier-controlled-pilot.test.ts
+++ b/netlify/functions/__tests__/supplier-controlled-pilot.test.ts
@@ -1,0 +1,156 @@
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
+const pilot = repo('supabase/665_supplier_controlled_pilot.sql');
+const closure = repo('supabase/666_supplier_controlled_pilot_closure.sql');
+const adminApi = repo('netlify/functions/admin-supplier-pilot.ts');
+const orchestrator = repo('supabase/635_supplier_order_orchestrator_runtime_guards.sql');
+const tracking = repo('supabase/644_supplier_tracking_exception_foundation.sql');
+const contract = [
+  repo('docs/canonical/loadify-supplier-commerce-2026-08-19/03_CANONICAL_EXECUTION_CONTRACT_LINES_1251_1750.md'),
+  repo('docs/canonical/loadify-supplier-commerce-2026-08-19/04_CANONICAL_EXECUTION_CONTRACT_LINES_1751_2210.md'),
+].join('\n');
+
+describe('Phase O Controlled Pilot', () => {
+  it('models an explicit GB one-supplier bounded pilot rather than global commerce', () => {
+    expect(pilot).toContain("territory text NOT NULL DEFAULT 'GB'");
+    expect(pilot).toContain("currency text NOT NULL DEFAULT 'GBP'");
+    expect(pilot).toContain('minimum_product_count integer NOT NULL DEFAULT 5');
+    expect(pilot).toContain('maximum_product_count integer NOT NULL DEFAULT 10');
+    expect(pilot).toContain('supplier_pilot_one_live_program');
+    expect(contract).toContain('SIMULATOR PASS');
+    expect(contract).toContain('≠ PILOT PASS');
+  });
+
+  it('keeps a distinct pilot master control OFF by default and does not turn on global Supplier Commerce', () => {
+    expect(pilot).toContain("('pilot','global',NULL,false,'Phase O controlled pilot safe default')");
+    expect(pilot).toContain("'globalSupplierCommerceEnabled',false");
+    expect(pilot).toContain('Supplier Commerce remains OFF');
+  });
+
+  it('keeps pilot definition, offers, evidence and audit private', () => {
+    for (const table of ['supplier_pilot_programs','supplier_pilot_offers','supplier_pilot_evidence','supplier_pilot_audit']) {
+      expect(pilot).toContain(`private.${table}`);
+    }
+    expect(pilot.match(/REVOKE ALL ON TABLE private\.supplier_pilot_/g)?.length).toBeGreaterThanOrEqual(4);
+    expect(pilot).toContain('FROM PUBLIC,anon,authenticated,service_role');
+  });
+
+  it('requires explicit volume, order-value and acceptance thresholds before a pilot exists', () => {
+    for (const key of ['maximum_order_count','maximum_order_value_minor','acknowledgementRateMinPct','duplicateSideEffectsMax','oversellMax','unreconciledFinancialExceptionsMax','criticalIncidentMax']) {
+      expect(pilot).toContain(key);
+    }
+    expect(closure).toContain('supplier_pilot_threshold_value_check');
+  });
+
+  it('requires only low-risk selected offers and caps the pilot set at ten products', () => {
+    expect(pilot).toContain("risk_class text NOT NULL DEFAULT 'low'");
+    expect(pilot).toContain("CONSTRAINT supplier_pilot_offer_risk_check CHECK (risk_class='low')");
+    expect(pilot).toContain('pilot product ceiling reached');
+    expect(pilot).toContain('active canonical product required');
+  });
+
+  it('keeps the foundation migration executable before the closure replaces its control helper', () => {
+    expect(pilot).toContain('SELECT p,s INTO v_pilot,v_supplier');
+    expect(pilot).not.toContain('SELECT p.*,s.* INTO v_pilot,v_supplier');
+  });
+
+  it('derives supplier identity only from the exact allowlisted offer for runtime callers that omit supplierRef', () => {
+    expect(orchestrator).toContain("'offerRef',v_offer.offer_key");
+    expect(closure).toContain('JOIN private.supplier_pilot_offers po ON po.pilot_id=p.id');
+    expect(closure).toContain("v_offer_ref IN (o.id::text,o.offer_key)");
+    expect(closure).toContain("o.status='approved'");
+    expect(closure).toContain("'pilot_supplier_or_offer_scope_required'");
+  });
+
+  it('allows preparation-only import and stock/price sync while buyer-facing pilot operations remain blocked', () => {
+    expect(pilot).toContain("v_pilot.status='preparing' AND v_operation NOT IN ('import','stock_sync','price_sync')");
+    expect(pilot).toContain("'buyerFacingOperationsEnabled',false");
+    expect(pilot).toContain("'pilot_not_active'");
+  });
+
+  it('respects supplier provider territory cohort offer and product kill switches inside the pilot path', () => {
+    for (const scope of ["scope_type='supplier'","scope_type='provider'","scope_type='territory'","scope_type='cohort'","scope_type='offer'","scope_type='product'"]) {
+      expect(closure).toContain(scope);
+    }
+    expect(closure).toContain("'scoped_kill_switch'");
+  });
+
+  it('enforces order value and order volume before a new supplier reservation is inserted', () => {
+    expect(closure).toContain('trg_guard_supplier_pilot_reservation_limits_v1');
+    expect(closure).toContain('BEFORE INSERT ON private.supplier_stock_reservations');
+    expect(closure).toContain('controlled pilot order value ceiling exceeded');
+    expect(closure).toContain('controlled pilot order volume ceiling reached');
+    expect(closure).toContain('count(DISTINCT r.order_id)');
+  });
+
+  it('requires factual supplier foundation governance provider capability adapter and stock/price readiness before activation', () => {
+    for (const phrase of ['server_supplier_foundation_decision_v1','server_supplier_governance_decision_v1','supplier_commerce_provider_capabilities','supplier_adapter_registrations','server_supplier_catalog_decision_v1','server_supplier_stock_price_decision_v1']) {
+      expect(pilot).toContain(phrase);
+    }
+    expect(pilot).toContain("'controlled_pilot_ready'");
+    expect(pilot).toContain("'controlled_pilot_not_ready'");
+  });
+
+  it('preserves first activation across a real pause/restart kill-switch exercise', () => {
+    expect(closure).toContain('activated_at=COALESCE(activated_at,now())');
+    expect(pilot).toContain("server_admin_pause_supplier_pilot_v1");
+    expect(pilot).toContain("'pilotControlEnabled',false");
+  });
+
+  it('requires real orders acknowledgement tracking delivery and full return/refund/recovery evidence for Pilot PASS', () => {
+    for (const phrase of ['no_real_pilot_orders','acknowledgement_rate','no_real_tracking_event','no_delivered_pilot_order','return_refund_recovery']) {
+      expect(closure).toContain(phrase);
+    }
+    expect(closure).toContain('supplier_customer_refund_evidence');
+    expect(closure).toContain('supplier_recovery_evidence');
+  });
+
+  it('treats canonical stock-disappeared and duplicate-submit exceptions as explicit pilot acceptance metrics', () => {
+    expect(tracking).toContain("'duplicate_submit'");
+    expect(tracking).toContain("'stock_disappeared'");
+    expect(closure).toContain("x.exception_type='duplicate_submit'");
+    expect(closure).toContain("x.exception_type='stock_disappeared'");
+    expect(closure).toContain("'duplicate_side_effects'");
+    expect(closure).toContain("'oversell'");
+  });
+
+  it('requires zero-unrecovered-loss financial reconciliation for pilot orders', () => {
+    expect(closure).toContain("f.state='reconciled'");
+    expect(closure).toContain('COALESCE(abs(f.unrecovered_loss),0)=0');
+    expect(closure).toContain("'financial_reconciliation'");
+  });
+
+  it('requires buyer communication operator escalation and an audited real kill-switch disable transition', () => {
+    for (const evidence of ['buyer_communication','operator_escalation','kill_switch_test']) expect(closure).toContain(`'${evidence}'`);
+    expect(closure).toContain("a.operation='pilot'");
+    expect(closure).toContain('a.new_enabled=false');
+    expect(closure).toContain("'kill_switch_control_audit'");
+  });
+
+  it('will not complete Phase O unless the no-fake-pass acceptance function itself passes', () => {
+    expect(pilot).toContain('server_supplier_pilot_acceptance_v1(v_pilot.id)');
+    expect(pilot).toContain("'pilot_acceptance_failed'");
+    expect(pilot).toContain("'pilotPass',true");
+    expect(closure).toContain("'simulatorPassIsNotPilotPass',true");
+  });
+
+  it('exposes the pilot only through an authenticated admin server boundary and rejects secret-bearing payloads', () => {
+    expect(adminApi).toContain("authenticateActiveAccount(event, admin, ['admin'])");
+    expect(adminApi).toContain('SUPABASE_SERVICE_ROLE_KEY');
+    expect(adminApi).toContain('containsSecretMaterial');
+    expect(adminApi).toContain('Raw credentials or secrets are forbidden');
+    for (const action of ['status','create','add_offer','readiness','prepare','activate','record_evidence','acceptance','pause','complete']) {
+      expect(adminApi).toContain(`'${action}'`);
+    }
+  });
+
+  it('does not introduce Workspace or Super Admin visual changes', () => {
+    expect(adminApi).not.toContain('Workspace');
+    expect(adminApi).not.toContain('SuperAdmin');
+    expect(pilot).not.toContain('Workspace');
+    expect(pilot).not.toContain('SuperAdmin');
+  });
+});

--- a/netlify/functions/__tests__/supplier-controlled-pilot.test.ts
+++ b/netlify/functions/__tests__/supplier-controlled-pilot.test.ts
@@ -5,19 +5,22 @@ import { describe, expect, it } from 'vitest';
 const repo = (path: string) => readFileSync(resolve(process.cwd(), path), 'utf8');
 const pilot = repo('supabase/665_supplier_controlled_pilot.sql');
 const closure = repo('supabase/666_supplier_controlled_pilot_closure.sql');
+const evidenceClosure = repo('supabase/668_supplier_controlled_pilot_cohort_evidence_closure.sql');
 const adminApi = repo('netlify/functions/admin-supplier-pilot.ts');
 const orchestrator = repo('supabase/635_supplier_order_orchestrator_runtime_guards.sql');
 const tracking = repo('supabase/644_supplier_tracking_exception_foundation.sql');
+const financial = repo('supabase/650_supplier_financial_reconciliation.sql');
 const contract = [
   repo('docs/canonical/loadify-supplier-commerce-2026-08-19/03_CANONICAL_EXECUTION_CONTRACT_LINES_1251_1750.md'),
   repo('docs/canonical/loadify-supplier-commerce-2026-08-19/04_CANONICAL_EXECUTION_CONTRACT_LINES_1751_2210.md'),
+  repo('docs/canonical/loadify-supplier-commerce-2026-08-19/10_CANONICAL_CONTINUATION_PLAN_PHASE_O_TO_Q_2026-08-21.md'),
 ].join('\n');
 
 describe('Phase O Controlled Pilot', () => {
   it('models an explicit GB one-supplier bounded pilot rather than global commerce', () => {
     expect(pilot).toContain("territory text NOT NULL DEFAULT 'GB'");
     expect(pilot).toContain("currency text NOT NULL DEFAULT 'GBP'");
-    expect(pilot).toContain('minimum_product_count integer NOT NULL DEFAULT 5');
+    expect(evidenceClosure).toContain('ALTER COLUMN minimum_product_count SET DEFAULT 1');
     expect(pilot).toContain('maximum_product_count integer NOT NULL DEFAULT 10');
     expect(pilot).toContain('supplier_pilot_one_live_program');
     expect(contract).toContain('SIMULATOR PASS');
@@ -28,14 +31,16 @@ describe('Phase O Controlled Pilot', () => {
     expect(pilot).toContain("('pilot','global',NULL,false,'Phase O controlled pilot safe default')");
     expect(pilot).toContain("'globalSupplierCommerceEnabled',false");
     expect(pilot).toContain('Supplier Commerce remains OFF');
+    expect(evidenceClosure).toContain("c.operation<>'pilot' AND c.enabled=true");
+    expect(evidenceClosure).toContain('non_pilot_global_supplier_commerce_control_enabled');
   });
 
-  it('keeps pilot definition, offers, evidence and audit private', () => {
+  it('keeps pilot definition, offers, cohort, evidence and audit private', () => {
     for (const table of ['supplier_pilot_programs','supplier_pilot_offers','supplier_pilot_evidence','supplier_pilot_audit']) {
       expect(pilot).toContain(`private.${table}`);
     }
-    expect(pilot.match(/REVOKE ALL ON TABLE private\.supplier_pilot_/g)?.length).toBeGreaterThanOrEqual(4);
-    expect(pilot).toContain('FROM PUBLIC,anon,authenticated,service_role');
+    expect(evidenceClosure).toContain('private.supplier_pilot_cohort_members');
+    expect(evidenceClosure).toContain('REVOKE ALL ON TABLE private.supplier_pilot_cohort_members FROM PUBLIC,anon,authenticated,service_role');
   });
 
   it('requires explicit volume, order-value and acceptance thresholds before a pilot exists', () => {
@@ -48,13 +53,14 @@ describe('Phase O Controlled Pilot', () => {
   it('requires only low-risk selected offers and caps the pilot set at ten products', () => {
     expect(pilot).toContain("risk_class text NOT NULL DEFAULT 'low'");
     expect(pilot).toContain("CONSTRAINT supplier_pilot_offer_risk_check CHECK (risk_class='low')");
-    expect(pilot).toContain('pilot product ceiling reached');
-    expect(pilot).toContain('active canonical product required');
+    expect(evidenceClosure).toContain('pilot product ceiling reached');
+    expect(evidenceClosure).toContain('active canonical product required');
   });
 
-  it('keeps the foundation migration executable before the closure replaces its control helper', () => {
-    expect(pilot).toContain('SELECT p,s INTO v_pilot,v_supplier');
-    expect(pilot).not.toContain('SELECT p.*,s.* INTO v_pilot,v_supplier');
+  it('keeps add-offer idempotency fail-closed instead of using a no-op update', () => {
+    expect(evidenceClosure).toContain('pilot offer idempotency collision');
+    expect(evidenceClosure).toContain('RETURN v_existing.id');
+    expect(evidenceClosure).not.toContain('ON CONFLICT(pilot_id,supplier_offer_id,external_variant_ref) DO UPDATE');
   });
 
   it('derives supplier identity only from the exact allowlisted offer for runtime callers that omit supplierRef', () => {
@@ -86,6 +92,15 @@ describe('Phase O Controlled Pilot', () => {
     expect(closure).toContain('count(DISTINCT r.order_id)');
   });
 
+  it('hard-enforces an explicit buyer cohort before active-pilot reservation', () => {
+    expect(evidenceClosure).toContain('supplier_pilot_cohort_members');
+    expect(evidenceClosure).toContain('server_admin_add_supplier_pilot_cohort_member_v1');
+    expect(evidenceClosure).toContain('trg_guard_supplier_pilot_cohort_reservation_v1');
+    expect(evidenceClosure).toContain('controlled pilot buyer outside explicit cohort');
+    expect(evidenceClosure).toContain('pilot cohort membership is append-only');
+    expect(adminApi).toContain("'add_cohort_member'");
+  });
+
   it('requires factual supplier foundation governance provider capability adapter and stock/price readiness before activation', () => {
     for (const phrase of ['server_supplier_foundation_decision_v1','server_supplier_governance_decision_v1','supplier_commerce_provider_capabilities','supplier_adapter_registrations','server_supplier_catalog_decision_v1','server_supplier_stock_price_decision_v1']) {
       expect(pilot).toContain(phrase);
@@ -94,47 +109,76 @@ describe('Phase O Controlled Pilot', () => {
     expect(pilot).toContain("'controlled_pilot_not_ready'");
   });
 
+  it('requires an actual passed Phase N simulator run rather than a free-text reference', () => {
+    expect(evidenceClosure).toContain('private.supplier_simulator_validation_runs');
+    expect(evidenceClosure).toContain("r.status='passed'");
+    expect(evidenceClosure).toContain("v_pilot.simulator_evidence_ref IN (r.id::text,r.run_key)");
+    expect(evidenceClosure).toContain('passed_phase_n_simulator_run_not_found');
+  });
+
+  it('uses the stronger activation readiness gate at the admin boundary', () => {
+    expect(evidenceClosure).toContain('server_supplier_pilot_activation_readiness_v1');
+    expect(evidenceClosure).toContain('v_readiness:=public.server_supplier_pilot_activation_readiness_v1(v_pilot.id)');
+    expect(adminApi).toContain("body.action === 'readiness' ? 'server_supplier_pilot_activation_readiness_v1'");
+  });
+
   it('preserves first activation across a real pause/restart kill-switch exercise', () => {
     expect(closure).toContain('activated_at=COALESCE(activated_at,now())');
-    expect(pilot).toContain("server_admin_pause_supplier_pilot_v1");
+    expect(pilot).toContain('server_admin_pause_supplier_pilot_v1');
     expect(pilot).toContain("'pilotControlEnabled',false");
   });
 
-  it('requires real orders acknowledgement tracking delivery and full return/refund/recovery evidence for Pilot PASS', () => {
-    for (const phrase of ['no_real_pilot_orders','acknowledgement_rate','no_real_tracking_event','no_delivered_pilot_order','return_refund_recovery']) {
-      expect(closure).toContain(phrase);
+  it('requires real orders acknowledgement tracking and delivery for Pilot PASS', () => {
+    for (const phrase of ['no_real_pilot_orders','acknowledgement_rate','no_real_tracking_event','no_delivered_pilot_order']) {
+      expect(evidenceClosure).toContain(phrase);
     }
-    expect(closure).toContain('supplier_customer_refund_evidence');
-    expect(closure).toContain('supplier_recovery_evidence');
+    expect(evidenceClosure).toContain('outsideCohortOrders');
+  });
+
+  it('does not manufacture a refund/recovery event merely to pass the first pilot', () => {
+    expect(contract).toContain('customer refund + supplier recovery separation where applicable');
+    expect(evidenceClosure).toContain('IF v_returns>0 AND v_return_incomplete>0 THEN');
+    expect(evidenceClosure).toContain("r.customer_refund_state<>'succeeded'");
+    expect(evidenceClosure).toContain("r.supplier_recovery_state NOT IN ('recovered','unrecoverable')");
+    expect(evidenceClosure).not.toContain('IF v_returns=0 OR v_refunds=0 OR v_recoveries=0 THEN');
   });
 
   it('treats canonical stock-disappeared and duplicate-submit exceptions as explicit pilot acceptance metrics', () => {
     expect(tracking).toContain("'duplicate_submit'");
     expect(tracking).toContain("'stock_disappeared'");
-    expect(closure).toContain("x.exception_type='duplicate_submit'");
-    expect(closure).toContain("x.exception_type='stock_disappeared'");
-    expect(closure).toContain("'duplicate_side_effects'");
-    expect(closure).toContain("'oversell'");
+    expect(evidenceClosure).toContain("x.exception_type='duplicate_submit'");
+    expect(evidenceClosure).toContain("x.exception_type='stock_disappeared'");
+    expect(evidenceClosure).toContain("'duplicate_side_effects'");
+    expect(evidenceClosure).toContain("'oversell'");
   });
 
-  it('requires zero-unrecovered-loss financial reconciliation for pilot orders', () => {
-    expect(closure).toContain("f.state='reconciled'");
-    expect(closure).toContain('COALESCE(abs(f.unrecovered_loss),0)=0');
-    expect(closure).toContain("'financial_reconciliation'");
+  it('uses the canonical uppercase reconciliation state and requires zero unrecovered loss', () => {
+    expect(financial).toContain("v_state:='RECONCILED'");
+    expect(evidenceClosure).toContain("f.state='RECONCILED'");
+    expect(evidenceClosure).not.toContain("f.state='reconciled'");
+    expect(evidenceClosure).toContain('COALESCE(abs(f.unrecovered_loss),0)=0');
   });
 
-  it('requires buyer communication operator escalation and an audited real kill-switch disable transition', () => {
-    for (const evidence of ['buyer_communication','operator_escalation','kill_switch_test']) expect(closure).toContain(`'${evidence}'`);
-    expect(closure).toContain("a.operation='pilot'");
-    expect(closure).toContain('a.new_enabled=false');
-    expect(closure).toContain("'kill_switch_control_audit'");
+  it('requires operational evidence including kill switch rollback incident release and duplicate-side-effect review', () => {
+    for (const evidence of ['buyer_communication','operator_escalation','kill_switch_test','rollback_recovery_test','incident_path_test','release_snapshot','duplicate_side_effect_review']) {
+      expect(evidenceClosure).toContain(`'${evidence}'`);
+    }
+    expect(evidenceClosure).toContain("a.operation='pilot'");
+    expect(evidenceClosure).toContain('a.new_enabled=false');
+    expect(evidenceClosure).toContain("'kill_switch_control_audit'");
+  });
+
+  it('requires exact release snapshot shape before Pilot PASS', () => {
+    for (const key of ['mainSha','migrationHead','controlState','pilotControlVersion']) expect(evidenceClosure).toContain(`'${key}'`);
+    expect(evidenceClosure).toContain("COALESCE(evidence->>'mainSha','') ~ '^[0-9a-f]{40}$'");
+    expect(evidenceClosure).toContain('exact_release_evidence_missing');
   });
 
   it('will not complete Phase O unless the no-fake-pass acceptance function itself passes', () => {
     expect(pilot).toContain('server_supplier_pilot_acceptance_v1(v_pilot.id)');
     expect(pilot).toContain("'pilot_acceptance_failed'");
     expect(pilot).toContain("'pilotPass',true");
-    expect(closure).toContain("'simulatorPassIsNotPilotPass',true");
+    expect(evidenceClosure).toContain("'simulatorPassIsNotPilotPass',true");
   });
 
   it('exposes the pilot only through an authenticated admin server boundary and rejects secret-bearing payloads', () => {
@@ -142,7 +186,7 @@ describe('Phase O Controlled Pilot', () => {
     expect(adminApi).toContain('SUPABASE_SERVICE_ROLE_KEY');
     expect(adminApi).toContain('containsSecretMaterial');
     expect(adminApi).toContain('Raw credentials or secrets are forbidden');
-    for (const action of ['status','create','add_offer','readiness','prepare','activate','record_evidence','acceptance','pause','complete']) {
+    for (const action of ['status','create','add_offer','add_cohort_member','readiness','prepare','activate','record_evidence','acceptance','pause','complete']) {
       expect(adminApi).toContain(`'${action}'`);
     }
   });
@@ -152,5 +196,7 @@ describe('Phase O Controlled Pilot', () => {
     expect(adminApi).not.toContain('SuperAdmin');
     expect(pilot).not.toContain('Workspace');
     expect(pilot).not.toContain('SuperAdmin');
+    expect(evidenceClosure).not.toContain('Workspace');
+    expect(evidenceClosure).not.toContain('SuperAdmin');
   });
 });

--- a/netlify/functions/admin-supplier-pilot.ts
+++ b/netlify/functions/admin-supplier-pilot.ts
@@ -1,0 +1,133 @@
+import { createClient } from '@supabase/supabase-js';
+import type { Handler } from '@netlify/functions';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { jsonResponse, optionsResponse } from './_shared/http';
+
+const METHODS = 'POST, OPTIONS';
+const text = (value: unknown) => typeof value === 'string' ? value.trim() : '';
+const object = (value: unknown): Record<string, unknown> | null => value && typeof value === 'object' && !Array.isArray(value) ? value as Record<string, unknown> : null;
+const positiveInteger = (value: unknown) => Number.isSafeInteger(value) && Number(value) > 0;
+const secretPattern = /(password|secret[_-]?key|api[_-]?key|access[_-]?token|refresh[_-]?token|private[_-]?key)\s*["']?\s*:/i;
+
+const containsSecretMaterial = (value: unknown) => {
+  try { return secretPattern.test(JSON.stringify(value)); }
+  catch { return true; }
+};
+
+type PilotAction =
+  | { action: 'status'; pilotId?: string }
+  | { action: 'create'; pilotKey: string; supplierId: string; providerKey: string; cohortKey: string; maximumOrderCount: number; maximumOrderValueMinor: number; acceptanceThresholds: Record<string, unknown>; simulatorEvidenceRef: string; evidence?: Record<string, unknown> }
+  | { action: 'add_offer'; pilotId: string; supplierOfferId: string; externalVariantRef?: string; selectionEvidence: Record<string, unknown> }
+  | { action: 'readiness'; pilotId: string }
+  | { action: 'prepare'; pilotId: string; reason: string }
+  | { action: 'activate'; pilotId: string; reason: string }
+  | { action: 'record_evidence'; pilotId: string; orderId?: string; evidenceType: string; evidenceRef: string; summary: string; observedAt: string; evidence?: Record<string, unknown> }
+  | { action: 'acceptance'; pilotId: string }
+  | { action: 'pause'; pilotId: string; reason: string }
+  | { action: 'complete'; pilotId: string; reason: string };
+
+const requiredThresholds = (value: Record<string, unknown>) => {
+  const ack = value.acknowledgementRateMinPct;
+  const duplicate = value.duplicateSideEffectsMax;
+  const oversell = value.oversellMax;
+  const financial = value.unreconciledFinancialExceptionsMax;
+  const critical = value.criticalIncidentMax;
+  return typeof ack === 'number' && Number.isFinite(ack) && ack >= 0 && ack <= 100
+    && Number.isInteger(duplicate) && duplicate === 0
+    && Number.isInteger(oversell) && Number(oversell) >= 0
+    && Number.isInteger(financial) && financial === 0
+    && Number.isInteger(critical) && critical === 0;
+};
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod === 'OPTIONS') return optionsResponse(METHODS);
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' }, METHODS);
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) return jsonResponse(500, { error: 'Server configuration error' }, METHODS);
+
+  const admin = createClient(supabaseUrl, serviceRoleKey, { auth: { autoRefreshToken: false, persistSession: false } });
+  const auth = await authenticateActiveAccount(event, admin, ['admin']);
+  if (!auth.ok) return jsonResponse(auth.status, { error: 'Unauthorized' }, METHODS);
+
+  let body: PilotAction;
+  try { body = JSON.parse(event.body || '{}') as PilotAction; }
+  catch { return jsonResponse(400, { error: 'Invalid JSON body' }, METHODS); }
+  if (!body || typeof body !== 'object' || !('action' in body)) return jsonResponse(400, { error: 'Unsupported Phase O pilot action' }, METHODS);
+  if (containsSecretMaterial(body)) return jsonResponse(400, { error: 'Raw credentials or secrets are forbidden in controlled pilot payloads' }, METHODS);
+
+  if (body.action === 'status') {
+    const pilotId = body.pilotId === undefined ? null : text(body.pilotId);
+    if (body.pilotId !== undefined && !pilotId) return jsonResponse(400, { error: 'pilotId must be non-empty when supplied' }, METHODS);
+    const { data, error } = await admin.rpc('server_admin_supplier_pilot_status_v1', { p_actor_id: auth.actor.id, p_pilot_id: pilotId });
+    if (error) return jsonResponse(500, { error: 'Unable to read controlled pilot status' }, METHODS);
+    return jsonResponse(200, { ok: true, result: data }, METHODS);
+  }
+
+  if (body.action === 'create') {
+    const pilotKey = text(body.pilotKey); const supplierId = text(body.supplierId); const providerKey = text(body.providerKey); const cohortKey = text(body.cohortKey);
+    const simulatorEvidenceRef = text(body.simulatorEvidenceRef); const thresholds = object(body.acceptanceThresholds); const evidence = object(body.evidence ?? {});
+    if (!pilotKey || !supplierId || !providerKey || !cohortKey || !simulatorEvidenceRef || !positiveInteger(body.maximumOrderCount)
+      || !positiveInteger(body.maximumOrderValueMinor) || !thresholds || !requiredThresholds(thresholds) || !evidence) {
+      return jsonResponse(400, { error: 'Complete bounded controlled pilot definition is required' }, METHODS);
+    }
+    const { data, error } = await admin.rpc('server_admin_create_supplier_pilot_v1', {
+      p_actor_id: auth.actor.id, p_pilot_key: pilotKey, p_supplier_id: supplierId, p_provider_key: providerKey,
+      p_cohort_key: cohortKey, p_maximum_order_count: body.maximumOrderCount, p_maximum_order_value_minor: body.maximumOrderValueMinor,
+      p_acceptance_thresholds: thresholds, p_simulator_evidence_ref: simulatorEvidenceRef, p_evidence: evidence,
+    });
+    if (error) return jsonResponse(400, { error: 'Unable to create controlled pilot' }, METHODS);
+    return jsonResponse(200, { ok: true, pilotId: data }, METHODS);
+  }
+
+  if (body.action === 'add_offer') {
+    const pilotId = text(body.pilotId); const supplierOfferId = text(body.supplierOfferId); const variantRef = body.externalVariantRef === undefined ? '' : text(body.externalVariantRef);
+    const selectionEvidence = object(body.selectionEvidence);
+    if (!pilotId || !supplierOfferId || !selectionEvidence || Object.keys(selectionEvidence).length === 0) return jsonResponse(400, { error: 'Pilot offer and low-risk selection evidence are required' }, METHODS);
+    const { data, error } = await admin.rpc('server_admin_add_supplier_pilot_offer_v1', {
+      p_actor_id: auth.actor.id, p_pilot_id: pilotId, p_supplier_offer_id: supplierOfferId,
+      p_external_variant_ref: variantRef, p_selection_evidence: selectionEvidence,
+    });
+    if (error) return jsonResponse(400, { error: 'Unable to add controlled pilot offer' }, METHODS);
+    return jsonResponse(200, { ok: true, pilotOfferId: data }, METHODS);
+  }
+
+  if (body.action === 'readiness' || body.action === 'acceptance') {
+    const pilotId = text(body.pilotId);
+    if (!pilotId) return jsonResponse(400, { error: 'pilotId is required' }, METHODS);
+    const rpc = body.action === 'readiness' ? 'server_supplier_pilot_readiness_v1' : 'server_supplier_pilot_acceptance_v1';
+    const { data, error } = await admin.rpc(rpc, { p_pilot_id: pilotId });
+    if (error) return jsonResponse(400, { error: body.action === 'readiness' ? 'Unable to evaluate pilot readiness' : 'Unable to evaluate pilot acceptance' }, METHODS);
+    return jsonResponse(200, { ok: true, result: data }, METHODS);
+  }
+
+  if (body.action === 'prepare' || body.action === 'activate' || body.action === 'pause' || body.action === 'complete') {
+    const pilotId = text(body.pilotId); const reason = text(body.reason);
+    if (!pilotId || !reason) return jsonResponse(400, { error: 'pilotId and reason are required' }, METHODS);
+    const rpc = body.action === 'prepare' ? 'server_admin_prepare_supplier_pilot_v1'
+      : body.action === 'activate' ? 'server_admin_activate_supplier_pilot_v1'
+        : body.action === 'pause' ? 'server_admin_pause_supplier_pilot_v1'
+          : 'server_admin_complete_supplier_pilot_v1';
+    const { data, error } = await admin.rpc(rpc, { p_actor_id: auth.actor.id, p_pilot_id: pilotId, p_reason: reason });
+    if (error) return jsonResponse(400, { error: `Unable to ${body.action} controlled pilot` }, METHODS);
+    return jsonResponse(200, { ok: true, result: data }, METHODS);
+  }
+
+  if (body.action === 'record_evidence') {
+    const pilotId = text(body.pilotId); const orderId = body.orderId === undefined ? null : text(body.orderId);
+    const evidenceType = text(body.evidenceType); const evidenceRef = text(body.evidenceRef); const summary = text(body.summary); const observedAt = text(body.observedAt);
+    const evidence = object(body.evidence ?? {});
+    if (!pilotId || (body.orderId !== undefined && !orderId) || !evidenceType || !evidenceRef || !summary || !observedAt || Number.isNaN(Date.parse(observedAt)) || !evidence) {
+      return jsonResponse(400, { error: 'Complete controlled pilot evidence is required' }, METHODS);
+    }
+    const { data, error } = await admin.rpc('server_admin_record_supplier_pilot_evidence_v1', {
+      p_actor_id: auth.actor.id, p_pilot_id: pilotId, p_order_id: orderId, p_evidence_type: evidenceType,
+      p_evidence_ref: evidenceRef, p_summary: summary, p_observed_at: observedAt, p_evidence: evidence,
+    });
+    if (error) return jsonResponse(400, { error: 'Unable to record controlled pilot evidence' }, METHODS);
+    return jsonResponse(200, { ok: true, evidenceId: data }, METHODS);
+  }
+
+  return jsonResponse(400, { error: 'Unsupported Phase O pilot action' }, METHODS);
+};

--- a/netlify/functions/admin-supplier-pilot.ts
+++ b/netlify/functions/admin-supplier-pilot.ts
@@ -18,6 +18,7 @@ type PilotAction =
   | { action: 'status'; pilotId?: string }
   | { action: 'create'; pilotKey: string; supplierId: string; providerKey: string; cohortKey: string; maximumOrderCount: number; maximumOrderValueMinor: number; acceptanceThresholds: Record<string, unknown>; simulatorEvidenceRef: string; evidence?: Record<string, unknown> }
   | { action: 'add_offer'; pilotId: string; supplierOfferId: string; externalVariantRef?: string; selectionEvidence: Record<string, unknown> }
+  | { action: 'add_cohort_member'; pilotId: string; buyerId: string; evidence: Record<string, unknown> }
   | { action: 'readiness'; pilotId: string }
   | { action: 'prepare'; pilotId: string; reason: string }
   | { action: 'activate'; pilotId: string; reason: string }
@@ -93,12 +94,24 @@ export const handler: Handler = async (event) => {
     return jsonResponse(200, { ok: true, pilotOfferId: data }, METHODS);
   }
 
+  if (body.action === 'add_cohort_member') {
+    const pilotId = text(body.pilotId); const buyerId = text(body.buyerId); const evidence = object(body.evidence);
+    if (!pilotId || !buyerId || !evidence || Object.keys(evidence).length === 0) {
+      return jsonResponse(400, { error: 'Pilot, buyer and cohort membership evidence are required' }, METHODS);
+    }
+    const { data, error } = await admin.rpc('server_admin_add_supplier_pilot_cohort_member_v1', {
+      p_actor_id: auth.actor.id, p_pilot_id: pilotId, p_buyer_id: buyerId, p_evidence: evidence,
+    });
+    if (error) return jsonResponse(400, { error: 'Unable to add controlled pilot cohort member' }, METHODS);
+    return jsonResponse(200, { ok: true, cohortMemberId: data }, METHODS);
+  }
+
   if (body.action === 'readiness' || body.action === 'acceptance') {
     const pilotId = text(body.pilotId);
     if (!pilotId) return jsonResponse(400, { error: 'pilotId is required' }, METHODS);
-    const rpc = body.action === 'readiness' ? 'server_supplier_pilot_readiness_v1' : 'server_supplier_pilot_acceptance_v1';
+    const rpc = body.action === 'readiness' ? 'server_supplier_pilot_activation_readiness_v1' : 'server_supplier_pilot_acceptance_v1';
     const { data, error } = await admin.rpc(rpc, { p_pilot_id: pilotId });
-    if (error) return jsonResponse(400, { error: body.action === 'readiness' ? 'Unable to evaluate pilot readiness' : 'Unable to evaluate pilot acceptance' }, METHODS);
+    if (error) return jsonResponse(400, { error: body.action === 'readiness' ? 'Unable to evaluate pilot activation readiness' : 'Unable to evaluate pilot acceptance' }, METHODS);
     return jsonResponse(200, { ok: true, result: data }, METHODS);
   }
 

--- a/supabase/665_supplier_controlled_pilot.sql
+++ b/supabase/665_supplier_controlled_pilot.sql
@@ -1,0 +1,667 @@
+-- 665_supplier_controlled_pilot.sql
+-- Phase O — Controlled Pilot.
+--
+-- This migration creates a fail-closed pilot control plane. It does NOT create a
+-- supplier, select products, fabricate pilot evidence, enable global Supplier
+-- Commerce, or declare Pilot PASS.
+--
+-- Global Supplier Commerce remains OFF. A distinct `pilot` master control may be
+-- enabled only by the dedicated admin pilot transition after factual readiness.
+
+CREATE SCHEMA IF NOT EXISTS private;
+
+ALTER TABLE private.supplier_commerce_controls
+  DROP CONSTRAINT IF EXISTS supplier_commerce_controls_operation_check;
+ALTER TABLE private.supplier_commerce_controls
+  ADD CONSTRAINT supplier_commerce_controls_operation_check
+  CHECK (operation IN (
+    '*','pilot','import','publish','checkout','reservation','supplier_order',
+    'tracking_ingest','return_recovery','stock_sync','price_sync'
+  ));
+
+INSERT INTO private.supplier_commerce_controls(operation,scope_type,scope_ref,enabled,reason)
+VALUES('pilot','global',NULL,false,'Phase O controlled pilot safe default')
+ON CONFLICT(operation,scope_type,scope_ref_key) DO NOTHING;
+
+CREATE TABLE IF NOT EXISTS private.supplier_pilot_programs (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pilot_key text NOT NULL UNIQUE,
+  supplier_id uuid NOT NULL REFERENCES private.supplier_foundation_suppliers(id) ON DELETE RESTRICT,
+  provider_key text NOT NULL,
+  cohort_key text NOT NULL UNIQUE,
+  territory text NOT NULL DEFAULT 'GB',
+  currency text NOT NULL DEFAULT 'GBP',
+  status text NOT NULL DEFAULT 'draft',
+  minimum_product_count integer NOT NULL DEFAULT 5,
+  maximum_product_count integer NOT NULL DEFAULT 10,
+  maximum_order_count integer NOT NULL,
+  maximum_order_value_minor bigint NOT NULL,
+  acceptance_thresholds jsonb NOT NULL,
+  simulator_evidence_ref text NOT NULL,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_by uuid NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  prepared_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  prepared_at timestamptz,
+  activated_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  activated_at timestamptz,
+  ended_by uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  ended_at timestamptz,
+  end_reason text,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_pilot_key_check CHECK (
+    pilot_key=lower(BTRIM(pilot_key)) AND pilot_key ~ '^[a-z0-9][a-z0-9._-]{2,127}$'
+  ),
+  CONSTRAINT supplier_pilot_provider_check CHECK (NULLIF(BTRIM(provider_key),'') IS NOT NULL),
+  CONSTRAINT supplier_pilot_cohort_check CHECK (
+    cohort_key=lower(BTRIM(cohort_key)) AND cohort_key ~ '^[a-z0-9][a-z0-9._-]{2,127}$'
+  ),
+  CONSTRAINT supplier_pilot_territory_check CHECK (territory='GB'),
+  CONSTRAINT supplier_pilot_currency_check CHECK (currency='GBP'),
+  CONSTRAINT supplier_pilot_status_check CHECK (
+    status IN ('draft','preparing','active','paused','completed','failed','cancelled')
+  ),
+  CONSTRAINT supplier_pilot_product_bounds_check CHECK (
+    minimum_product_count BETWEEN 1 AND 10
+    AND maximum_product_count BETWEEN 1 AND 10
+    AND minimum_product_count<=maximum_product_count
+  ),
+  CONSTRAINT supplier_pilot_order_bounds_check CHECK (
+    maximum_order_count>0 AND maximum_order_value_minor>0
+  ),
+  CONSTRAINT supplier_pilot_thresholds_check CHECK (
+    jsonb_typeof(acceptance_thresholds)='object'
+    AND acceptance_thresholds ? 'acknowledgementRateMinPct'
+    AND acceptance_thresholds ? 'duplicateSideEffectsMax'
+    AND acceptance_thresholds ? 'oversellMax'
+    AND acceptance_thresholds ? 'unreconciledFinancialExceptionsMax'
+    AND acceptance_thresholds ? 'criticalIncidentMax'
+    AND COALESCE((acceptance_thresholds->>'duplicateSideEffectsMax')::integer,-1)=0
+    AND COALESCE((acceptance_thresholds->>'unreconciledFinancialExceptionsMax')::integer,-1)=0
+    AND COALESCE((acceptance_thresholds->>'criticalIncidentMax')::integer,-1)=0
+  ),
+  CONSTRAINT supplier_pilot_evidence_check CHECK (jsonb_typeof(evidence)='object'),
+  CONSTRAINT supplier_pilot_simulator_ref_check CHECK (NULLIF(BTRIM(simulator_evidence_ref),'') IS NOT NULL),
+  CONSTRAINT supplier_pilot_prepare_check CHECK (
+    status NOT IN ('preparing','active','paused','completed','failed')
+    OR (prepared_by IS NOT NULL AND prepared_at IS NOT NULL)
+  ),
+  CONSTRAINT supplier_pilot_activate_check CHECK (
+    status NOT IN ('active','paused','completed','failed')
+    OR (activated_by IS NOT NULL AND activated_at IS NOT NULL)
+  ),
+  CONSTRAINT supplier_pilot_end_check CHECK (
+    status NOT IN ('completed','failed','cancelled')
+    OR (ended_by IS NOT NULL AND ended_at IS NOT NULL AND NULLIF(BTRIM(end_reason),'') IS NOT NULL)
+  )
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS supplier_pilot_one_live_program
+  ON private.supplier_pilot_programs((true))
+  WHERE status IN ('preparing','active');
+CREATE INDEX IF NOT EXISTS supplier_pilot_supplier_idx
+  ON private.supplier_pilot_programs(supplier_id,status,created_at DESC);
+
+CREATE TABLE IF NOT EXISTS private.supplier_pilot_offers (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pilot_id uuid NOT NULL REFERENCES private.supplier_pilot_programs(id) ON DELETE RESTRICT,
+  supplier_offer_id uuid NOT NULL REFERENCES private.supplier_offers(id) ON DELETE RESTRICT,
+  external_variant_ref text NOT NULL DEFAULT '',
+  risk_class text NOT NULL DEFAULT 'low',
+  selection_evidence jsonb NOT NULL,
+  approved_by uuid NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  approved_at timestamptz NOT NULL DEFAULT now(),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_pilot_offer_variant_check CHECK (external_variant_ref=BTRIM(external_variant_ref)),
+  CONSTRAINT supplier_pilot_offer_risk_check CHECK (risk_class='low'),
+  CONSTRAINT supplier_pilot_offer_evidence_check CHECK (
+    jsonb_typeof(selection_evidence)='object' AND selection_evidence<>'{}'::jsonb
+  ),
+  UNIQUE(pilot_id,supplier_offer_id,external_variant_ref)
+);
+CREATE INDEX IF NOT EXISTS supplier_pilot_offer_lookup_idx
+  ON private.supplier_pilot_offers(pilot_id,supplier_offer_id);
+
+CREATE TABLE IF NOT EXISTS private.supplier_pilot_evidence (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pilot_id uuid NOT NULL REFERENCES private.supplier_pilot_programs(id) ON DELETE RESTRICT,
+  order_id uuid REFERENCES public.orders(id) ON DELETE RESTRICT,
+  evidence_type text NOT NULL,
+  evidence_ref text NOT NULL,
+  summary text NOT NULL,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  recorded_by uuid NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  observed_at timestamptz NOT NULL,
+  recorded_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_pilot_evidence_type_check CHECK (
+    evidence_type IN ('buyer_communication','kill_switch_test','operator_escalation','incident_review','pilot_note')
+  ),
+  CONSTRAINT supplier_pilot_evidence_ref_check CHECK (NULLIF(BTRIM(evidence_ref),'') IS NOT NULL),
+  CONSTRAINT supplier_pilot_evidence_summary_check CHECK (NULLIF(BTRIM(summary),'') IS NOT NULL),
+  CONSTRAINT supplier_pilot_evidence_object_check CHECK (jsonb_typeof(evidence)='object')
+);
+CREATE INDEX IF NOT EXISTS supplier_pilot_evidence_idx
+  ON private.supplier_pilot_evidence(pilot_id,evidence_type,observed_at DESC);
+
+CREATE TABLE IF NOT EXISTS private.supplier_pilot_audit (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pilot_id uuid NOT NULL REFERENCES private.supplier_pilot_programs(id) ON DELETE RESTRICT,
+  actor_id uuid REFERENCES public.users(id) ON DELETE SET NULL,
+  action text NOT NULL,
+  previous_status text,
+  new_status text,
+  evidence jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_pilot_audit_evidence_check CHECK (jsonb_typeof(evidence)='object')
+);
+CREATE INDEX IF NOT EXISTS supplier_pilot_audit_idx
+  ON private.supplier_pilot_audit(pilot_id,created_at DESC);
+
+REVOKE ALL ON TABLE private.supplier_pilot_programs FROM PUBLIC,anon,authenticated,service_role;
+REVOKE ALL ON TABLE private.supplier_pilot_offers FROM PUBLIC,anon,authenticated,service_role;
+REVOKE ALL ON TABLE private.supplier_pilot_evidence FROM PUBLIC,anon,authenticated,service_role;
+REVOKE ALL ON TABLE private.supplier_pilot_audit FROM PUBLIC,anon,authenticated,service_role;
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_pilot_history_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  RAISE EXCEPTION 'controlled pilot evidence/history is append-only';
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_pilot_evidence_immutable_v1 ON private.supplier_pilot_evidence;
+CREATE TRIGGER trg_guard_supplier_pilot_evidence_immutable_v1
+BEFORE UPDATE OR DELETE ON private.supplier_pilot_evidence
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_pilot_history_v1();
+DROP TRIGGER IF EXISTS trg_guard_supplier_pilot_audit_immutable_v1 ON private.supplier_pilot_audit;
+CREATE TRIGGER trg_guard_supplier_pilot_audit_immutable_v1
+BEFORE UPDATE OR DELETE ON private.supplier_pilot_audit
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_pilot_history_v1();
+
+CREATE OR REPLACE FUNCTION private.set_supplier_pilot_master_control_v1(
+  p_actor_id uuid,p_enabled boolean,p_reason text
+)
+RETURNS void LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_existing private.supplier_commerce_controls%ROWTYPE;
+  v_saved private.supplier_commerce_controls%ROWTYPE;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF NULLIF(BTRIM(p_reason),'') IS NULL THEN RAISE EXCEPTION 'pilot control reason is required'; END IF;
+  SELECT * INTO v_existing FROM private.supplier_commerce_controls
+   WHERE operation='pilot' AND scope_type='global' AND scope_ref IS NULL FOR UPDATE;
+  IF FOUND THEN
+    UPDATE private.supplier_commerce_controls
+       SET enabled=p_enabled,reason=BTRIM(p_reason),version=version+1,updated_by=p_actor_id,updated_at=now()
+     WHERE id=v_existing.id RETURNING * INTO v_saved;
+  ELSE
+    INSERT INTO private.supplier_commerce_controls(operation,scope_type,scope_ref,enabled,reason,updated_by)
+    VALUES('pilot','global',NULL,p_enabled,BTRIM(p_reason),p_actor_id) RETURNING * INTO v_saved;
+  END IF;
+  INSERT INTO private.supplier_commerce_control_audit(
+    control_id,actor_id,operation,scope_type,scope_ref,previous_enabled,new_enabled,previous_version,new_version,reason
+  ) VALUES(
+    v_saved.id,p_actor_id,'pilot','global',NULL,
+    CASE WHEN v_existing.id IS NULL THEN NULL ELSE v_existing.enabled END,v_saved.enabled,
+    CASE WHEN v_existing.id IS NULL THEN NULL ELSE v_existing.version END,v_saved.version,BTRIM(p_reason)
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION private.set_supplier_pilot_master_control_v1(uuid,boolean,text) FROM PUBLIC,anon,authenticated,service_role;
+
+CREATE OR REPLACE FUNCTION private.supplier_pilot_control_decision_v1(
+  p_operation text,p_scope jsonb
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_operation text:=lower(BTRIM(COALESCE(p_operation,'')));
+  v_supplier_ref text:=NULLIF(BTRIM(p_scope->>'supplierRef'),'');
+  v_provider_ref text:=NULLIF(BTRIM(p_scope->>'providerRef'),'');
+  v_offer_ref text:=NULLIF(BTRIM(p_scope->>'offerRef'),'');
+  v_product_ref text:=NULLIF(BTRIM(p_scope->>'productRef'),'');
+  v_territory text:=NULLIF(upper(BTRIM(p_scope->>'territory')),'');
+  v_cohort text:=NULLIF(BTRIM(p_scope->>'cohort'),'');
+  v_pilot private.supplier_pilot_programs%ROWTYPE;
+  v_supplier private.supplier_foundation_suppliers%ROWTYPE;
+  v_offer private.supplier_offers%ROWTYPE;
+  v_pilot_control private.supplier_commerce_controls%ROWTYPE;
+  v_blocker private.supplier_commerce_controls%ROWTYPE;
+BEGIN
+  SELECT * INTO v_pilot_control FROM private.supplier_commerce_controls
+   WHERE operation='pilot' AND scope_type='global' AND scope_ref IS NULL LIMIT 1;
+  IF NOT FOUND OR v_pilot_control.enabled IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('enabled',false,'reason','pilot_master_disabled','interfaceVersion',1);
+  END IF;
+
+  IF v_supplier_ref IS NULL THEN
+    RETURN jsonb_build_object('enabled',false,'reason','pilot_supplier_scope_required','interfaceVersion',1);
+  END IF;
+
+  SELECT p,s INTO v_pilot,v_supplier
+    FROM private.supplier_pilot_programs p
+    JOIN private.supplier_foundation_suppliers s ON s.id=p.supplier_id
+   WHERE p.status IN ('preparing','active')
+     AND v_supplier_ref IN (p.supplier_id::text,s.supplier_key)
+     AND (v_provider_ref IS NULL OR v_provider_ref=p.provider_key)
+     AND (v_cohort IS NULL OR v_cohort=p.cohort_key)
+     AND (v_territory IS NULL OR v_territory=p.territory)
+   ORDER BY p.created_at DESC LIMIT 1;
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('enabled',false,'reason','pilot_scope_not_allowlisted','interfaceVersion',1);
+  END IF;
+
+  IF v_pilot.status='preparing' AND v_operation NOT IN ('import','stock_sync','price_sync') THEN
+    RETURN jsonb_build_object('enabled',false,'reason','pilot_not_active','pilotId',v_pilot.id,'interfaceVersion',1);
+  END IF;
+
+  IF v_operation<>'import' THEN
+    IF v_offer_ref IS NULL THEN
+      RETURN jsonb_build_object('enabled',false,'reason','pilot_offer_scope_required','pilotId',v_pilot.id,'interfaceVersion',1);
+    END IF;
+    SELECT o.* INTO v_offer
+      FROM private.supplier_pilot_offers po
+      JOIN private.supplier_offers o ON o.id=po.supplier_offer_id
+     WHERE po.pilot_id=v_pilot.id
+       AND v_offer_ref IN (o.id::text,o.offer_key)
+       AND o.supplier_id=v_pilot.supplier_id
+       AND o.territory=v_pilot.territory
+       AND o.status='approved'
+     LIMIT 1;
+    IF NOT FOUND THEN
+      RETURN jsonb_build_object('enabled',false,'reason','pilot_offer_not_allowlisted','pilotId',v_pilot.id,'interfaceVersion',1);
+    END IF;
+    IF v_product_ref IS NOT NULL AND v_product_ref NOT IN (v_offer.canonical_product_id::text) THEN
+      RETURN jsonb_build_object('enabled',false,'reason','pilot_product_scope_mismatch','pilotId',v_pilot.id,'interfaceVersion',1);
+    END IF;
+  END IF;
+
+  SELECT * INTO v_blocker FROM private.supplier_commerce_controls c
+   WHERE c.enabled=false AND c.operation IN ('*',v_operation)
+     AND (
+       (c.scope_type='supplier' AND c.scope_ref IN (v_pilot.supplier_id::text,v_supplier.supplier_key))
+       OR (c.scope_type='provider' AND c.scope_ref=v_pilot.provider_key)
+       OR (c.scope_type='territory' AND c.scope_ref=v_pilot.territory)
+       OR (c.scope_type='cohort' AND c.scope_ref=v_pilot.cohort_key)
+       OR (v_offer.id IS NOT NULL AND c.scope_type='offer' AND c.scope_ref IN (v_offer.id::text,v_offer.offer_key))
+       OR (v_offer.id IS NOT NULL AND c.scope_type='product' AND c.scope_ref=v_offer.canonical_product_id::text)
+     )
+   ORDER BY c.updated_at DESC LIMIT 1;
+  IF FOUND THEN
+    RETURN jsonb_build_object('enabled',false,'reason','scoped_kill_switch','pilotId',v_pilot.id,
+      'scopeType',v_blocker.scope_type,'scopeRef',v_blocker.scope_ref,'controlVersion',v_blocker.version,'interfaceVersion',1);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'enabled',true,
+    'reason',CASE WHEN v_pilot.status='preparing' THEN 'controlled_pilot_preparation_enabled' ELSE 'controlled_pilot_enabled' END,
+    'operation',v_operation,'pilotId',v_pilot.id,'cohort',v_pilot.cohort_key,'interfaceVersion',1,
+    'controlVersion',v_pilot_control.version
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION private.supplier_pilot_control_decision_v1(text,jsonb) FROM PUBLIC,anon,authenticated,service_role;
+
+CREATE OR REPLACE FUNCTION public.server_supplier_commerce_control_decision_v1(
+  p_operation text,p_scope jsonb DEFAULT '{}'::jsonb
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_operation text:=lower(BTRIM(COALESCE(p_operation,'')));
+  v_global private.supplier_commerce_controls%ROWTYPE;
+  v_operation_control private.supplier_commerce_controls%ROWTYPE;
+  v_scope_type text; v_scope_ref text; v_scope_key text;
+  v_blocker private.supplier_commerce_controls%ROWTYPE;
+  v_pilot jsonb;
+BEGIN
+  IF v_operation NOT IN ('import','publish','checkout','reservation','supplier_order','tracking_ingest','return_recovery','stock_sync','price_sync') THEN
+    RETURN jsonb_build_object('enabled',false,'reason','unknown_operation','interfaceVersion',1);
+  END IF;
+  IF p_scope IS NULL OR jsonb_typeof(p_scope) IS DISTINCT FROM 'object' THEN
+    RETURN jsonb_build_object('enabled',false,'reason','invalid_scope','interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_global FROM private.supplier_commerce_controls
+   WHERE operation='*' AND scope_type='global' AND scope_ref IS NULL LIMIT 1;
+  SELECT * INTO v_operation_control FROM private.supplier_commerce_controls
+   WHERE operation=v_operation AND scope_type='global' AND scope_ref IS NULL LIMIT 1;
+
+  IF FOUND AND v_global.enabled=true AND v_operation_control.enabled=true THEN
+    FOREACH v_scope_type IN ARRAY ARRAY['provider','supplier','offer','product','category','territory','cohort']::text[] LOOP
+      v_scope_key:=CASE v_scope_type WHEN 'provider' THEN 'providerRef' WHEN 'supplier' THEN 'supplierRef'
+        WHEN 'offer' THEN 'offerRef' WHEN 'product' THEN 'productRef' WHEN 'category' THEN 'categoryRef'
+        WHEN 'territory' THEN 'territory' WHEN 'cohort' THEN 'cohort' END;
+      v_scope_ref:=NULLIF(BTRIM(p_scope->>v_scope_key),'');
+      IF v_scope_ref IS NOT NULL THEN
+        SELECT * INTO v_blocker FROM private.supplier_commerce_controls
+         WHERE operation IN ('*',v_operation) AND scope_type=v_scope_type AND scope_ref=v_scope_ref AND enabled=false
+         ORDER BY CASE WHEN operation=v_operation THEN 0 ELSE 1 END LIMIT 1;
+        IF FOUND THEN RETURN jsonb_build_object('enabled',false,'reason','scoped_kill_switch','operation',v_operation,
+          'scopeType',v_scope_type,'scopeRef',v_scope_ref,'interfaceVersion',1,'controlVersion',v_blocker.version); END IF;
+      END IF;
+    END LOOP;
+    RETURN jsonb_build_object('enabled',true,'reason','enabled','operation',v_operation,'interfaceVersion',1,
+      'controlVersion',GREATEST(v_global.version,v_operation_control.version));
+  END IF;
+
+  v_pilot:=private.supplier_pilot_control_decision_v1(v_operation,p_scope);
+  IF COALESCE((v_pilot->>'enabled')::boolean,false)=true THEN RETURN v_pilot; END IF;
+
+  IF v_global.id IS NULL OR v_global.enabled IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('enabled',false,'reason','supplier_commerce_global_disabled','operation',v_operation,
+      'pilotReason',v_pilot->>'reason','interfaceVersion',1,'controlVersion',COALESCE(v_global.version,0));
+  END IF;
+  RETURN jsonb_build_object('enabled',false,'reason','operation_disabled','operation',v_operation,
+    'pilotReason',v_pilot->>'reason','interfaceVersion',1,'controlVersion',COALESCE(v_operation_control.version,0));
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_supplier_commerce_control_decision_v1(text,jsonb) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_commerce_control_decision_v1(text,jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_create_supplier_pilot_v1(
+  p_actor_id uuid,p_pilot_key text,p_supplier_id uuid,p_provider_key text,p_cohort_key text,
+  p_maximum_order_count integer,p_maximum_order_value_minor bigint,p_acceptance_thresholds jsonb,
+  p_simulator_evidence_ref text,p_evidence jsonb DEFAULT '{}'::jsonb
+)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_id uuid;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_foundation_suppliers s WHERE s.id=p_supplier_id) THEN RAISE EXCEPTION 'supplier foundation record required'; END IF;
+  IF NULLIF(BTRIM(p_pilot_key),'') IS NULL OR NULLIF(BTRIM(p_provider_key),'') IS NULL OR NULLIF(BTRIM(p_cohort_key),'') IS NULL
+     OR p_maximum_order_count IS NULL OR p_maximum_order_count<=0 OR p_maximum_order_value_minor IS NULL OR p_maximum_order_value_minor<=0
+     OR jsonb_typeof(COALESCE(p_acceptance_thresholds,'{}'::jsonb))<>'object' OR NULLIF(BTRIM(p_simulator_evidence_ref),'') IS NULL
+     OR jsonb_typeof(COALESCE(p_evidence,'{}'::jsonb))<>'object' THEN RAISE EXCEPTION 'complete controlled pilot definition is required'; END IF;
+  INSERT INTO private.supplier_pilot_programs(
+    pilot_key,supplier_id,provider_key,cohort_key,maximum_order_count,maximum_order_value_minor,
+    acceptance_thresholds,simulator_evidence_ref,evidence,created_by
+  ) VALUES(
+    lower(BTRIM(p_pilot_key)),p_supplier_id,BTRIM(p_provider_key),lower(BTRIM(p_cohort_key)),p_maximum_order_count,p_maximum_order_value_minor,
+    p_acceptance_thresholds,BTRIM(p_simulator_evidence_ref),COALESCE(p_evidence,'{}'::jsonb),p_actor_id
+  ) RETURNING id INTO v_id;
+  INSERT INTO private.supplier_pilot_audit(pilot_id,actor_id,action,new_status,evidence)
+  VALUES(v_id,p_actor_id,'create','draft',jsonb_build_object('simulatorEvidenceRef',BTRIM(p_simulator_evidence_ref)));
+  RETURN v_id;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_create_supplier_pilot_v1(uuid,text,uuid,text,text,integer,bigint,jsonb,text,jsonb) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_create_supplier_pilot_v1(uuid,text,uuid,text,text,integer,bigint,jsonb,text,jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_add_supplier_pilot_offer_v1(
+  p_actor_id uuid,p_pilot_id uuid,p_supplier_offer_id uuid,p_external_variant_ref text,p_selection_evidence jsonb
+)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_pilot private.supplier_pilot_programs%ROWTYPE; v_offer private.supplier_offers%ROWTYPE; v_id uuid; v_count integer;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id FOR UPDATE;
+  IF NOT FOUND OR v_pilot.status NOT IN ('draft','preparing') THEN RAISE EXCEPTION 'pilot offer set is mutable only before activation'; END IF;
+  SELECT * INTO v_offer FROM private.supplier_offers WHERE id=p_supplier_offer_id AND supplier_id=v_pilot.supplier_id AND territory='GB' AND status='approved';
+  IF NOT FOUND THEN RAISE EXCEPTION 'approved GB supplier offer for pilot supplier required'; END IF;
+  IF NOT EXISTS(SELECT 1 FROM private.canonical_products p WHERE p.id=v_offer.canonical_product_id AND p.status='active') THEN RAISE EXCEPTION 'active canonical product required'; END IF;
+  IF jsonb_typeof(COALESCE(p_selection_evidence,'{}'::jsonb))<>'object' OR COALESCE(p_selection_evidence,'{}'::jsonb)='{}'::jsonb THEN RAISE EXCEPTION 'low-risk product selection evidence required'; END IF;
+  SELECT count(*) INTO v_count FROM private.supplier_pilot_offers WHERE pilot_id=p_pilot_id;
+  IF v_count>=v_pilot.maximum_product_count THEN RAISE EXCEPTION 'pilot product ceiling reached'; END IF;
+  INSERT INTO private.supplier_pilot_offers(pilot_id,supplier_offer_id,external_variant_ref,selection_evidence,approved_by)
+  VALUES(p_pilot_id,p_supplier_offer_id,BTRIM(COALESCE(p_external_variant_ref,'')),p_selection_evidence,p_actor_id)
+  ON CONFLICT(pilot_id,supplier_offer_id,external_variant_ref) DO UPDATE SET supplier_offer_id=EXCLUDED.supplier_offer_id
+  RETURNING id INTO v_id;
+  INSERT INTO private.supplier_pilot_audit(pilot_id,actor_id,action,new_status,evidence)
+  VALUES(p_pilot_id,p_actor_id,'add_offer',v_pilot.status,jsonb_build_object('supplierOfferId',p_supplier_offer_id,'variantRef',BTRIM(COALESCE(p_external_variant_ref,''))));
+  RETURN v_id;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_add_supplier_pilot_offer_v1(uuid,uuid,uuid,text,jsonb) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_add_supplier_pilot_offer_v1(uuid,uuid,uuid,text,jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_supplier_pilot_readiness_v1(p_pilot_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_pilot private.supplier_pilot_programs%ROWTYPE; v_supplier private.supplier_foundation_suppliers%ROWTYPE;
+  v_foundation jsonb; v_governance jsonb; v_offer record; v_decision jsonb;
+  v_offer_count integer:=0; v_product_count integer:=0; v_failures jsonb:='[]'::jsonb;
+  v_required_cap text;
+BEGIN
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ready',false,'reason','pilot_not_found','interfaceVersion',1); END IF;
+  SELECT * INTO v_supplier FROM private.supplier_foundation_suppliers WHERE id=v_pilot.supplier_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ready',false,'reason','supplier_not_found','interfaceVersion',1); END IF;
+
+  v_foundation:=public.server_supplier_foundation_decision_v1(v_supplier.supplier_key,'GB','catalog');
+  IF COALESCE((v_foundation->>'eligible')::boolean,false) IS DISTINCT FROM true THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','supplier_foundation','detail',v_foundation));
+  END IF;
+  v_governance:=public.server_supplier_governance_decision_v1(v_pilot.supplier_id,v_pilot.provider_key);
+  IF COALESCE((v_governance->>'eligible')::boolean,false) IS DISTINCT FROM true THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','supplier_governance','detail',v_governance));
+  END IF;
+
+  IF NOT EXISTS(
+    SELECT 1 FROM private.supplier_commerce_provider_capabilities c
+     WHERE c.provider_key=v_pilot.provider_key AND c.territory='GB' AND c.role IN ('supplier','fulfilment_provider')
+       AND c.status='verified' AND c.verified_at IS NOT NULL AND c.reverify_due_at>now()
+       AND jsonb_array_length(c.official_source_refs)>0
+  ) THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','provider_capability_register','reason','current_verified_provider_capability_missing')); END IF;
+
+  FOREACH v_required_cap IN ARRAY ARRAY['catalog','stock','price','shipping','order_submission','acknowledgement','tracking','cancellation','returns','reimbursement']::text[] LOOP
+    IF NOT EXISTS(
+      SELECT 1 FROM private.supplier_adapter_registrations a
+       WHERE a.supplier_id=v_pilot.supplier_id AND a.provider_key=v_pilot.provider_key AND a.status='active'
+         AND a.interface_version=1 AND a.capabilities @> ARRAY[v_required_cap]::text[]
+         AND a.verified_at IS NOT NULL
+    ) THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','adapter_capability','capability',v_required_cap)); END IF;
+  END LOOP;
+
+  SELECT count(*),count(DISTINCT o.canonical_product_id) INTO v_offer_count,v_product_count
+    FROM private.supplier_pilot_offers po JOIN private.supplier_offers o ON o.id=po.supplier_offer_id
+   WHERE po.pilot_id=v_pilot.id;
+  IF v_offer_count<v_pilot.minimum_product_count OR v_offer_count>v_pilot.maximum_product_count OR v_product_count<>v_offer_count THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','pilot_product_set','offerCount',v_offer_count,'distinctProductCount',v_product_count,'minimum',v_pilot.minimum_product_count,'maximum',v_pilot.maximum_product_count));
+  END IF;
+
+  FOR v_offer IN
+    SELECT po.supplier_offer_id,po.external_variant_ref,o.canonical_product_id,o.offer_key
+      FROM private.supplier_pilot_offers po JOIN private.supplier_offers o ON o.id=po.supplier_offer_id
+     WHERE po.pilot_id=v_pilot.id
+  LOOP
+    v_decision:=public.server_supplier_catalog_decision_v1(v_offer.canonical_product_id,v_offer.supplier_offer_id,'GB');
+    IF COALESCE((v_decision->>'eligible')::boolean,false) IS DISTINCT FROM true THEN
+      v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','catalog_readiness','offer',v_offer.offer_key,'detail',v_decision));
+    END IF;
+    v_decision:=public.server_supplier_stock_price_decision_v1(v_offer.supplier_offer_id,v_offer.canonical_product_id,'loadify_supplier_fulfilled','GB',v_offer.external_variant_ref);
+    IF COALESCE((v_decision->>'eligible')::boolean,false) IS DISTINCT FROM true THEN
+      v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','stock_price_readiness','offer',v_offer.offer_key,'detail',v_decision));
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'ready',jsonb_array_length(v_failures)=0,'reason',CASE WHEN jsonb_array_length(v_failures)=0 THEN 'controlled_pilot_ready' ELSE 'controlled_pilot_not_ready' END,
+    'pilotId',v_pilot.id,'supplierId',v_pilot.supplier_id,'providerKey',v_pilot.provider_key,'territory','GB',
+    'offerCount',v_offer_count,'distinctProductCount',v_product_count,'failures',v_failures,'simulatorPassIsNotPilotPass',true,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_supplier_pilot_readiness_v1(uuid) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_pilot_readiness_v1(uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_prepare_supplier_pilot_v1(p_actor_id uuid,p_pilot_id uuid,p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_pilot private.supplier_pilot_programs%ROWTYPE; v_supplier private.supplier_foundation_suppliers%ROWTYPE; v_foundation jsonb; v_governance jsonb;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF NULLIF(BTRIM(p_reason),'') IS NULL THEN RAISE EXCEPTION 'pilot preparation reason required'; END IF;
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id FOR UPDATE;
+  IF NOT FOUND OR v_pilot.status NOT IN ('draft','paused') THEN RAISE EXCEPTION 'pilot must be draft or paused to enter preparation'; END IF;
+  SELECT * INTO v_supplier FROM private.supplier_foundation_suppliers WHERE id=v_pilot.supplier_id;
+  v_foundation:=public.server_supplier_foundation_decision_v1(v_supplier.supplier_key,'GB','catalog');
+  IF COALESCE((v_foundation->>'eligible')::boolean,false) IS DISTINCT FROM true THEN RETURN jsonb_build_object('ok',false,'reason','supplier_foundation_not_ready','detail',v_foundation,'interfaceVersion',1); END IF;
+  v_governance:=public.server_supplier_governance_decision_v1(v_pilot.supplier_id,v_pilot.provider_key);
+  IF COALESCE((v_governance->>'eligible')::boolean,false) IS DISTINCT FROM true THEN RETURN jsonb_build_object('ok',false,'reason','supplier_governance_not_ready','detail',v_governance,'interfaceVersion',1); END IF;
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_commerce_provider_capabilities c WHERE c.provider_key=v_pilot.provider_key AND c.territory='GB' AND c.status='verified' AND c.reverify_due_at>now()) THEN
+    RETURN jsonb_build_object('ok',false,'reason','provider_capability_not_current','interfaceVersion',1);
+  END IF;
+  UPDATE private.supplier_pilot_programs SET status='preparing',prepared_by=COALESCE(prepared_by,p_actor_id),prepared_at=COALESCE(prepared_at,now()),updated_at=now() WHERE id=v_pilot.id;
+  PERFORM private.set_supplier_pilot_master_control_v1(p_actor_id,true,'Phase O preparation: '||BTRIM(p_reason));
+  INSERT INTO private.supplier_pilot_audit(pilot_id,actor_id,action,previous_status,new_status,evidence)
+  VALUES(v_pilot.id,p_actor_id,'prepare',v_pilot.status,'preparing',jsonb_build_object('reason',BTRIM(p_reason)));
+  RETURN jsonb_build_object('ok',true,'pilotId',v_pilot.id,'status','preparing','buyerFacingOperationsEnabled',false,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_prepare_supplier_pilot_v1(uuid,uuid,text) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_prepare_supplier_pilot_v1(uuid,uuid,text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_activate_supplier_pilot_v1(p_actor_id uuid,p_pilot_id uuid,p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_pilot private.supplier_pilot_programs%ROWTYPE; v_readiness jsonb;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF NULLIF(BTRIM(p_reason),'') IS NULL THEN RAISE EXCEPTION 'pilot activation reason required'; END IF;
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id FOR UPDATE;
+  IF NOT FOUND OR v_pilot.status<>'preparing' THEN RAISE EXCEPTION 'pilot must be preparing before activation'; END IF;
+  v_readiness:=public.server_supplier_pilot_readiness_v1(v_pilot.id);
+  IF COALESCE((v_readiness->>'ready')::boolean,false) IS DISTINCT FROM true THEN RETURN jsonb_build_object('ok',false,'reason','pilot_readiness_failed','readiness',v_readiness,'interfaceVersion',1); END IF;
+  UPDATE private.supplier_pilot_programs SET status='active',activated_by=p_actor_id,activated_at=now(),updated_at=now() WHERE id=v_pilot.id;
+  PERFORM private.set_supplier_pilot_master_control_v1(p_actor_id,true,'Phase O active controlled pilot: '||BTRIM(p_reason));
+  INSERT INTO private.supplier_pilot_audit(pilot_id,actor_id,action,previous_status,new_status,evidence)
+  VALUES(v_pilot.id,p_actor_id,'activate','preparing','active',jsonb_build_object('reason',BTRIM(p_reason),'readiness',v_readiness));
+  RETURN jsonb_build_object('ok',true,'pilotId',v_pilot.id,'status','active','globalSupplierCommerceEnabled',false,'readiness',v_readiness,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_activate_supplier_pilot_v1(uuid,uuid,text) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_activate_supplier_pilot_v1(uuid,uuid,text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_record_supplier_pilot_evidence_v1(
+  p_actor_id uuid,p_pilot_id uuid,p_order_id uuid,p_evidence_type text,p_evidence_ref text,p_summary text,p_observed_at timestamptz,p_evidence jsonb
+)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_id uuid;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_pilot_programs p WHERE p.id=p_pilot_id AND p.status IN ('active','paused')) THEN RAISE EXCEPTION 'pilot must be active or paused to record evidence'; END IF;
+  IF p_order_id IS NOT NULL AND NOT EXISTS(SELECT 1 FROM public.orders o WHERE o.id=p_order_id) THEN RAISE EXCEPTION 'pilot evidence order not found'; END IF;
+  INSERT INTO private.supplier_pilot_evidence(pilot_id,order_id,evidence_type,evidence_ref,summary,evidence,recorded_by,observed_at)
+  VALUES(p_pilot_id,p_order_id,lower(BTRIM(p_evidence_type)),BTRIM(p_evidence_ref),BTRIM(p_summary),COALESCE(p_evidence,'{}'::jsonb),p_actor_id,p_observed_at)
+  RETURNING id INTO v_id;
+  RETURN v_id;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_record_supplier_pilot_evidence_v1(uuid,uuid,uuid,text,text,text,timestamptz,jsonb) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_record_supplier_pilot_evidence_v1(uuid,uuid,uuid,text,text,text,timestamptz,jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_supplier_pilot_acceptance_v1(p_pilot_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_pilot private.supplier_pilot_programs%ROWTYPE;
+  v_orders integer:=0; v_acks integer:=0; v_delivered integer:=0; v_returns integer:=0; v_refunds integer:=0; v_recoveries integer:=0; v_reconciled integer:=0;
+  v_open_critical integer:=0; v_ack_rate numeric:=0; v_ack_min numeric:=0; v_failures jsonb:='[]'::jsonb;
+BEGIN
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id;
+  IF NOT FOUND OR v_pilot.activated_at IS NULL THEN RETURN jsonb_build_object('passed',false,'reason','pilot_not_activated','interfaceVersion',1); END IF;
+
+  SELECT count(DISTINCT h.order_id),count(DISTINCT h.order_id) FILTER(WHERE h.state='reconciled' AND h.acknowledgement_state='accepted')
+    INTO v_orders,v_acks
+    FROM private.supplier_order_handshakes h
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+   WHERE h.supplier_id=v_pilot.supplier_id AND h.provider_key=v_pilot.provider_key AND h.created_at>=v_pilot.activated_at;
+  IF v_orders>0 THEN v_ack_rate:=round((v_acks::numeric/v_orders::numeric)*100,3); END IF;
+  v_ack_min:=COALESCE((v_pilot.acceptance_thresholds->>'acknowledgementRateMinPct')::numeric,101);
+
+  SELECT count(DISTINCT s.order_id) INTO v_delivered FROM private.supplier_leg_shipments s
+    JOIN private.supplier_order_handshakes h ON h.id=s.handshake_id
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+   WHERE s.supplier_id=v_pilot.supplier_id AND s.provider_key=v_pilot.provider_key AND s.canonical_status='delivered' AND s.created_at>=v_pilot.activated_at;
+  SELECT count(DISTINCT r.order_id) INTO v_returns FROM private.supplier_return_cases r
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=r.supplier_offer_id
+   WHERE r.supplier_id=v_pilot.supplier_id AND r.requested_at>=v_pilot.activated_at;
+  SELECT count(DISTINCT e.order_id) INTO v_refunds FROM private.supplier_customer_refund_evidence e
+    JOIN private.supplier_return_cases r ON r.id=e.return_case_id
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=r.supplier_offer_id
+   WHERE e.state IN ('partial','succeeded') AND e.occurred_at>=v_pilot.activated_at;
+  SELECT count(DISTINCT e.order_id) INTO v_recoveries FROM private.supplier_recovery_evidence e
+   WHERE e.supplier_id=v_pilot.supplier_id AND e.state IN ('partial','recovered') AND e.occurred_at>=v_pilot.activated_at;
+  SELECT count(DISTINCT f.order_id) INTO v_reconciled FROM private.supplier_financial_reconciliations f
+   WHERE f.state='reconciled' AND f.evaluated_at>=v_pilot.activated_at
+     AND EXISTS(SELECT 1 FROM private.supplier_order_handshakes h JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id WHERE h.order_id=f.order_id AND h.supplier_id=v_pilot.supplier_id);
+  SELECT count(*) INTO v_open_critical FROM private.supplier_commerce_incidents i
+   WHERE i.severity='critical' AND i.status NOT IN ('resolved','closed') AND i.supplier_ref IN (v_pilot.supplier_id::text,(SELECT supplier_key FROM private.supplier_foundation_suppliers WHERE id=v_pilot.supplier_id));
+
+  IF v_orders=0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','real_orders','reason','no_real_pilot_orders')); END IF;
+  IF v_orders>v_pilot.maximum_order_count THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','order_volume_limit','orders',v_orders,'maximum',v_pilot.maximum_order_count)); END IF;
+  IF v_ack_rate<v_ack_min THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','acknowledgement_rate','actualPct',v_ack_rate,'minimumPct',v_ack_min)); END IF;
+  IF v_delivered=0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','delivery','reason','no_delivered_pilot_order')); END IF;
+  IF v_returns=0 OR v_refunds=0 OR v_recoveries=0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','return_refund_recovery','returns',v_returns,'refunds',v_refunds,'recoveries',v_recoveries)); END IF;
+  IF v_reconciled<v_orders THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','financial_reconciliation','reconciledOrders',v_reconciled,'pilotOrders',v_orders)); END IF;
+  IF v_open_critical>0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','critical_incidents','open',v_open_critical)); END IF;
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_pilot_evidence e WHERE e.pilot_id=v_pilot.id AND e.evidence_type='buyer_communication') THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','buyer_communication','reason','evidence_missing')); END IF;
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_pilot_evidence e WHERE e.pilot_id=v_pilot.id AND e.evidence_type='kill_switch_test') THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','kill_switch_test','reason','evidence_missing')); END IF;
+
+  RETURN jsonb_build_object(
+    'passed',jsonb_array_length(v_failures)=0,'reason',CASE WHEN jsonb_array_length(v_failures)=0 THEN 'controlled_pilot_pass' ELSE 'controlled_pilot_evidence_incomplete' END,
+    'pilotId',v_pilot.id,'orders',v_orders,'acknowledgedOrders',v_acks,'acknowledgementRatePct',v_ack_rate,'deliveredOrders',v_delivered,
+    'returnOrders',v_returns,'refundOrders',v_refunds,'recoveryOrders',v_recoveries,'reconciledOrders',v_reconciled,'openCriticalIncidents',v_open_critical,
+    'failures',v_failures,'simulatorPassIsNotPilotPass',true,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_supplier_pilot_acceptance_v1(uuid) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_pilot_acceptance_v1(uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_pause_supplier_pilot_v1(p_actor_id uuid,p_pilot_id uuid,p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_pilot private.supplier_pilot_programs%ROWTYPE;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF NULLIF(BTRIM(p_reason),'') IS NULL THEN RAISE EXCEPTION 'pilot pause reason required'; END IF;
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id FOR UPDATE;
+  IF NOT FOUND OR v_pilot.status NOT IN ('preparing','active') THEN RAISE EXCEPTION 'only preparing/active pilot can be paused'; END IF;
+  UPDATE private.supplier_pilot_programs SET status='paused',updated_at=now() WHERE id=v_pilot.id;
+  PERFORM private.set_supplier_pilot_master_control_v1(p_actor_id,false,'Phase O pilot paused: '||BTRIM(p_reason));
+  INSERT INTO private.supplier_pilot_audit(pilot_id,actor_id,action,previous_status,new_status,evidence)
+  VALUES(v_pilot.id,p_actor_id,'pause',v_pilot.status,'paused',jsonb_build_object('reason',BTRIM(p_reason)));
+  RETURN jsonb_build_object('ok',true,'pilotId',v_pilot.id,'status','paused','pilotControlEnabled',false,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_pause_supplier_pilot_v1(uuid,uuid,text) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_pause_supplier_pilot_v1(uuid,uuid,text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_complete_supplier_pilot_v1(p_actor_id uuid,p_pilot_id uuid,p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_pilot private.supplier_pilot_programs%ROWTYPE; v_acceptance jsonb;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF NULLIF(BTRIM(p_reason),'') IS NULL THEN RAISE EXCEPTION 'pilot completion reason required'; END IF;
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id FOR UPDATE;
+  IF NOT FOUND OR v_pilot.status NOT IN ('active','paused') THEN RAISE EXCEPTION 'pilot must be active or paused to complete'; END IF;
+  v_acceptance:=public.server_supplier_pilot_acceptance_v1(v_pilot.id);
+  IF COALESCE((v_acceptance->>'passed')::boolean,false) IS DISTINCT FROM true THEN RETURN jsonb_build_object('ok',false,'reason','pilot_acceptance_failed','acceptance',v_acceptance,'interfaceVersion',1); END IF;
+  UPDATE private.supplier_pilot_programs SET status='completed',ended_by=p_actor_id,ended_at=now(),end_reason=BTRIM(p_reason),updated_at=now() WHERE id=v_pilot.id;
+  PERFORM private.set_supplier_pilot_master_control_v1(p_actor_id,false,'Phase O pilot completed: '||BTRIM(p_reason));
+  INSERT INTO private.supplier_pilot_audit(pilot_id,actor_id,action,previous_status,new_status,evidence)
+  VALUES(v_pilot.id,p_actor_id,'complete',v_pilot.status,'completed',jsonb_build_object('reason',BTRIM(p_reason),'acceptance',v_acceptance));
+  RETURN jsonb_build_object('ok',true,'pilotId',v_pilot.id,'status','completed','pilotPass',true,'globalSupplierCommerceEnabled',false,'acceptance',v_acceptance,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_complete_supplier_pilot_v1(uuid,uuid,text) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_complete_supplier_pilot_v1(uuid,uuid,text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_supplier_pilot_status_v1(p_actor_id uuid,p_pilot_id uuid DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_pilot private.supplier_pilot_programs%ROWTYPE; v_control private.supplier_commerce_controls%ROWTYPE; v_readiness jsonb; v_acceptance jsonb;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF p_pilot_id IS NULL THEN SELECT * INTO v_pilot FROM private.supplier_pilot_programs ORDER BY created_at DESC LIMIT 1;
+  ELSE SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id; END IF;
+  SELECT * INTO v_control FROM private.supplier_commerce_controls WHERE operation='pilot' AND scope_type='global' AND scope_ref IS NULL LIMIT 1;
+  IF v_pilot.id IS NULL THEN RETURN jsonb_build_object('exists',false,'pilotControlEnabled',COALESCE(v_control.enabled,false),'globalSupplierCommerceEnabled',false,'interfaceVersion',1); END IF;
+  v_readiness:=public.server_supplier_pilot_readiness_v1(v_pilot.id);
+  v_acceptance:=CASE WHEN v_pilot.activated_at IS NULL THEN jsonb_build_object('passed',false,'reason','pilot_not_activated','interfaceVersion',1) ELSE public.server_supplier_pilot_acceptance_v1(v_pilot.id) END;
+  RETURN jsonb_build_object('exists',true,'pilotId',v_pilot.id,'pilotKey',v_pilot.pilot_key,'status',v_pilot.status,'supplierId',v_pilot.supplier_id,
+    'providerKey',v_pilot.provider_key,'cohort',v_pilot.cohort_key,'territory',v_pilot.territory,'pilotControlEnabled',COALESCE(v_control.enabled,false),
+    'globalSupplierCommerceEnabled',(SELECT COALESCE(enabled,false) FROM private.supplier_commerce_controls WHERE operation='*' AND scope_type='global' AND scope_ref IS NULL LIMIT 1),
+    'readiness',v_readiness,'acceptance',v_acceptance,'simulatorPassIsNotPilotPass',true,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_supplier_pilot_status_v1(uuid,uuid) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_supplier_pilot_status_v1(uuid,uuid) TO service_role;
+
+COMMENT ON TABLE private.supplier_pilot_programs IS 'Phase O controlled-pilot definition. Exactly one live preparation/active pilot; GB baseline; no global Supplier Commerce activation.';
+COMMENT ON FUNCTION public.server_supplier_pilot_readiness_v1(uuid) IS 'Phase O factual preflight gate. Readiness is not Pilot PASS and requires real supplier/offer/governance/stock/price evidence.';
+COMMENT ON FUNCTION public.server_supplier_pilot_acceptance_v1(uuid) IS 'Phase O no-fake-pass acceptance gate. Requires real orders, acknowledgement, delivery, return/refund/recovery, reconciliation and operator evidence.';

--- a/supabase/666_supplier_controlled_pilot_closure.sql
+++ b/supabase/666_supplier_controlled_pilot_closure.sql
@@ -1,0 +1,332 @@
+-- 666_supplier_controlled_pilot_closure.sql
+-- Phase O Branch Guard closure.
+-- Corrects pilot scope derivation for canonical runtime callers and adds hard
+-- order-volume/value + no-fake-pass acceptance guards. Supplier Commerce global
+-- remains OFF; this migration does not create or activate a pilot.
+
+ALTER TABLE private.supplier_pilot_programs
+  ADD CONSTRAINT supplier_pilot_threshold_value_check CHECK (
+    COALESCE((acceptance_thresholds->>'acknowledgementRateMinPct')::numeric,-1) BETWEEN 0 AND 100
+    AND COALESCE((acceptance_thresholds->>'oversellMax')::integer,-1) >= 0
+  );
+
+CREATE OR REPLACE FUNCTION private.supplier_pilot_control_decision_v1(
+  p_operation text,p_scope jsonb
+)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_operation text:=lower(BTRIM(COALESCE(p_operation,'')));
+  v_supplier_ref text:=NULLIF(BTRIM(p_scope->>'supplierRef'),'');
+  v_provider_ref text:=NULLIF(BTRIM(p_scope->>'providerRef'),'');
+  v_offer_ref text:=NULLIF(BTRIM(p_scope->>'offerRef'),'');
+  v_product_ref text:=NULLIF(BTRIM(p_scope->>'productRef'),'');
+  v_territory text:=NULLIF(upper(BTRIM(p_scope->>'territory')),'');
+  v_cohort text:=NULLIF(BTRIM(p_scope->>'cohort'),'');
+  v_pilot private.supplier_pilot_programs%ROWTYPE;
+  v_supplier private.supplier_foundation_suppliers%ROWTYPE;
+  v_offer private.supplier_offers%ROWTYPE;
+  v_pilot_control private.supplier_commerce_controls%ROWTYPE;
+  v_blocker private.supplier_commerce_controls%ROWTYPE;
+BEGIN
+  SELECT * INTO v_pilot_control FROM private.supplier_commerce_controls
+   WHERE operation='pilot' AND scope_type='global' AND scope_ref IS NULL LIMIT 1;
+  IF NOT FOUND OR v_pilot_control.enabled IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('enabled',false,'reason','pilot_master_disabled','interfaceVersion',1);
+  END IF;
+
+  -- Canonical runtime callers do not all carry the same identity envelope.
+  -- Reservation, tracking and return paths carry an approved offer identity,
+  -- so derive the supplier only from the exact allowlisted offer when present.
+  IF v_offer_ref IS NOT NULL THEN
+    SELECT p,s,o INTO v_pilot,v_supplier,v_offer
+      FROM private.supplier_pilot_programs p
+      JOIN private.supplier_foundation_suppliers s ON s.id=p.supplier_id
+      JOIN private.supplier_pilot_offers po ON po.pilot_id=p.id
+      JOIN private.supplier_offers o ON o.id=po.supplier_offer_id
+     WHERE p.status IN ('preparing','active')
+       AND v_offer_ref IN (o.id::text,o.offer_key)
+       AND o.supplier_id=p.supplier_id
+       AND o.territory=p.territory
+       AND o.status='approved'
+       AND (v_supplier_ref IS NULL OR v_supplier_ref IN (p.supplier_id::text,s.supplier_key))
+       AND (v_provider_ref IS NULL OR v_provider_ref=p.provider_key)
+       AND (v_cohort IS NULL OR v_cohort=p.cohort_key)
+       AND (v_territory IS NULL OR v_territory=p.territory)
+     ORDER BY p.created_at DESC LIMIT 1;
+  ELSE
+    IF v_supplier_ref IS NULL THEN
+      RETURN jsonb_build_object('enabled',false,'reason','pilot_supplier_or_offer_scope_required','interfaceVersion',1);
+    END IF;
+    SELECT p,s INTO v_pilot,v_supplier
+      FROM private.supplier_pilot_programs p
+      JOIN private.supplier_foundation_suppliers s ON s.id=p.supplier_id
+     WHERE p.status IN ('preparing','active')
+       AND v_supplier_ref IN (p.supplier_id::text,s.supplier_key)
+       AND (v_provider_ref IS NULL OR v_provider_ref=p.provider_key)
+       AND (v_cohort IS NULL OR v_cohort=p.cohort_key)
+       AND (v_territory IS NULL OR v_territory=p.territory)
+     ORDER BY p.created_at DESC LIMIT 1;
+  END IF;
+
+  IF v_pilot.id IS NULL THEN
+    RETURN jsonb_build_object('enabled',false,'reason','pilot_scope_not_allowlisted','interfaceVersion',1);
+  END IF;
+
+  IF v_pilot.status='preparing' AND v_operation NOT IN ('import','stock_sync','price_sync') THEN
+    RETURN jsonb_build_object('enabled',false,'reason','pilot_not_active','pilotId',v_pilot.id,'interfaceVersion',1);
+  END IF;
+
+  IF v_operation<>'import' AND v_offer.id IS NULL THEN
+    RETURN jsonb_build_object('enabled',false,'reason','pilot_offer_scope_required','pilotId',v_pilot.id,'interfaceVersion',1);
+  END IF;
+  IF v_offer.id IS NOT NULL AND v_product_ref IS NOT NULL AND v_product_ref<>v_offer.canonical_product_id::text THEN
+    RETURN jsonb_build_object('enabled',false,'reason','pilot_product_scope_mismatch','pilotId',v_pilot.id,'interfaceVersion',1);
+  END IF;
+
+  SELECT * INTO v_blocker FROM private.supplier_commerce_controls c
+   WHERE c.enabled=false AND c.operation IN ('*',v_operation)
+     AND (
+       (c.scope_type='supplier' AND c.scope_ref IN (v_pilot.supplier_id::text,v_supplier.supplier_key))
+       OR (c.scope_type='provider' AND c.scope_ref=v_pilot.provider_key)
+       OR (c.scope_type='territory' AND c.scope_ref=v_pilot.territory)
+       OR (c.scope_type='cohort' AND c.scope_ref=v_pilot.cohort_key)
+       OR (v_offer.id IS NOT NULL AND c.scope_type='offer' AND c.scope_ref IN (v_offer.id::text,v_offer.offer_key))
+       OR (v_offer.id IS NOT NULL AND c.scope_type='product' AND c.scope_ref=v_offer.canonical_product_id::text)
+     )
+   ORDER BY c.updated_at DESC LIMIT 1;
+  IF FOUND THEN
+    RETURN jsonb_build_object('enabled',false,'reason','scoped_kill_switch','pilotId',v_pilot.id,
+      'scopeType',v_blocker.scope_type,'scopeRef',v_blocker.scope_ref,
+      'controlVersion',v_blocker.version,'interfaceVersion',1);
+  END IF;
+
+  RETURN jsonb_build_object(
+    'enabled',true,
+    'reason',CASE WHEN v_pilot.status='preparing' THEN 'controlled_pilot_preparation_enabled' ELSE 'controlled_pilot_enabled' END,
+    'operation',v_operation,'pilotId',v_pilot.id,'cohort',v_pilot.cohort_key,
+    'interfaceVersion',1,'controlVersion',v_pilot_control.version
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION private.supplier_pilot_control_decision_v1(text,jsonb) FROM PUBLIC,anon,authenticated,service_role;
+
+-- Enforce the pilot order ceiling before a supplier reservation can become part
+-- of the payment/submission path. Multiple items in the same canonical order do
+-- not consume multiple order slots.
+CREATE OR REPLACE FUNCTION private.guard_supplier_pilot_reservation_limits_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+DECLARE
+  v_pilot private.supplier_pilot_programs%ROWTYPE;
+  v_order public.orders%ROWTYPE;
+  v_existing_order_count integer:=0;
+  v_order_already_seen boolean:=false;
+BEGIN
+  SELECT p.* INTO v_pilot
+    FROM private.supplier_pilot_programs p
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=p.id
+   WHERE p.status='active' AND po.supplier_offer_id=NEW.supplier_offer_id
+   ORDER BY p.activated_at DESC LIMIT 1;
+  IF NOT FOUND THEN RETURN NEW; END IF;
+
+  SELECT * INTO v_order FROM public.orders WHERE id=NEW.order_id;
+  IF NOT FOUND THEN RAISE EXCEPTION 'controlled pilot canonical order required'; END IF;
+  IF COALESCE(round(v_order.total*100)::bigint,0)>v_pilot.maximum_order_value_minor THEN
+    RAISE EXCEPTION 'controlled pilot order value ceiling exceeded';
+  END IF;
+
+  SELECT EXISTS(
+    SELECT 1 FROM private.supplier_stock_reservations r
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=r.supplier_offer_id
+    WHERE r.order_id=NEW.order_id AND r.created_at>=v_pilot.activated_at
+  ) INTO v_order_already_seen;
+
+  IF NOT v_order_already_seen THEN
+    SELECT count(DISTINCT r.order_id)::integer INTO v_existing_order_count
+      FROM private.supplier_stock_reservations r
+      JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=r.supplier_offer_id
+     WHERE r.created_at>=v_pilot.activated_at;
+    IF v_existing_order_count>=v_pilot.maximum_order_count THEN
+      RAISE EXCEPTION 'controlled pilot order volume ceiling reached';
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_pilot_reservation_limits_v1 ON private.supplier_stock_reservations;
+CREATE TRIGGER trg_guard_supplier_pilot_reservation_limits_v1
+BEFORE INSERT ON private.supplier_stock_reservations
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_pilot_reservation_limits_v1();
+
+-- Preserve the first real activation timestamp across a kill-switch pause/restart
+-- so acceptance evidence cannot be erased by restarting the same pilot.
+CREATE OR REPLACE FUNCTION public.server_admin_activate_supplier_pilot_v1(p_actor_id uuid,p_pilot_id uuid,p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_pilot private.supplier_pilot_programs%ROWTYPE; v_readiness jsonb;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF NULLIF(BTRIM(p_reason),'') IS NULL THEN RAISE EXCEPTION 'pilot activation reason required'; END IF;
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id FOR UPDATE;
+  IF NOT FOUND OR v_pilot.status<>'preparing' THEN RAISE EXCEPTION 'pilot must be preparing before activation'; END IF;
+  v_readiness:=public.server_supplier_pilot_readiness_v1(v_pilot.id);
+  IF COALESCE((v_readiness->>'ready')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('ok',false,'reason','pilot_readiness_failed','readiness',v_readiness,'interfaceVersion',1);
+  END IF;
+  UPDATE private.supplier_pilot_programs
+     SET status='active',activated_by=COALESCE(activated_by,p_actor_id),activated_at=COALESCE(activated_at,now()),updated_at=now()
+   WHERE id=v_pilot.id;
+  PERFORM private.set_supplier_pilot_master_control_v1(p_actor_id,true,'Phase O active controlled pilot: '||BTRIM(p_reason));
+  INSERT INTO private.supplier_pilot_audit(pilot_id,actor_id,action,previous_status,new_status,evidence)
+  VALUES(v_pilot.id,p_actor_id,'activate','preparing','active',jsonb_build_object('reason',BTRIM(p_reason),'readiness',v_readiness));
+  RETURN jsonb_build_object('ok',true,'pilotId',v_pilot.id,'status','active','globalSupplierCommerceEnabled',false,
+    'readiness',v_readiness,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_activate_supplier_pilot_v1(uuid,uuid,text) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_activate_supplier_pilot_v1(uuid,uuid,text) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_supplier_pilot_acceptance_v1(p_pilot_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_pilot private.supplier_pilot_programs%ROWTYPE;
+  v_orders integer:=0; v_acks integer:=0; v_delivered integer:=0; v_tracking integer:=0;
+  v_returns integer:=0; v_refunds integer:=0; v_recoveries integer:=0; v_reconciled integer:=0;
+  v_over_value integer:=0; v_duplicate_submit integer:=0; v_oversell integer:=0; v_critical integer:=0;
+  v_ack_rate numeric:=0; v_ack_min numeric:=0; v_duplicate_max integer:=0; v_oversell_max integer:=0;
+  v_financial_max integer:=0; v_critical_max integer:=0; v_failures jsonb:='[]'::jsonb;
+BEGIN
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id;
+  IF NOT FOUND OR v_pilot.activated_at IS NULL THEN
+    RETURN jsonb_build_object('passed',false,'reason','pilot_not_activated','interfaceVersion',1);
+  END IF;
+
+  v_ack_min:=(v_pilot.acceptance_thresholds->>'acknowledgementRateMinPct')::numeric;
+  v_duplicate_max:=(v_pilot.acceptance_thresholds->>'duplicateSideEffectsMax')::integer;
+  v_oversell_max:=(v_pilot.acceptance_thresholds->>'oversellMax')::integer;
+  v_financial_max:=(v_pilot.acceptance_thresholds->>'unreconciledFinancialExceptionsMax')::integer;
+  v_critical_max:=(v_pilot.acceptance_thresholds->>'criticalIncidentMax')::integer;
+
+  SELECT count(DISTINCT h.order_id),
+         count(DISTINCT h.order_id) FILTER(WHERE h.state='reconciled' AND h.acknowledgement_state='accepted')
+    INTO v_orders,v_acks
+    FROM private.supplier_order_handshakes h
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+   WHERE h.supplier_id=v_pilot.supplier_id AND h.provider_key=v_pilot.provider_key AND h.created_at>=v_pilot.activated_at;
+  IF v_orders>0 THEN v_ack_rate:=round((v_acks::numeric/v_orders::numeric)*100,3); END IF;
+
+  SELECT count(DISTINCT h.order_id)::integer INTO v_over_value
+    FROM private.supplier_order_handshakes h
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+    JOIN public.orders o ON o.id=h.order_id
+   WHERE h.created_at>=v_pilot.activated_at AND round(o.total*100)::bigint>v_pilot.maximum_order_value_minor;
+
+  SELECT count(DISTINCT s.order_id)::integer INTO v_delivered
+    FROM private.supplier_leg_shipments s
+    JOIN private.supplier_order_handshakes h ON h.id=s.handshake_id
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+   WHERE s.supplier_id=v_pilot.supplier_id AND s.provider_key=v_pilot.provider_key
+     AND s.canonical_status='delivered' AND s.created_at>=v_pilot.activated_at;
+
+  SELECT count(*)::integer INTO v_tracking
+    FROM private.supplier_tracking_events e
+    JOIN private.supplier_leg_shipments s ON s.id=e.shipment_id
+    JOIN private.supplier_order_handshakes h ON h.id=s.handshake_id
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+   WHERE e.occurred_at>=v_pilot.activated_at;
+
+  SELECT count(DISTINCT r.order_id)::integer INTO v_returns
+    FROM private.supplier_return_cases r
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=r.supplier_offer_id
+   WHERE r.supplier_id=v_pilot.supplier_id AND r.requested_at>=v_pilot.activated_at;
+
+  SELECT count(DISTINCT e.order_id)::integer INTO v_refunds
+    FROM private.supplier_customer_refund_evidence e
+    JOIN private.supplier_return_cases r ON r.id=e.return_case_id
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=r.supplier_offer_id
+   WHERE e.state IN ('partial','succeeded') AND e.occurred_at>=v_pilot.activated_at;
+
+  SELECT count(DISTINCT e.order_id)::integer INTO v_recoveries
+    FROM private.supplier_recovery_evidence e
+   WHERE e.supplier_id=v_pilot.supplier_id AND e.state IN ('partial','recovered') AND e.occurred_at>=v_pilot.activated_at
+     AND EXISTS(
+       SELECT 1 FROM private.supplier_order_handshakes h
+       JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+       WHERE h.order_id=e.order_id AND h.supplier_id=v_pilot.supplier_id
+     );
+
+  SELECT count(DISTINCT h.order_id)::integer INTO v_reconciled
+    FROM private.supplier_order_handshakes h
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+   WHERE h.created_at>=v_pilot.activated_at
+     AND EXISTS(
+       SELECT 1 FROM private.supplier_financial_reconciliations f
+        WHERE f.order_id=h.order_id AND f.state='reconciled' AND COALESCE(abs(f.unrecovered_loss),0)=0
+     );
+
+  SELECT count(*)::integer INTO v_duplicate_submit
+    FROM private.supplier_order_exceptions x
+   WHERE x.exception_type='duplicate_submit' AND x.opened_at>=v_pilot.activated_at
+     AND EXISTS(
+       SELECT 1 FROM private.supplier_order_handshakes h
+       JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+       WHERE h.order_id=x.order_id
+     );
+
+  SELECT count(*)::integer INTO v_oversell
+    FROM private.supplier_order_exceptions x
+   WHERE x.exception_type='stock_disappeared' AND x.opened_at>=v_pilot.activated_at
+     AND EXISTS(
+       SELECT 1 FROM private.supplier_order_handshakes h
+       JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+       WHERE h.order_id=x.order_id
+     );
+
+  SELECT count(*)::integer INTO v_critical
+    FROM private.supplier_commerce_incidents i
+   WHERE i.severity='critical' AND i.status NOT IN ('resolved','closed')
+     AND i.supplier_ref IN (
+       v_pilot.supplier_id::text,
+       (SELECT supplier_key FROM private.supplier_foundation_suppliers WHERE id=v_pilot.supplier_id)
+     );
+
+  IF v_orders=0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','real_orders','reason','no_real_pilot_orders')); END IF;
+  IF v_orders>v_pilot.maximum_order_count THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','order_volume_limit','orders',v_orders,'maximum',v_pilot.maximum_order_count)); END IF;
+  IF v_over_value>0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','order_value_limit','violations',v_over_value,'maximumOrderValueMinor',v_pilot.maximum_order_value_minor)); END IF;
+  IF v_ack_rate<v_ack_min THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','acknowledgement_rate','actualPct',v_ack_rate,'minimumPct',v_ack_min)); END IF;
+  IF v_duplicate_submit>v_duplicate_max THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','duplicate_side_effects','duplicateSubmitExceptions',v_duplicate_submit,'maximum',v_duplicate_max)); END IF;
+  IF v_oversell>v_oversell_max THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','oversell','stockDisappearedExceptions',v_oversell,'maximum',v_oversell_max)); END IF;
+  IF v_delivered=0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','delivery','reason','no_delivered_pilot_order')); END IF;
+  IF v_tracking=0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','tracking','reason','no_real_tracking_event')); END IF;
+  IF v_returns=0 OR v_refunds=0 OR v_recoveries=0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','return_refund_recovery','returns',v_returns,'refunds',v_refunds,'recoveries',v_recoveries)); END IF;
+  IF (v_orders-v_reconciled)>v_financial_max THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','financial_reconciliation','reconciledOrders',v_reconciled,'pilotOrders',v_orders,'maximumUnreconciled',v_financial_max)); END IF;
+  IF v_critical>v_critical_max THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','critical_incidents','open',v_critical,'maximum',v_critical_max)); END IF;
+
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_pilot_evidence e WHERE e.pilot_id=v_pilot.id AND e.evidence_type='buyer_communication') THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','buyer_communication','reason','evidence_missing'));
+  END IF;
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_pilot_evidence e WHERE e.pilot_id=v_pilot.id AND e.evidence_type='operator_escalation') THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','operator_escalation','reason','evidence_missing'));
+  END IF;
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_pilot_evidence e WHERE e.pilot_id=v_pilot.id AND e.evidence_type='kill_switch_test') THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','kill_switch_test','reason','evidence_missing'));
+  END IF;
+  IF NOT EXISTS(
+    SELECT 1 FROM private.supplier_commerce_control_audit a
+     WHERE a.operation='pilot' AND a.scope_type='global' AND a.new_enabled=false AND a.created_at>=v_pilot.activated_at
+  ) THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','kill_switch_control_audit','reason','real_disable_transition_missing')); END IF;
+
+  RETURN jsonb_build_object(
+    'passed',jsonb_array_length(v_failures)=0,
+    'reason',CASE WHEN jsonb_array_length(v_failures)=0 THEN 'controlled_pilot_pass' ELSE 'controlled_pilot_evidence_incomplete' END,
+    'pilotId',v_pilot.id,'orders',v_orders,'acknowledgedOrders',v_acks,'acknowledgementRatePct',v_ack_rate,
+    'deliveredOrders',v_delivered,'trackingEvents',v_tracking,'returnOrders',v_returns,'refundOrders',v_refunds,
+    'recoveryOrders',v_recoveries,'reconciledOrders',v_reconciled,'orderValueViolations',v_over_value,
+    'duplicateSubmitExceptions',v_duplicate_submit,'oversellExceptions',v_oversell,'openCriticalIncidents',v_critical,
+    'failures',v_failures,'simulatorPassIsNotPilotPass',true,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_supplier_pilot_acceptance_v1(uuid) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_pilot_acceptance_v1(uuid) TO service_role;
+
+COMMENT ON FUNCTION private.guard_supplier_pilot_reservation_limits_v1() IS 'Phase O hard pre-payment-path reservation ceiling for the active controlled pilot.';
+COMMENT ON FUNCTION private.supplier_pilot_control_decision_v1(text,jsonb) IS 'Phase O fail-closed scoped control gate. Exact allowlisted offer identity may derive the supplier for canonical callers that do not carry supplierRef.';

--- a/supabase/667_supplier_controlled_pilot_adapter_readiness_closure.sql
+++ b/supabase/667_supplier_controlled_pilot_adapter_readiness_closure.sql
@@ -1,0 +1,120 @@
+-- 667_supplier_controlled_pilot_adapter_readiness_closure.sql
+-- Phase O Branch Guard closure: a pilot cannot become ready by combining
+-- capabilities from different adapter registrations or adapter versions.
+
+CREATE OR REPLACE FUNCTION public.server_supplier_pilot_readiness_v1(p_pilot_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_pilot private.supplier_pilot_programs%ROWTYPE;
+  v_supplier private.supplier_foundation_suppliers%ROWTYPE;
+  v_adapter private.supplier_adapter_registrations%ROWTYPE;
+  v_foundation jsonb;
+  v_governance jsonb;
+  v_offer record;
+  v_decision jsonb;
+  v_offer_count integer:=0;
+  v_product_count integer:=0;
+  v_failures jsonb:='[]'::jsonb;
+  v_required_capabilities text[]:=ARRAY[
+    'catalog','stock','price','shipping','order_submission','acknowledgement',
+    'tracking','cancellation','returns','reimbursement'
+  ]::text[];
+BEGIN
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ready',false,'reason','pilot_not_found','interfaceVersion',1); END IF;
+  SELECT * INTO v_supplier FROM private.supplier_foundation_suppliers WHERE id=v_pilot.supplier_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ready',false,'reason','supplier_not_found','interfaceVersion',1); END IF;
+
+  v_foundation:=public.server_supplier_foundation_decision_v1(v_supplier.supplier_key,'GB','catalog');
+  IF COALESCE((v_foundation->>'eligible')::boolean,false) IS DISTINCT FROM true THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','supplier_foundation','detail',v_foundation));
+  END IF;
+
+  v_governance:=public.server_supplier_governance_decision_v1(v_pilot.supplier_id,v_pilot.provider_key);
+  IF COALESCE((v_governance->>'eligible')::boolean,false) IS DISTINCT FROM true THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','supplier_governance','detail',v_governance));
+  END IF;
+
+  IF NOT EXISTS(
+    SELECT 1 FROM private.supplier_commerce_provider_capabilities c
+     WHERE c.provider_key=v_pilot.provider_key AND c.territory='GB'
+       AND c.role IN ('supplier','fulfilment_provider') AND c.status='verified'
+       AND c.verified_at IS NOT NULL AND c.reverify_due_at>now()
+       AND jsonb_array_length(c.official_source_refs)>0
+  ) THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object(
+      'check','provider_capability_register','reason','current_verified_provider_capability_missing'
+    ));
+  END IF;
+
+  SELECT * INTO v_adapter
+    FROM private.supplier_adapter_registrations a
+   WHERE a.supplier_id=v_pilot.supplier_id
+     AND a.provider_key=v_pilot.provider_key
+     AND a.status='active'
+     AND a.interface_version=1
+     AND a.verified_at IS NOT NULL
+     AND a.verified_by IS NOT NULL
+     AND NULLIF(BTRIM(a.config_ref),'') IS NOT NULL
+     AND a.capabilities @> v_required_capabilities
+   ORDER BY a.verified_at DESC
+   LIMIT 1;
+  IF NOT FOUND THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object(
+      'check','single_verified_full_capability_adapter',
+      'reason','one_active_verified_adapter_version_with_all_pilot_capabilities_is_required',
+      'requiredCapabilities',to_jsonb(v_required_capabilities)
+    ));
+  END IF;
+
+  SELECT count(*),count(DISTINCT o.canonical_product_id) INTO v_offer_count,v_product_count
+    FROM private.supplier_pilot_offers po
+    JOIN private.supplier_offers o ON o.id=po.supplier_offer_id
+   WHERE po.pilot_id=v_pilot.id;
+  IF v_offer_count<v_pilot.minimum_product_count OR v_offer_count>v_pilot.maximum_product_count OR v_product_count<>v_offer_count THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object(
+      'check','pilot_product_set','offerCount',v_offer_count,'distinctProductCount',v_product_count,
+      'minimum',v_pilot.minimum_product_count,'maximum',v_pilot.maximum_product_count
+    ));
+  END IF;
+
+  FOR v_offer IN
+    SELECT po.supplier_offer_id,po.external_variant_ref,o.canonical_product_id,o.offer_key
+      FROM private.supplier_pilot_offers po
+      JOIN private.supplier_offers o ON o.id=po.supplier_offer_id
+     WHERE po.pilot_id=v_pilot.id
+  LOOP
+    v_decision:=public.server_supplier_catalog_decision_v1(v_offer.canonical_product_id,v_offer.supplier_offer_id,'GB');
+    IF COALESCE((v_decision->>'eligible')::boolean,false) IS DISTINCT FROM true THEN
+      v_failures:=v_failures||jsonb_build_array(jsonb_build_object(
+        'check','catalog_readiness','offer',v_offer.offer_key,'detail',v_decision
+      ));
+    END IF;
+
+    v_decision:=public.server_supplier_stock_price_decision_v1(
+      v_offer.supplier_offer_id,v_offer.canonical_product_id,
+      'loadify_supplier_fulfilled','GB',v_offer.external_variant_ref
+    );
+    IF COALESCE((v_decision->>'eligible')::boolean,false) IS DISTINCT FROM true THEN
+      v_failures:=v_failures||jsonb_build_array(jsonb_build_object(
+        'check','stock_price_readiness','offer',v_offer.offer_key,'detail',v_decision
+      ));
+    END IF;
+  END LOOP;
+
+  RETURN jsonb_build_object(
+    'ready',jsonb_array_length(v_failures)=0,
+    'reason',CASE WHEN jsonb_array_length(v_failures)=0 THEN 'controlled_pilot_ready' ELSE 'controlled_pilot_not_ready' END,
+    'pilotId',v_pilot.id,'supplierId',v_pilot.supplier_id,'providerKey',v_pilot.provider_key,'territory','GB',
+    'adapterId',CASE WHEN v_adapter.id IS NULL THEN NULL ELSE v_adapter.id END,
+    'adapterKey',CASE WHEN v_adapter.id IS NULL THEN NULL ELSE v_adapter.adapter_key END,
+    'adapterVersion',CASE WHEN v_adapter.id IS NULL THEN NULL ELSE v_adapter.adapter_version END,
+    'offerCount',v_offer_count,'distinctProductCount',v_product_count,'failures',v_failures,
+    'simulatorPassIsNotPilotPass',true,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_supplier_pilot_readiness_v1(uuid) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_pilot_readiness_v1(uuid) TO service_role;
+
+COMMENT ON FUNCTION public.server_supplier_pilot_readiness_v1(uuid) IS 'Phase O factual readiness gate. Requires one active verified adapter version carrying the complete pilot capability set; capabilities cannot be aggregated across registrations.';

--- a/supabase/668_supplier_controlled_pilot_cohort_evidence_closure.sql
+++ b/supabase/668_supplier_controlled_pilot_cohort_evidence_closure.sql
@@ -1,0 +1,485 @@
+-- 668_supplier_controlled_pilot_cohort_evidence_closure.sql
+-- Phase O Branch Guard closure.
+-- Adds an explicit buyer cohort boundary, requires real Phase N simulator evidence,
+-- fixes reconciliation state casing, and makes return/refund/recovery acceptance conditional
+-- on a real return rather than forcing artificial customer financial side effects.
+-- No pilot is created or activated by this migration. Global Supplier Commerce remains OFF.
+
+ALTER TABLE private.supplier_pilot_programs
+  ALTER COLUMN minimum_product_count SET DEFAULT 1;
+
+CREATE TABLE IF NOT EXISTS private.supplier_pilot_cohort_members (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  pilot_id uuid NOT NULL REFERENCES private.supplier_pilot_programs(id) ON DELETE RESTRICT,
+  buyer_id uuid NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  evidence jsonb NOT NULL,
+  added_by uuid NOT NULL REFERENCES public.users(id) ON DELETE RESTRICT,
+  added_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT supplier_pilot_cohort_evidence_check CHECK (
+    jsonb_typeof(evidence)='object' AND evidence<>'{}'::jsonb
+  ),
+  UNIQUE(pilot_id,buyer_id)
+);
+CREATE INDEX IF NOT EXISTS supplier_pilot_cohort_lookup_idx
+  ON private.supplier_pilot_cohort_members(pilot_id,buyer_id);
+REVOKE ALL ON TABLE private.supplier_pilot_cohort_members FROM PUBLIC,anon,authenticated,service_role;
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_pilot_cohort_history_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+BEGIN
+  RAISE EXCEPTION 'controlled pilot cohort membership is append-only';
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_pilot_cohort_immutable_v1 ON private.supplier_pilot_cohort_members;
+CREATE TRIGGER trg_guard_supplier_pilot_cohort_immutable_v1
+BEFORE UPDATE OR DELETE ON private.supplier_pilot_cohort_members
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_pilot_cohort_history_v1();
+
+ALTER TABLE private.supplier_pilot_evidence
+  DROP CONSTRAINT IF EXISTS supplier_pilot_evidence_type_check;
+ALTER TABLE private.supplier_pilot_evidence
+  ADD CONSTRAINT supplier_pilot_evidence_type_check CHECK (
+    evidence_type IN (
+      'buyer_communication','kill_switch_test','operator_escalation','incident_review','pilot_note',
+      'rollback_recovery_test','incident_path_test','release_snapshot','duplicate_side_effect_review'
+    )
+  );
+ALTER TABLE private.supplier_pilot_evidence
+  ADD CONSTRAINT supplier_pilot_release_snapshot_shape_check CHECK (
+    evidence_type<>'release_snapshot' OR (
+      evidence ? 'mainSha'
+      AND evidence ? 'migrationHead'
+      AND evidence ? 'controlState'
+      AND evidence ? 'pilotControlVersion'
+      AND COALESCE(evidence->>'mainSha','') ~ '^[0-9a-f]{40}$'
+      AND NULLIF(BTRIM(evidence->>'migrationHead'),'') IS NOT NULL
+      AND jsonb_typeof(evidence->'controlState')='object'
+      AND COALESCE((evidence->>'pilotControlVersion')::integer,0)>0
+    )
+  );
+
+CREATE OR REPLACE FUNCTION public.server_admin_add_supplier_pilot_cohort_member_v1(
+  p_actor_id uuid,p_pilot_id uuid,p_buyer_id uuid,p_evidence jsonb
+)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_pilot private.supplier_pilot_programs%ROWTYPE;
+  v_existing private.supplier_pilot_cohort_members%ROWTYPE;
+  v_id uuid;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id FOR UPDATE;
+  IF NOT FOUND OR v_pilot.status NOT IN ('draft','preparing') THEN
+    RAISE EXCEPTION 'pilot cohort is mutable only before activation';
+  END IF;
+  IF NOT EXISTS(SELECT 1 FROM public.users u WHERE u.id=p_buyer_id) THEN
+    RAISE EXCEPTION 'pilot cohort buyer must exist';
+  END IF;
+  IF jsonb_typeof(COALESCE(p_evidence,'{}'::jsonb))<>'object' OR COALESCE(p_evidence,'{}'::jsonb)='{}'::jsonb THEN
+    RAISE EXCEPTION 'pilot cohort membership evidence required';
+  END IF;
+
+  SELECT * INTO v_existing FROM private.supplier_pilot_cohort_members
+   WHERE pilot_id=p_pilot_id AND buyer_id=p_buyer_id;
+  IF FOUND THEN
+    IF v_existing.evidence IS DISTINCT FROM p_evidence THEN
+      RAISE EXCEPTION 'pilot cohort membership idempotency collision';
+    END IF;
+    RETURN v_existing.id;
+  END IF;
+
+  INSERT INTO private.supplier_pilot_cohort_members(pilot_id,buyer_id,evidence,added_by)
+  VALUES(p_pilot_id,p_buyer_id,p_evidence,p_actor_id)
+  RETURNING id INTO v_id;
+  INSERT INTO private.supplier_pilot_audit(pilot_id,actor_id,action,new_status,evidence)
+  VALUES(p_pilot_id,p_actor_id,'add_cohort_member',v_pilot.status,
+    jsonb_build_object('buyerId',p_buyer_id,'membershipEvidence',p_evidence));
+  RETURN v_id;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_add_supplier_pilot_cohort_member_v1(uuid,uuid,uuid,jsonb) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_add_supplier_pilot_cohort_member_v1(uuid,uuid,uuid,jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_add_supplier_pilot_offer_v1(
+  p_actor_id uuid,p_pilot_id uuid,p_supplier_offer_id uuid,p_external_variant_ref text,p_selection_evidence jsonb
+)
+RETURNS uuid LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_pilot private.supplier_pilot_programs%ROWTYPE;
+  v_offer private.supplier_offers%ROWTYPE;
+  v_existing private.supplier_pilot_offers%ROWTYPE;
+  v_id uuid;
+  v_count integer;
+  v_variant text:=BTRIM(COALESCE(p_external_variant_ref,''));
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id FOR UPDATE;
+  IF NOT FOUND OR v_pilot.status NOT IN ('draft','preparing') THEN
+    RAISE EXCEPTION 'pilot offer set is mutable only before activation';
+  END IF;
+  SELECT * INTO v_offer FROM private.supplier_offers
+   WHERE id=p_supplier_offer_id AND supplier_id=v_pilot.supplier_id AND territory='GB' AND status='approved';
+  IF NOT FOUND THEN RAISE EXCEPTION 'approved GB supplier offer for pilot supplier required'; END IF;
+  IF NOT EXISTS(SELECT 1 FROM private.canonical_products p WHERE p.id=v_offer.canonical_product_id AND p.status='active') THEN
+    RAISE EXCEPTION 'active canonical product required';
+  END IF;
+  IF jsonb_typeof(COALESCE(p_selection_evidence,'{}'::jsonb))<>'object' OR COALESCE(p_selection_evidence,'{}'::jsonb)='{}'::jsonb THEN
+    RAISE EXCEPTION 'low-risk product selection evidence required';
+  END IF;
+
+  SELECT * INTO v_existing FROM private.supplier_pilot_offers
+   WHERE pilot_id=p_pilot_id AND supplier_offer_id=p_supplier_offer_id AND external_variant_ref=v_variant;
+  IF FOUND THEN
+    IF v_existing.selection_evidence IS DISTINCT FROM p_selection_evidence THEN
+      RAISE EXCEPTION 'pilot offer idempotency collision';
+    END IF;
+    RETURN v_existing.id;
+  END IF;
+
+  SELECT count(*) INTO v_count FROM private.supplier_pilot_offers WHERE pilot_id=p_pilot_id;
+  IF v_count>=v_pilot.maximum_product_count THEN RAISE EXCEPTION 'pilot product ceiling reached'; END IF;
+  INSERT INTO private.supplier_pilot_offers(
+    pilot_id,supplier_offer_id,external_variant_ref,selection_evidence,approved_by
+  ) VALUES(
+    p_pilot_id,p_supplier_offer_id,v_variant,p_selection_evidence,p_actor_id
+  ) RETURNING id INTO v_id;
+  INSERT INTO private.supplier_pilot_audit(pilot_id,actor_id,action,new_status,evidence)
+  VALUES(p_pilot_id,p_actor_id,'add_offer',v_pilot.status,
+    jsonb_build_object('supplierOfferId',p_supplier_offer_id,'variantRef',v_variant));
+  RETURN v_id;
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_add_supplier_pilot_offer_v1(uuid,uuid,uuid,text,jsonb) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_add_supplier_pilot_offer_v1(uuid,uuid,uuid,text,jsonb) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_supplier_pilot_activation_readiness_v1(p_pilot_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_pilot private.supplier_pilot_programs%ROWTYPE;
+  v_core jsonb;
+  v_control private.supplier_commerce_controls%ROWTYPE;
+  v_cohort_count integer:=0;
+  v_other_global_enabled integer:=0;
+  v_failures jsonb:='[]'::jsonb;
+BEGIN
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id;
+  IF NOT FOUND THEN RETURN jsonb_build_object('ready',false,'reason','pilot_not_found','interfaceVersion',1); END IF;
+
+  v_core:=public.server_supplier_pilot_readiness_v1(p_pilot_id);
+  IF COALESCE((v_core->>'ready')::boolean,false) IS DISTINCT FROM true THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','core_readiness','detail',v_core));
+  END IF;
+
+  IF NOT EXISTS(
+    SELECT 1 FROM private.supplier_simulator_validation_runs r
+     WHERE r.status='passed' AND v_pilot.simulator_evidence_ref IN (r.id::text,r.run_key)
+  ) THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object(
+      'check','real_simulator_evidence','reason','passed_phase_n_simulator_run_not_found',
+      'simulatorEvidenceRef',v_pilot.simulator_evidence_ref
+    ));
+  END IF;
+
+  SELECT count(*)::integer INTO v_cohort_count
+    FROM private.supplier_pilot_cohort_members m WHERE m.pilot_id=v_pilot.id;
+  IF v_cohort_count=0 THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object(
+      'check','pilot_cohort','reason','explicit_buyer_cohort_missing'
+    ));
+  END IF;
+
+  SELECT * INTO v_control FROM private.supplier_commerce_controls
+   WHERE operation='pilot' AND scope_type='global' AND scope_ref IS NULL LIMIT 1;
+  IF NOT FOUND OR v_control.enabled IS DISTINCT FROM true THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object(
+      'check','pilot_master_control','reason','pilot_master_disabled'
+    ));
+  END IF;
+
+  SELECT count(*)::integer INTO v_other_global_enabled
+    FROM private.supplier_commerce_controls c
+   WHERE c.scope_type='global' AND c.scope_ref IS NULL
+     AND c.operation<>'pilot' AND c.enabled=true;
+  IF v_other_global_enabled>0 THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object(
+      'check','global_activation_guard','reason','non_pilot_global_supplier_commerce_control_enabled',
+      'enabledCount',v_other_global_enabled
+    ));
+  END IF;
+
+  RETURN jsonb_build_object(
+    'ready',jsonb_array_length(v_failures)=0,
+    'reason',CASE WHEN jsonb_array_length(v_failures)=0 THEN 'controlled_pilot_activation_ready' ELSE 'controlled_pilot_activation_not_ready' END,
+    'pilotId',v_pilot.id,'cohortMemberCount',v_cohort_count,'coreReadiness',v_core,
+    'failures',v_failures,'simulatorPassIsNotPilotPass',true,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_supplier_pilot_activation_readiness_v1(uuid) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_pilot_activation_readiness_v1(uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_activate_supplier_pilot_v1(p_actor_id uuid,p_pilot_id uuid,p_reason text)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE v_pilot private.supplier_pilot_programs%ROWTYPE; v_readiness jsonb;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF NULLIF(BTRIM(p_reason),'') IS NULL THEN RAISE EXCEPTION 'pilot activation reason required'; END IF;
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id FOR UPDATE;
+  IF NOT FOUND OR v_pilot.status<>'preparing' THEN RAISE EXCEPTION 'pilot must be preparing before activation'; END IF;
+  v_readiness:=public.server_supplier_pilot_activation_readiness_v1(v_pilot.id);
+  IF COALESCE((v_readiness->>'ready')::boolean,false) IS DISTINCT FROM true THEN
+    RETURN jsonb_build_object('ok',false,'reason','pilot_readiness_failed','readiness',v_readiness,'interfaceVersion',1);
+  END IF;
+  UPDATE private.supplier_pilot_programs
+     SET status='active',activated_by=COALESCE(activated_by,p_actor_id),activated_at=COALESCE(activated_at,now()),updated_at=now()
+   WHERE id=v_pilot.id;
+  PERFORM private.set_supplier_pilot_master_control_v1(p_actor_id,true,'Phase O active controlled pilot: '||BTRIM(p_reason));
+  INSERT INTO private.supplier_pilot_audit(pilot_id,actor_id,action,previous_status,new_status,evidence)
+  VALUES(v_pilot.id,p_actor_id,'activate','preparing','active',jsonb_build_object('reason',BTRIM(p_reason),'readiness',v_readiness));
+  RETURN jsonb_build_object('ok',true,'pilotId',v_pilot.id,'status','active','globalSupplierCommerceEnabled',false,
+    'readiness',v_readiness,'interfaceVersion',1);
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_activate_supplier_pilot_v1(uuid,uuid,text) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_activate_supplier_pilot_v1(uuid,uuid,text) TO service_role;
+
+CREATE OR REPLACE FUNCTION private.guard_supplier_pilot_cohort_reservation_v1()
+RETURNS trigger LANGUAGE plpgsql SET search_path TO '' AS $$
+DECLARE
+  v_pilot_id uuid;
+  v_buyer_id uuid;
+BEGIN
+  SELECT p.id INTO v_pilot_id
+    FROM private.supplier_pilot_programs p
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=p.id
+   WHERE p.status='active' AND po.supplier_offer_id=NEW.supplier_offer_id
+   ORDER BY p.activated_at DESC LIMIT 1;
+  IF NOT FOUND THEN RETURN NEW; END IF;
+
+  SELECT o."buyerId" INTO v_buyer_id FROM public.orders o WHERE o.id=NEW.order_id;
+  IF v_buyer_id IS NULL OR NOT EXISTS(
+    SELECT 1 FROM private.supplier_pilot_cohort_members m
+     WHERE m.pilot_id=v_pilot_id AND m.buyer_id=v_buyer_id
+  ) THEN
+    RAISE EXCEPTION 'controlled pilot buyer outside explicit cohort';
+  END IF;
+  RETURN NEW;
+END;
+$$;
+DROP TRIGGER IF EXISTS trg_guard_supplier_pilot_cohort_reservation_v1 ON private.supplier_stock_reservations;
+CREATE TRIGGER trg_guard_supplier_pilot_cohort_reservation_v1
+BEFORE INSERT ON private.supplier_stock_reservations
+FOR EACH ROW EXECUTE FUNCTION private.guard_supplier_pilot_cohort_reservation_v1();
+
+CREATE OR REPLACE FUNCTION public.server_supplier_pilot_acceptance_v1(p_pilot_id uuid)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_pilot private.supplier_pilot_programs%ROWTYPE;
+  v_orders integer:=0; v_acks integer:=0; v_delivered integer:=0; v_tracking integer:=0;
+  v_returns integer:=0; v_refunds integer:=0; v_recoveries integer:=0; v_return_incomplete integer:=0;
+  v_reconciled integer:=0; v_outside_cohort integer:=0;
+  v_over_value integer:=0; v_duplicate_submit integer:=0; v_oversell integer:=0; v_critical integer:=0;
+  v_ack_rate numeric:=0; v_ack_min numeric:=0; v_duplicate_max integer:=0; v_oversell_max integer:=0;
+  v_financial_max integer:=0; v_critical_max integer:=0; v_failures jsonb:='[]'::jsonb;
+BEGIN
+  SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id;
+  IF NOT FOUND OR v_pilot.activated_at IS NULL THEN
+    RETURN jsonb_build_object('passed',false,'reason','pilot_not_activated','interfaceVersion',1);
+  END IF;
+
+  v_ack_min:=(v_pilot.acceptance_thresholds->>'acknowledgementRateMinPct')::numeric;
+  v_duplicate_max:=(v_pilot.acceptance_thresholds->>'duplicateSideEffectsMax')::integer;
+  v_oversell_max:=(v_pilot.acceptance_thresholds->>'oversellMax')::integer;
+  v_financial_max:=(v_pilot.acceptance_thresholds->>'unreconciledFinancialExceptionsMax')::integer;
+  v_critical_max:=(v_pilot.acceptance_thresholds->>'criticalIncidentMax')::integer;
+
+  SELECT count(DISTINCT h.order_id),
+         count(DISTINCT h.order_id) FILTER(WHERE h.state='reconciled' AND h.acknowledgement_state='accepted')
+    INTO v_orders,v_acks
+    FROM private.supplier_order_handshakes h
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+   WHERE h.supplier_id=v_pilot.supplier_id AND h.provider_key=v_pilot.provider_key AND h.created_at>=v_pilot.activated_at;
+  IF v_orders>0 THEN v_ack_rate:=round((v_acks::numeric/v_orders::numeric)*100,3); END IF;
+
+  SELECT count(DISTINCT h.order_id)::integer INTO v_outside_cohort
+    FROM private.supplier_order_handshakes h
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+    JOIN public.orders o ON o.id=h.order_id
+   WHERE h.created_at>=v_pilot.activated_at
+     AND NOT EXISTS(
+       SELECT 1 FROM private.supplier_pilot_cohort_members m
+        WHERE m.pilot_id=v_pilot.id AND m.buyer_id=o."buyerId"
+     );
+
+  SELECT count(DISTINCT h.order_id)::integer INTO v_over_value
+    FROM private.supplier_order_handshakes h
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+    JOIN public.orders o ON o.id=h.order_id
+   WHERE h.created_at>=v_pilot.activated_at AND round(o.total*100)::bigint>v_pilot.maximum_order_value_minor;
+
+  SELECT count(DISTINCT s.order_id)::integer INTO v_delivered
+    FROM private.supplier_leg_shipments s
+    JOIN private.supplier_order_handshakes h ON h.id=s.handshake_id
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+   WHERE s.supplier_id=v_pilot.supplier_id AND s.provider_key=v_pilot.provider_key
+     AND s.canonical_status='delivered' AND s.created_at>=v_pilot.activated_at;
+
+  SELECT count(*)::integer INTO v_tracking
+    FROM private.supplier_tracking_events e
+    JOIN private.supplier_leg_shipments s ON s.id=e.shipment_id
+    JOIN private.supplier_order_handshakes h ON h.id=s.handshake_id
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+   WHERE e.occurred_at>=v_pilot.activated_at;
+
+  SELECT count(*)::integer INTO v_returns
+    FROM private.supplier_return_cases r
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=r.supplier_offer_id
+   WHERE r.supplier_id=v_pilot.supplier_id AND r.requested_at>=v_pilot.activated_at;
+
+  SELECT count(DISTINCT e.return_case_id)::integer INTO v_refunds
+    FROM private.supplier_customer_refund_evidence e
+    JOIN private.supplier_return_cases r ON r.id=e.return_case_id
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=r.supplier_offer_id
+   WHERE e.state='succeeded' AND e.occurred_at>=v_pilot.activated_at;
+
+  SELECT count(DISTINCT e.return_case_id)::integer INTO v_recoveries
+    FROM private.supplier_recovery_evidence e
+    JOIN private.supplier_return_cases r ON r.id=e.return_case_id
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=r.supplier_offer_id
+   WHERE e.supplier_id=v_pilot.supplier_id AND e.state='recovered' AND e.occurred_at>=v_pilot.activated_at;
+
+  SELECT count(*)::integer INTO v_return_incomplete
+    FROM private.supplier_return_cases r
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=r.supplier_offer_id
+   WHERE r.supplier_id=v_pilot.supplier_id AND r.requested_at>=v_pilot.activated_at
+     AND r.state<>'cancelled'
+     AND (r.state<>'closed' OR r.customer_refund_state<>'succeeded' OR r.supplier_recovery_state NOT IN ('recovered','unrecoverable'));
+
+  SELECT count(DISTINCT h.order_id)::integer INTO v_reconciled
+    FROM private.supplier_order_handshakes h
+    JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+   WHERE h.created_at>=v_pilot.activated_at
+     AND EXISTS(
+       SELECT 1 FROM private.supplier_financial_reconciliations f
+        WHERE f.order_id=h.order_id AND f.state='RECONCILED' AND COALESCE(abs(f.unrecovered_loss),0)=0
+     );
+
+  SELECT count(*)::integer INTO v_duplicate_submit
+    FROM private.supplier_order_exceptions x
+   WHERE x.exception_type='duplicate_submit' AND x.opened_at>=v_pilot.activated_at
+     AND EXISTS(
+       SELECT 1 FROM private.supplier_order_handshakes h
+       JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+       WHERE h.order_id=x.order_id
+     );
+
+  SELECT count(*)::integer INTO v_oversell
+    FROM private.supplier_order_exceptions x
+   WHERE x.exception_type='stock_disappeared' AND x.opened_at>=v_pilot.activated_at
+     AND EXISTS(
+       SELECT 1 FROM private.supplier_order_handshakes h
+       JOIN private.supplier_pilot_offers po ON po.pilot_id=v_pilot.id AND po.supplier_offer_id=h.supplier_offer_id
+       WHERE h.order_id=x.order_id
+     );
+
+  SELECT count(*)::integer INTO v_critical
+    FROM private.supplier_commerce_incidents i
+   WHERE i.severity='critical' AND i.status NOT IN ('resolved','closed')
+     AND i.supplier_ref IN (
+       v_pilot.supplier_id::text,
+       (SELECT supplier_key FROM private.supplier_foundation_suppliers WHERE id=v_pilot.supplier_id)
+     );
+
+  IF v_orders=0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','real_orders','reason','no_real_pilot_orders')); END IF;
+  IF v_orders>v_pilot.maximum_order_count THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','order_volume_limit','orders',v_orders,'maximum',v_pilot.maximum_order_count)); END IF;
+  IF v_outside_cohort>0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','pilot_cohort','outsideCohortOrders',v_outside_cohort)); END IF;
+  IF v_over_value>0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','order_value_limit','violations',v_over_value,'maximumOrderValueMinor',v_pilot.maximum_order_value_minor)); END IF;
+  IF v_ack_rate<v_ack_min THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','acknowledgement_rate','actualPct',v_ack_rate,'minimumPct',v_ack_min)); END IF;
+  IF v_duplicate_submit>v_duplicate_max THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','duplicate_side_effects','duplicateSubmitExceptions',v_duplicate_submit,'maximum',v_duplicate_max)); END IF;
+  IF v_oversell>v_oversell_max THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','oversell','stockDisappearedExceptions',v_oversell,'maximum',v_oversell_max)); END IF;
+  IF v_delivered=0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','delivery','reason','no_delivered_pilot_order')); END IF;
+  IF v_tracking=0 THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','tracking','reason','no_real_tracking_event')); END IF;
+  IF v_returns>0 AND v_return_incomplete>0 THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','return_refund_recovery','returns',v_returns,'refundCases',v_refunds,'recoveryCases',v_recoveries,'incompleteReturnCases',v_return_incomplete));
+  END IF;
+  IF (v_orders-v_reconciled)>v_financial_max THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','financial_reconciliation','reconciledOrders',v_reconciled,'pilotOrders',v_orders,'maximumUnreconciled',v_financial_max)); END IF;
+  IF v_critical>v_critical_max THEN v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','critical_incidents','open',v_critical,'maximum',v_critical_max)); END IF;
+
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_pilot_evidence e WHERE e.pilot_id=v_pilot.id AND e.evidence_type='buyer_communication') THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','buyer_communication','reason','evidence_missing'));
+  END IF;
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_pilot_evidence e WHERE e.pilot_id=v_pilot.id AND e.evidence_type='operator_escalation') THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','operator_escalation','reason','evidence_missing'));
+  END IF;
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_pilot_evidence e WHERE e.pilot_id=v_pilot.id AND e.evidence_type='kill_switch_test') THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','kill_switch_test','reason','evidence_missing'));
+  END IF;
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_pilot_evidence e WHERE e.pilot_id=v_pilot.id AND e.evidence_type='rollback_recovery_test') THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','rollback_recovery','reason','evidence_missing'));
+  END IF;
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_pilot_evidence e WHERE e.pilot_id=v_pilot.id AND e.evidence_type='incident_path_test') THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','incident_path','reason','evidence_missing'));
+  END IF;
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_pilot_evidence e WHERE e.pilot_id=v_pilot.id AND e.evidence_type='release_snapshot') THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','release_snapshot','reason','exact_release_evidence_missing'));
+  END IF;
+  IF NOT EXISTS(SELECT 1 FROM private.supplier_pilot_evidence e WHERE e.pilot_id=v_pilot.id AND e.evidence_type='duplicate_side_effect_review') THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','duplicate_side_effect_review','reason','evidence_missing'));
+  END IF;
+  IF NOT EXISTS(
+    SELECT 1 FROM private.supplier_commerce_control_audit a
+     WHERE a.operation='pilot' AND a.scope_type='global' AND a.new_enabled=false AND a.created_at>=v_pilot.activated_at
+  ) THEN
+    v_failures:=v_failures||jsonb_build_array(jsonb_build_object('check','kill_switch_control_audit','reason','real_disable_transition_missing'));
+  END IF;
+
+  RETURN jsonb_build_object(
+    'passed',jsonb_array_length(v_failures)=0,
+    'reason',CASE WHEN jsonb_array_length(v_failures)=0 THEN 'controlled_pilot_pass' ELSE 'controlled_pilot_evidence_incomplete' END,
+    'pilotId',v_pilot.id,'orders',v_orders,'acknowledgedOrders',v_acks,'acknowledgementRatePct',v_ack_rate,
+    'deliveredOrders',v_delivered,'trackingEvents',v_tracking,'returnCases',v_returns,'refundCases',v_refunds,
+    'recoveryCases',v_recoveries,'incompleteReturnCases',v_return_incomplete,'reconciledOrders',v_reconciled,
+    'outsideCohortOrders',v_outside_cohort,'orderValueViolations',v_over_value,'duplicateSubmitExceptions',v_duplicate_submit,
+    'oversellExceptions',v_oversell,'openCriticalIncidents',v_critical,'failures',v_failures,
+    'simulatorPassIsNotPilotPass',true,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_supplier_pilot_acceptance_v1(uuid) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_supplier_pilot_acceptance_v1(uuid) TO service_role;
+
+CREATE OR REPLACE FUNCTION public.server_admin_supplier_pilot_status_v1(p_actor_id uuid,p_pilot_id uuid DEFAULT NULL)
+RETURNS jsonb LANGUAGE plpgsql SECURITY DEFINER SET search_path TO '' AS $$
+DECLARE
+  v_pilot private.supplier_pilot_programs%ROWTYPE;
+  v_control private.supplier_commerce_controls%ROWTYPE;
+  v_readiness jsonb;
+  v_acceptance jsonb;
+  v_cohort_count integer:=0;
+BEGIN
+  PERFORM private.require_active_admin_v1(p_actor_id);
+  IF p_pilot_id IS NULL THEN SELECT * INTO v_pilot FROM private.supplier_pilot_programs ORDER BY created_at DESC LIMIT 1;
+  ELSE SELECT * INTO v_pilot FROM private.supplier_pilot_programs WHERE id=p_pilot_id; END IF;
+  SELECT * INTO v_control FROM private.supplier_commerce_controls WHERE operation='pilot' AND scope_type='global' AND scope_ref IS NULL LIMIT 1;
+  IF v_pilot.id IS NULL THEN
+    RETURN jsonb_build_object('exists',false,'pilotControlEnabled',COALESCE(v_control.enabled,false),'globalSupplierCommerceEnabled',false,'interfaceVersion',1);
+  END IF;
+  SELECT count(*)::integer INTO v_cohort_count FROM private.supplier_pilot_cohort_members WHERE pilot_id=v_pilot.id;
+  v_readiness:=public.server_supplier_pilot_activation_readiness_v1(v_pilot.id);
+  v_acceptance:=CASE WHEN v_pilot.activated_at IS NULL THEN jsonb_build_object('passed',false,'reason','pilot_not_activated','interfaceVersion',1) ELSE public.server_supplier_pilot_acceptance_v1(v_pilot.id) END;
+  RETURN jsonb_build_object(
+    'exists',true,'pilotId',v_pilot.id,'pilotKey',v_pilot.pilot_key,'status',v_pilot.status,
+    'supplierId',v_pilot.supplier_id,'providerKey',v_pilot.provider_key,'cohort',v_pilot.cohort_key,
+    'cohortMemberCount',v_cohort_count,'territory',v_pilot.territory,'pilotControlEnabled',COALESCE(v_control.enabled,false),
+    'globalSupplierCommerceEnabled',(SELECT COALESCE(enabled,false) FROM private.supplier_commerce_controls WHERE operation='*' AND scope_type='global' AND scope_ref IS NULL LIMIT 1),
+    'readiness',v_readiness,'acceptance',v_acceptance,'simulatorPassIsNotPilotPass',true,'interfaceVersion',1
+  );
+END;
+$$;
+REVOKE ALL ON FUNCTION public.server_admin_supplier_pilot_status_v1(uuid,uuid) FROM PUBLIC,anon,authenticated;
+GRANT EXECUTE ON FUNCTION public.server_admin_supplier_pilot_status_v1(uuid,uuid) TO service_role;
+
+COMMENT ON TABLE private.supplier_pilot_cohort_members IS 'Phase O explicit buyer cohort allowlist. Membership is append-only and enforced before supplier reservation.';
+COMMENT ON FUNCTION public.server_supplier_pilot_activation_readiness_v1(uuid) IS 'Phase O activation gate combining core supplier/offer readiness with passed simulator evidence, explicit buyer cohort, pilot master control and global-off proof.';
+COMMENT ON FUNCTION private.guard_supplier_pilot_cohort_reservation_v1() IS 'Hard Phase O order boundary: active-pilot supplier reservations require the canonical order buyer to be in the explicit pilot cohort.';
+COMMENT ON FUNCTION public.server_supplier_pilot_acceptance_v1(uuid) IS 'Phase O no-fake-pass gate. Requires real pilot orders, cohort containment, tracking/delivery, conditional return/refund/recovery closure, uppercase canonical financial reconciliation, kill-switch/recovery/incident/release evidence and no relevant critical failures.';


### PR DESCRIPTION
## Purpose

Add the production-safe Phase O Controlled Pilot boundary without declaring Pilot PASS and without globally enabling Supplier Commerce.

## Verified base / head

- base `main`: `35265d9eafb394822b3933298a9c1e44f9143303`
- tested head: `ff74f02379c355009f6e88031ef8eafd2fb56f88`
- Branch Guard: ahead 4 / behind 0

## Exact scope

- private bounded pilot programme, offer allowlist, explicit buyer cohort, evidence and audit records;
- admin-only lifecycle boundary;
- factual Phase N simulator prerequisite and provider/adapter/catalog/stock/price readiness gates;
- cohort enforcement at reservation;
- real controlled-pilot acceptance evidence and no-fake-PASS completion gate.

## Safety invariants

- existing global Supplier Commerce controls remain OFF / fail-closed;
- the new `pilot` control defaults OFF;
- no global activation;
- simulator PASS remains distinct from Controlled Pilot PASS;
- no Workspace or Super Admin visual changes;
- no PR #529 changes;
- no Phase P work.

## Branch Guard

Exactly 7 Phase O files: 2 dedicated tests, 1 admin server function and migrations 665–668. No unrelated files.

## Validation evidence

PowerShell at tested HEAD `ff74f02379c355009f6e88031ef8eafd2fb56f88`: Phase O dedicated tests PASS; upstream C–N PASS; TypeScript PASS; lint PASS; build PASS; full suite retains the known 27-failure baseline with no Phase O regression family.

## Status discipline

**IMPLEMENTATION PASS ≠ CONTROLLED PILOT PASS.** This PR cannot be used to claim Phase O PASS. A real bounded production pilot and complete acceptance evidence remain mandatory before closeout or Phase P.