### PR TITLE
Fix Phase O PostgreSQL record assignment

### DIFF
--- a/supabase/665_supplier_controlled_pilot.sql
+++ b/supabase/665_supplier_controlled_pilot.sql
@@ -236,7 +236,7 @@ BEGIN
     RETURN jsonb_build_object('enabled',false,'reason','pilot_supplier_scope_required','interfaceVersion',1);
   END IF;
 
-  SELECT p,s INTO v_pilot,v_supplier
+  SELECT p.* INTO v_pilot
     FROM private.supplier_pilot_programs p
     JOIN private.supplier_foundation_suppliers s ON s.id=p.supplier_id
    WHERE p.status IN ('preparing','active')
@@ -248,6 +248,9 @@ BEGIN
   IF NOT FOUND THEN
     RETURN jsonb_build_object('enabled',false,'reason','pilot_scope_not_allowlisted','interfaceVersion',1);
   END IF;
+  SELECT * INTO v_supplier
+    FROM private.supplier_foundation_suppliers
+   WHERE id=v_pilot.supplier_id;
 
   IF v_pilot.status='preparing' AND v_operation NOT IN ('import','stock_sync','price_sync') THEN
     RETURN jsonb_build_object('enabled',false,'reason','pilot_not_active','pilotId',v_pilot.id,'interfaceVersion',1);

--- a/supabase/666_supplier_controlled_pilot_closure.sql
+++ b/supabase/666_supplier_controlled_pilot_closure.sql
@@ -38,7 +38,7 @@ BEGIN
   -- Reservation, tracking and return paths carry an approved offer identity,
   -- so derive the supplier only from the exact allowlisted offer when present.
   IF v_offer_ref IS NOT NULL THEN
-    SELECT p,s,o INTO v_pilot,v_supplier,v_offer
+    SELECT p.* INTO v_pilot
       FROM private.supplier_pilot_programs p
       JOIN private.supplier_foundation_suppliers s ON s.id=p.supplier_id
       JOIN private.supplier_pilot_offers po ON po.pilot_id=p.id
@@ -57,7 +57,7 @@ BEGIN
     IF v_supplier_ref IS NULL THEN
       RETURN jsonb_build_object('enabled',false,'reason','pilot_supplier_or_offer_scope_required','interfaceVersion',1);
     END IF;
-    SELECT p,s INTO v_pilot,v_supplier
+    SELECT p.* INTO v_pilot
       FROM private.supplier_pilot_programs p
       JOIN private.supplier_foundation_suppliers s ON s.id=p.supplier_id
      WHERE p.status IN ('preparing','active')
@@ -70,6 +70,20 @@ BEGIN
 
   IF v_pilot.id IS NULL THEN
     RETURN jsonb_build_object('enabled',false,'reason','pilot_scope_not_allowlisted','interfaceVersion',1);
+  END IF;
+  SELECT * INTO v_supplier
+    FROM private.supplier_foundation_suppliers
+   WHERE id=v_pilot.supplier_id;
+  IF v_offer_ref IS NOT NULL THEN
+    SELECT o.* INTO v_offer
+      FROM private.supplier_pilot_offers po
+      JOIN private.supplier_offers o ON o.id=po.supplier_offer_id
+     WHERE po.pilot_id=v_pilot.id
+       AND v_offer_ref IN (o.id::text,o.offer_key)
+       AND o.supplier_id=v_pilot.supplier_id
+       AND o.territory=v_pilot.territory
+       AND o.status='approved'
+     LIMIT 1;
   END IF;
 
   IF v_pilot.status='preparing' AND v_operation NOT IN ('import','stock_sync','price_sync') THEN


### PR DESCRIPTION
## Root cause

Production migration execution exposed PostgreSQL `42601: record variable cannot be part of multiple-item INTO list` in Phase O migrations 665 and 666. Static source tests had not executed the function bodies against PostgreSQL.

## Fix

Select each `%ROWTYPE` record independently while preserving the exact allowlist, supplier, provider, cohort, territory and approved-offer predicates.

## Scope

- `supabase/665_supplier_controlled_pilot.sql`
- `supabase/666_supplier_controlled_pilot_closure.sql`

No UI, Workspace, Super Admin, PR #529 or global Supplier Commerce control changes.

## Real verification

Corrected 665 and 666, followed by unchanged 667 and 668, applied successfully to production Supabase in canonical order. All controls remain subject to post-deploy fail-closed verification. Phase O remains open; implementation deployment is not Controlled Pilot PASS.