### PR TITLE
Fix Stage 2 function execute privileges

### DIFF
--- a/supabase/671_identity_function_execute_privilege_closure.sql
+++ b/supabase/671_identity_function_execute_privilege_closure.sql
@@ -1,0 +1,56 @@
+-- 671_identity_function_execute_privilege_closure.sql
+-- Stage 2 hosted security closure.
+--
+-- Supabase production default privileges grant EXECUTE directly to anon and
+-- authenticated for newly created public functions. REVOKE FROM PUBLIC alone
+-- therefore does not remove those explicit grants. Close only the Stage 2
+-- functions whose direct execution surface is not intended.
+
+REVOKE ALL ON FUNCTION public.has_account_capability(text)
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.has_account_capability(text)
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.is_seller()
+  FROM PUBLIC, anon;
+GRANT EXECUTE ON FUNCTION public.is_seller()
+  TO authenticated, service_role;
+
+REVOKE ALL ON FUNCTION public.sync_legacy_role_to_account_capabilities()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.sync_legacy_role_to_account_capabilities()
+  TO service_role;
+
+REVOKE ALL ON FUNCTION public.handle_new_user_profile()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.handle_new_user_profile()
+  TO service_role;
+
+DO $$
+BEGIN
+  IF has_function_privilege('anon', 'public.has_account_capability(text)', 'EXECUTE') THEN
+    RAISE EXCEPTION '671 privilege closure failed: anon can execute has_account_capability';
+  END IF;
+
+  IF NOT has_function_privilege('authenticated', 'public.has_account_capability(text)', 'EXECUTE') THEN
+    RAISE EXCEPTION '671 privilege closure failed: authenticated cannot execute has_account_capability';
+  END IF;
+
+  IF has_function_privilege('anon', 'public.is_seller()', 'EXECUTE') THEN
+    RAISE EXCEPTION '671 privilege closure failed: anon can execute is_seller';
+  END IF;
+
+  IF NOT has_function_privilege('authenticated', 'public.is_seller()', 'EXECUTE') THEN
+    RAISE EXCEPTION '671 privilege closure failed: authenticated cannot execute is_seller';
+  END IF;
+
+  IF has_function_privilege('anon', 'public.sync_legacy_role_to_account_capabilities()', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.sync_legacy_role_to_account_capabilities()', 'EXECUTE') THEN
+    RAISE EXCEPTION '671 privilege closure failed: client role can execute legacy capability sync trigger helper';
+  END IF;
+
+  IF has_function_privilege('anon', 'public.handle_new_user_profile()', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.handle_new_user_profile()', 'EXECUTE') THEN
+    RAISE EXCEPTION '671 privilege closure failed: client role can execute profile trigger helper';
+  END IF;
+END $$;


### PR DESCRIPTION
## Purpose
Close the hosted Stage 2 function EXECUTE privilege regression discovered during post-deploy Supabase Security Advisor verification.

## Root cause
Production default privileges grant EXECUTE directly to `anon` / `authenticated` for newly created public functions. Stage 2 migration 669 revoked `PUBLIC` for `has_account_capability(text)` and `is_seller()`, but that does not remove direct role grants. The new trigger helper `sync_legacy_role_to_account_capabilities()` also inherited direct client EXECUTE grants.

## Scope
One migration only: `supabase/671_identity_function_execute_privilege_closure.sql`.

It:
- removes `anon` EXECUTE from `has_account_capability(text)` and preserves authenticated/service_role use;
- removes `anon` EXECUTE from `is_seller()` and preserves authenticated/service_role use;
- removes client EXECUTE from `sync_legacy_role_to_account_capabilities()`;
- explicitly keeps `handle_new_user_profile()` non-callable by client roles;
- includes fail-closed SQL assertions.

## Evidence
Hosted Stage 2 deployment itself succeeded:
- Phase O GB adapter guard applied;
- Identity 669 applied;
- Identity 670 applied;
- account_capabilities RLS enabled;
- authenticated table access is SELECT-only;
- seller activation RPC is service_role-only;
- Buyer/Seller capability backfill correct;
- Admin active ordinary capabilities = 0;
- non-ready active seller stores reduced from 1 to 0;
- Supplier Commerce controls remain 0 enabled.

Security Advisor then exposed this direct-function privilege issue, so hosted verification remains HOLD until this closure is merged/deployed and re-verified.

## Branch Guard
Base: `main@97bea01608cb3641f01c8be8b4029d2ac2dc9768`
Head: `ae953c0ef12d9dd12c1844f4a9d81feb64780be4`
Ahead 1 / behind 0 / exactly 1 changed file.

Do not merge automatically; separate merge authorization required.