### PR TITLE
Stage 3: Seller Onboarding V2

### DIFF
--- a/netlify/functions/__tests__/seller-onboarding.test.ts
+++ b/netlify/functions/__tests__/seller-onboarding.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildStoreSlug,
+  deriveSellerOnboardingReadiness,
+  legacyAccountTypeForSellerType,
+  parseSellerType,
+} from '../_shared/sellerOnboarding';
+
+describe('seller onboarding V2 readiness', () => {
+  it('accepts only canonical Marketplace Seller types', () => {
+    expect(parseSellerType('individual')).toBe('individual');
+    expect(parseSellerType('sole_trader')).toBe('sole_trader');
+    expect(parseSellerType('company')).toBe('company');
+    expect(parseSellerType('business')).toBeNull();
+    expect(parseSellerType('supplier')).toBeNull();
+  });
+
+  it('keeps the legacy accountType projection compatibility-only', () => {
+    expect(legacyAccountTypeForSellerType('individual')).toBe('individual');
+    expect(legacyAccountTypeForSellerType('sole_trader')).toBe('business');
+    expect(legacyAccountTypeForSellerType('company')).toBe('business');
+  });
+
+  it('creates deterministic store slugs without trusting display names as identifiers', () => {
+    expect(buildStoreSlug('Daniel’s UK Store', '12345678-aaaa-bbbb-cccc-dddddddddddd'))
+      .toBe('daniel-s-uk-store-12345678');
+  });
+
+  it('does not let Stripe gate marketplace setup completion', () => {
+    const state = deriveSellerOnboardingReadiness({
+      sellerType: 'sole_trader',
+      profileComplete: true,
+      storeName: 'Loadify Seller',
+      productCount: 1,
+      sellerStatus: 'submitted',
+      stripeConnectStatus: null,
+      stripeChargesEnabled: false,
+      stripePayoutsEnabled: false,
+      requiresAdminApproval: false,
+      isApproved: false,
+    });
+
+    expect(state.setupComplete).toBe(true);
+    expect(state.stripeReady).toBe(false);
+    expect(state.sellerActive).toBe(false);
+    expect(state.nextStep).toBe(5);
+  });
+
+  it('requires a product catalogue row rather than legacy service capability', () => {
+    const state = deriveSellerOnboardingReadiness({
+      sellerType: 'individual',
+      profileComplete: true,
+      storeName: 'Seller Store',
+      productCount: 0,
+      sellerStatus: 'draft',
+      stripeConnectStatus: 'active',
+      stripeChargesEnabled: true,
+      stripePayoutsEnabled: true,
+      requiresAdminApproval: false,
+      isApproved: false,
+    });
+
+    expect(state.setupComplete).toBe(false);
+    expect(state.nextStep).toBe(4);
+  });
+
+  it('keeps company review separate from Stripe readiness', () => {
+    const state = deriveSellerOnboardingReadiness({
+      sellerType: 'company',
+      profileComplete: true,
+      storeName: 'Company Store',
+      productCount: 2,
+      sellerStatus: 'submitted',
+      stripeConnectStatus: 'active',
+      stripeChargesEnabled: true,
+      stripePayoutsEnabled: true,
+      requiresAdminApproval: true,
+      isApproved: false,
+    });
+
+    expect(state.setupComplete).toBe(true);
+    expect(state.stripeReady).toBe(true);
+    expect(state.adminReviewPending).toBe(true);
+    expect(state.sellerActive).toBe(false);
+  });
+});

--- a/netlify/functions/_shared/sellerOnboarding.ts
+++ b/netlify/functions/_shared/sellerOnboarding.ts
@@ -1,0 +1,91 @@
+export const SELLER_TYPES = ['individual', 'sole_trader', 'company'] as const;
+export type SellerType = (typeof SELLER_TYPES)[number];
+
+export function parseSellerType(value: unknown): SellerType | null {
+  return typeof value === 'string' && (SELLER_TYPES as readonly string[]).includes(value)
+    ? (value as SellerType)
+    : null;
+}
+
+export function legacyAccountTypeForSellerType(type: SellerType): 'individual' | 'business' {
+  return type === 'individual' ? 'individual' : 'business';
+}
+
+export function buildStoreSlug(storeName: string, userId: string): string {
+  const base = storeName
+    .trim()
+    .toLowerCase()
+    .normalize('NFKD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 48);
+  const suffix = userId.replace(/-/g, '').slice(0, 8).toLowerCase();
+  return `${base || 'store'}-${suffix}`;
+}
+
+export interface SellerOnboardingFacts {
+  sellerType: string | null;
+  profileComplete: boolean;
+  storeName: string | null;
+  productCount: number;
+  sellerStatus: string | null;
+  stripeConnectStatus: string | null;
+  stripeChargesEnabled: boolean;
+  stripePayoutsEnabled: boolean;
+  requiresAdminApproval: boolean;
+  isApproved: boolean;
+}
+
+export interface SellerOnboardingReadiness {
+  sellerTypeReady: boolean;
+  profileReady: boolean;
+  storeReady: boolean;
+  catalogueReady: boolean;
+  setupComplete: boolean;
+  stripeReady: boolean;
+  adminReviewPending: boolean;
+  sellerActive: boolean;
+  nextStep: 1 | 2 | 3 | 4 | 5;
+}
+
+export function deriveSellerOnboardingReadiness(
+  facts: SellerOnboardingFacts,
+): SellerOnboardingReadiness {
+  const sellerTypeReady = parseSellerType(facts.sellerType) !== null;
+  const profileReady = facts.profileComplete;
+  const storeReady = Boolean(facts.storeName?.trim());
+  const catalogueReady = facts.productCount > 0;
+  const setupComplete = sellerTypeReady && profileReady && storeReady && catalogueReady;
+  const stripeReady =
+    facts.stripeConnectStatus === 'active' &&
+    facts.stripeChargesEnabled &&
+    facts.stripePayoutsEnabled;
+  const adminReviewPending =
+    facts.requiresAdminApproval &&
+    !facts.isApproved &&
+    facts.sellerStatus !== 'active';
+  const sellerActive = facts.sellerStatus === 'active';
+
+  const nextStep: 1 | 2 | 3 | 4 | 5 = !sellerTypeReady
+    ? 1
+    : !profileReady
+      ? 2
+      : !storeReady
+        ? 3
+        : !catalogueReady
+          ? 4
+          : 5;
+
+  return {
+    sellerTypeReady,
+    profileReady,
+    storeReady,
+    catalogueReady,
+    setupComplete,
+    stripeReady,
+    adminReviewPending,
+    sellerActive,
+    nextStep,
+  };
+}

--- a/netlify/functions/connect-status.ts
+++ b/netlify/functions/connect-status.ts
@@ -9,6 +9,8 @@ import { authenticateActiveAccount } from './_shared/activeAccountAuth';
  * Fetches the live Stripe Connect account status for the authenticated active
  * seller and persists the result in seller_profiles.stripeConnectStatus.
  * Stripe Account location is also persisted as server-only tax evidence.
+ *
+ * Stage 3 invariant: Stripe readiness never creates or completes store identity.
  */
 export const handler: Handler = async (event) => {
   if (event.httpMethod !== 'POST') {
@@ -126,9 +128,7 @@ export const handler: Handler = async (event) => {
       stripeUpdate.taxCountrySource = 'stripe_connect_account_v1';
       stripeUpdate.taxCountryCapturedAt = new Date().toISOString();
     }
-    if (stripeConnectStatus === 'active') {
-      stripeUpdate.storeCreated = true;
-    }
+
     const { error: stripeStatusUpdateError } = await supabase
       .from('seller_profiles')
       .update(stripeUpdate)

--- a/netlify/functions/seller-onboarding-status.ts
+++ b/netlify/functions/seller-onboarding-status.ts
@@ -1,0 +1,182 @@
+import type { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { isProfileComplete, tryAutoActivateSeller } from './_shared/sellerActivation';
+import { deriveSellerOnboardingReadiness } from './_shared/sellerOnboarding';
+
+/**
+ * POST /.netlify/functions/seller-onboarding-status
+ *
+ * Returns the canonical Marketplace Seller onboarding/readiness snapshot and
+ * reconciles server-managed progress projections from persisted facts.
+ *
+ * This endpoint intentionally separates:
+ *   - marketplace setup completion (seller type + legal profile + store + product)
+ *   - commercial activation (sellerStatus + Stripe + optional admin approval)
+ */
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  const supabaseUrl = process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    return { statusCode: 503, body: JSON.stringify({ error: 'Server misconfiguration' }) };
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const auth = await authenticateActiveAccount(event, supabase, ['seller']);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({
+        error: auth.status === 401 ? 'Authentication required' : 'Active Marketplace Seller account required',
+      }),
+    };
+  }
+
+  const sellerId = auth.actor.id;
+
+  try {
+    const [profileRes, storeRes, productRes] = await Promise.all([
+      supabase
+        .from('seller_profiles')
+        .select(
+          'sellerType, sellerStatus, isApproved, requiresAdminApproval, storeName, businessName, contactPhone, businessAddress, companyRegistrationNumber, vatNumber, isVatRegistered, profileCompleted, storeCreated, firstProductCreated, stripeAccountId, stripeConnectStatus, stripeChargesEnabled, stripePayoutsEnabled, stripeDetailsSubmitted',
+        )
+        .eq('userId', sellerId)
+        .maybeSingle(),
+      supabase
+        .from('seller_stores')
+        .select('storeName, storeSlug, storeDescription')
+        .eq('userId', sellerId)
+        .maybeSingle(),
+      supabase
+        .from('products')
+        .select('id', { count: 'exact', head: true })
+        .eq('sellerId', sellerId),
+    ]);
+
+    if (profileRes.error || !profileRes.data) {
+      return { statusCode: 409, body: JSON.stringify({ error: 'Seller profile is not available' }) };
+    }
+    if (storeRes.error) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'Unable to verify store identity' }) };
+    }
+    if (productRes.error) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'Unable to verify catalogue readiness' }) };
+    }
+
+    const profile = profileRes.data as {
+      sellerType: string | null;
+      sellerStatus: string | null;
+      isApproved: boolean | null;
+      requiresAdminApproval: boolean | null;
+      storeName: string | null;
+      businessName: string | null;
+      contactPhone: string | null;
+      businessAddress: { postcode?: string } | null;
+      companyRegistrationNumber: string | null;
+      vatNumber: string | null;
+      isVatRegistered: boolean | null;
+      profileCompleted: boolean | null;
+      storeCreated: boolean | null;
+      firstProductCreated: boolean | null;
+      stripeAccountId: string | null;
+      stripeConnectStatus: string | null;
+      stripeChargesEnabled: boolean | null;
+      stripePayoutsEnabled: boolean | null;
+      stripeDetailsSubmitted: boolean | null;
+    };
+
+    const store = storeRes.data as {
+      storeName: string | null;
+      storeSlug: string | null;
+      storeDescription: string | null;
+    } | null;
+
+    const profileComplete = isProfileComplete(profile, profile.sellerType);
+    const storeReady = Boolean(store?.storeName?.trim());
+    const productCount = productRes.count ?? 0;
+    const catalogueReady = productCount > 0;
+
+    // Server-owned projection flags. These are compatibility fields consumed by
+    // historical triggers/routes; Stage 3 UI derives readiness from the same
+    // underlying facts rather than trusting browser-written booleans.
+    const { error: reconcileError } = await supabase
+      .from('seller_profiles')
+      .update({
+        profileCompleted: profileComplete,
+        storeCreated: storeReady,
+        firstProductCreated: catalogueReady,
+      })
+      .eq('userId', sellerId);
+
+    if (reconcileError) {
+      console.error('seller-onboarding-status: reconciliation failed:', reconcileError.message);
+      return { statusCode: 500, body: JSON.stringify({ error: 'Unable to reconcile onboarding progress' }) };
+    }
+
+    // Re-evaluate commercial activation separately. Stripe remains a technical
+    // payment/readiness signal only and never becomes a claim of Loadify KYC.
+    const activation = await tryAutoActivateSeller(supabase, sellerId);
+    const sellerStatus = activation?.sellerStatus ?? profile.sellerStatus ?? 'draft';
+
+    const { data: userState, error: userStateError } = await supabase
+      .from('users')
+      .select('onboardingCompleted, onboardingStep')
+      .eq('id', sellerId)
+      .maybeSingle<{ onboardingCompleted: boolean | null; onboardingStep: number | null }>();
+
+    if (userStateError) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'Unable to verify onboarding completion' }) };
+    }
+
+    const readiness = deriveSellerOnboardingReadiness({
+      sellerType: profile.sellerType,
+      profileComplete,
+      storeName: store?.storeName ?? null,
+      productCount,
+      sellerStatus,
+      stripeConnectStatus: profile.stripeConnectStatus,
+      stripeChargesEnabled: Boolean(profile.stripeChargesEnabled),
+      stripePayoutsEnabled: Boolean(profile.stripePayoutsEnabled),
+      requiresAdminApproval: Boolean(profile.requiresAdminApproval),
+      isApproved: Boolean(profile.isApproved),
+    });
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        sellerType: profile.sellerType,
+        sellerStatus,
+        requiresAdminApproval: Boolean(profile.requiresAdminApproval),
+        isApproved: Boolean(profile.isApproved),
+        profileComplete,
+        store: {
+          storeName: store?.storeName ?? '',
+          storeSlug: store?.storeSlug ?? '',
+          storeDescription: store?.storeDescription ?? '',
+        },
+        productCount,
+        stripe: {
+          connected: Boolean(profile.stripeAccountId || profile.stripeConnectStatus),
+          status: profile.stripeConnectStatus,
+          chargesEnabled: Boolean(profile.stripeChargesEnabled),
+          payoutsEnabled: Boolean(profile.stripePayoutsEnabled),
+          detailsSubmitted: Boolean(profile.stripeDetailsSubmitted),
+        },
+        onboardingCompleted: Boolean(userState?.onboardingCompleted),
+        onboardingStep: userState?.onboardingStep ?? 0,
+        readiness,
+      }),
+    };
+  } catch (error) {
+    console.error('seller-onboarding-status error:', error);
+    return { statusCode: 500, body: JSON.stringify({ error: 'Unable to load Seller setup status' }) };
+  }
+};

--- a/netlify/functions/set-seller-onboarding.ts
+++ b/netlify/functions/set-seller-onboarding.ts
@@ -1,0 +1,198 @@
+import type { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+import { authenticateActiveAccount } from './_shared/activeAccountAuth';
+import { getFeatureFlagsStrict } from './_shared/platformFlags';
+import {
+  buildStoreSlug,
+  legacyAccountTypeForSellerType,
+  parseSellerType,
+} from './_shared/sellerOnboarding';
+
+type SellerOnboardingAction = 'seller_type' | 'store_identity';
+
+/**
+ * POST /.netlify/functions/set-seller-onboarding
+ *
+ * Trusted Stage 3 mutation boundary for fields that must not be directly
+ * client-governed. It does not modify sellerStatus, Stripe readiness, Supplier
+ * Commerce, or Admin state.
+ */
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  const supabaseUrl = process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!supabaseUrl || !serviceRoleKey) {
+    return { statusCode: 503, body: JSON.stringify({ error: 'Server misconfiguration' }) };
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const auth = await authenticateActiveAccount(event, supabase, ['seller']);
+  if (!auth.ok) {
+    return {
+      statusCode: auth.status,
+      body: JSON.stringify({
+        error: auth.status === 401 ? 'Authentication required' : 'Active Marketplace Seller account required',
+      }),
+    };
+  }
+
+  let body: Record<string, unknown>;
+  try {
+    body = JSON.parse(event.body || '{}') as Record<string, unknown>;
+  } catch {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid JSON body' }) };
+  }
+
+  const action = body.action as SellerOnboardingAction | undefined;
+  const sellerId = auth.actor.id;
+
+  if (action === 'seller_type') {
+    const sellerType = parseSellerType(body.sellerType);
+    if (!sellerType) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'sellerType must be individual, sole_trader, or company' }),
+      };
+    }
+
+    const { data: current, error: currentError } = await supabase
+      .from('seller_profiles')
+      .select('sellerType, sellerStatus, requiresAdminApproval, isApproved')
+      .eq('userId', sellerId)
+      .maybeSingle<{
+        sellerType: string | null;
+        sellerStatus: string | null;
+        requiresAdminApproval: boolean | null;
+        isApproved: boolean | null;
+      }>();
+
+    if (currentError || !current) {
+      return { statusCode: 409, body: JSON.stringify({ error: 'Seller profile is not available' }) };
+    }
+    if (current.sellerStatus === 'suspended') {
+      return { statusCode: 403, body: JSON.stringify({ error: 'Suspended Seller accounts cannot change onboarding identity' }) };
+    }
+    if (
+      current.sellerStatus === 'active' &&
+      current.sellerType &&
+      current.sellerType !== sellerType
+    ) {
+      return {
+        statusCode: 409,
+        body: JSON.stringify({ error: 'Active Sellers must contact support to change their legal seller type' }),
+      };
+    }
+
+    let requireCompanyApproval = false;
+    if (current.sellerStatus !== 'active') {
+      try {
+        const flags = await getFeatureFlagsStrict(supabase);
+        requireCompanyApproval = sellerType === 'company' && flags.requireCompanyApproval;
+      } catch (error) {
+        console.error('set-seller-onboarding: feature flags unavailable:', error);
+        return {
+          statusCode: 503,
+          body: JSON.stringify({ error: 'Seller approval policy could not be verified. Please try again later.' }),
+        };
+      }
+    }
+
+    const update: Record<string, unknown> = {
+      sellerType,
+      accountType: legacyAccountTypeForSellerType(sellerType),
+    };
+
+    // Do not retroactively change approval policy for historical active sellers.
+    if (current.sellerStatus !== 'active') {
+      update.requiresAdminApproval = requireCompanyApproval;
+      if (requireCompanyApproval) update.isApproved = false;
+    }
+
+    const { error } = await supabase
+      .from('seller_profiles')
+      .update(update)
+      .eq('userId', sellerId);
+
+    if (error) {
+      console.error('set-seller-onboarding seller_type:', error.message);
+      return { statusCode: 500, body: JSON.stringify({ error: 'Unable to save Seller type' }) };
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({
+        ok: true,
+        sellerType,
+        requiresAdminApproval:
+          current.sellerStatus === 'active'
+            ? Boolean(current.requiresAdminApproval)
+            : requireCompanyApproval,
+      }),
+    };
+  }
+
+  if (action === 'store_identity') {
+    const storeName = typeof body.storeName === 'string' ? body.storeName.trim() : '';
+    const storeDescription = typeof body.storeDescription === 'string'
+      ? body.storeDescription.trim()
+      : '';
+
+    if (storeName.length < 2 || storeName.length > 80) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'Store name must be between 2 and 80 characters' }),
+      };
+    }
+    if (storeDescription.length > 1000) {
+      return {
+        statusCode: 400,
+        body: JSON.stringify({ error: 'Store description must be 1000 characters or fewer' }),
+      };
+    }
+
+    const { data: existing, error: existingError } = await supabase
+      .from('seller_stores')
+      .select('storeSlug')
+      .eq('userId', sellerId)
+      .maybeSingle<{ storeSlug: string | null }>();
+
+    if (existingError) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'Unable to load store identity' }) };
+    }
+
+    const storeSlug = existing?.storeSlug?.trim() || buildStoreSlug(storeName, sellerId);
+
+    const { error } = await supabase
+      .from('seller_stores')
+      .upsert(
+        {
+          userId: sellerId,
+          storeName,
+          storeSlug,
+          storeDescription,
+        },
+        { onConflict: 'userId' },
+      );
+
+    if (error) {
+      console.error('set-seller-onboarding store_identity:', error.message);
+      return { statusCode: 500, body: JSON.stringify({ error: 'Unable to save store identity' }) };
+    }
+
+    return {
+      statusCode: 200,
+      body: JSON.stringify({ ok: true, storeName, storeSlug, storeDescription }),
+    };
+  }
+
+  return {
+    statusCode: 400,
+    body: JSON.stringify({ error: 'Unsupported onboarding action' }),
+  };
+};

--- a/src/components/auth/RequireSeller.tsx
+++ b/src/components/auth/RequireSeller.tsx
@@ -20,6 +20,10 @@ const CardShell = ({ children }: { children: ReactNode }) => (
   </div>
 );
 
+function isOnboardingCatalogueRoute(pathname: string): boolean {
+  return /^\/seller\/products\/(?:new|[^/]+\/edit)$/.test(pathname);
+}
+
 /**
  * Active seller workspace guard.
  *
@@ -28,11 +32,17 @@ const CardShell = ({ children }: { children: ReactNode }) => (
  * falls back to session metadata because user_metadata is user-editable.
  * Admin bypass is allowed only through hasAdminAccess(), which itself requires
  * DB-hydrated isAdmin=true.
+ *
+ * Stage 3 exception: draft/submitted Marketplace Sellers may enter only the
+ * product create/edit route so they can prepare a catalogue draft during
+ * onboarding. The server create/update endpoints independently forbid public
+ * publishing until sellerStatus + Stripe + tax readiness are satisfied.
  */
 export default function RequireSeller({ children }: Props) {
   const { user, isLoading } = useAuthStore();
   const navigate = useNavigate();
   const location = useLocation();
+  const allowOnboardingCatalogue = isOnboardingCatalogueRoute(location.pathname);
 
   useEffect(() => {
     if (!isLoading && !user) {
@@ -71,8 +81,6 @@ export default function RequireSeller({ children }: Props) {
     let cancelled = false;
 
     const verifySeller = async () => {
-      // Always resolve missing/draft/submitted state against the canonical DB.
-      // This prevents session metadata from being enough to unlock the workspace.
       const { data, error } = await supabase
         .from('seller_profiles')
         .select('sellerStatus')
@@ -90,7 +98,6 @@ export default function RequireSeller({ children }: Props) {
         console.warn('RequireSeller: seller status query failed; using server recheck', error.message);
       }
 
-      // Server recheck uses service-role-backed canonical activation conditions.
       try {
         const response = await authorizedFetch('/.netlify/functions/recheck-activation', { method: 'POST' });
         if (response.ok) {
@@ -165,6 +172,15 @@ export default function RequireSeller({ children }: Props) {
     );
   }
 
+  // Narrow Stage 3 exception: catalogue drafts can be prepared before seller
+  // commercial activation. No other Seller Workspace route is opened here.
+  if (
+    allowOnboardingCatalogue &&
+    (fetchState === 'draft' || fetchState === 'submitted')
+  ) {
+    return <>{children}</>;
+  }
+
   if (fetchState === 'draft') return <Navigate to="/onboarding" replace />;
 
   if (fetchState === 'submitted') {
@@ -172,9 +188,9 @@ export default function RequireSeller({ children }: Props) {
       <CardShell>
         <p className="text-5xl mb-4">⏳</p>
         <h2 className="text-2xl font-bold text-white mb-2">Application Under Review</h2>
-        <p className="text-slate-400 mb-6">Your seller application has been submitted and is awaiting approval.</p>
+        <p className="text-slate-400 mb-6">Your seller application has been submitted and is awaiting approval or remaining activation requirements.</p>
         <div className="flex flex-col sm:flex-row gap-3 justify-center">
-          <Link to="/" className="btn-primary">Back to Home</Link>
+          <Link to="/onboarding" className="btn-primary">View Seller Setup</Link>
           <Link to="/contact" className="btn-secondary">Contact Support</Link>
         </div>
       </CardShell>

--- a/src/components/auth/RequireSeller.tsx
+++ b/src/components/auth/RequireSeller.tsx
@@ -25,18 +25,23 @@ function isOnboardingCatalogueRoute(pathname: string): boolean {
 }
 
 /**
- * Active seller workspace guard.
+ * Seller workspace guard.
  *
- * Only sellerStatus === 'active' may enter the seller workspace. A missing
- * status is never treated as active. This is important when auth hydration
- * falls back to session metadata because user_metadata is user-editable.
+ * Full Seller Workspace access requires BOTH:
+ *   - sellerStatus === 'active'; and
+ *   - server-managed users.onboardingCompleted === true.
+ *
+ * This keeps commercial activation separate from marketplace setup while
+ * preventing an active seller from bypassing mandatory store/catalogue setup by
+ * navigating directly to /seller.
+ *
  * Admin bypass is allowed only through hasAdminAccess(), which itself requires
  * DB-hydrated isAdmin=true.
  *
- * Stage 3 exception: draft/submitted Marketplace Sellers may enter only the
- * product create/edit route so they can prepare a catalogue draft during
- * onboarding. The server create/update endpoints independently forbid public
- * publishing until sellerStatus + Stripe + tax readiness are satisfied.
+ * Stage 3 exception: draft/submitted/active-but-incomplete Marketplace Sellers
+ * may enter only the product create/edit route so they can prepare a catalogue
+ * draft during onboarding. The server create/update endpoints independently
+ * forbid public publishing until sellerStatus + Stripe + tax readiness pass.
  */
 export default function RequireSeller({ children }: Props) {
   const { user, isLoading } = useAuthStore();
@@ -60,34 +65,71 @@ export default function RequireSeller({ children }: Props) {
     if (user.sellerStatus === 'draft') return 'draft';
     return 'loading';
   });
+  const [onboardingComplete, setOnboardingComplete] = useState<boolean>(
+    () => user?.onboardingCompleted === true,
+  );
+  const [onboardingChecked, setOnboardingChecked] = useState<boolean>(
+    () => Boolean(user && (hasAdminAccess(user) || user.onboardingCompleted === true)),
+  );
 
   useEffect(() => {
     if (!user) return;
     if (hasAdminAccess(user)) {
-      queueMicrotask(() => setFetchState('active'));
+      queueMicrotask(() => {
+        setFetchState('active');
+        setOnboardingComplete(true);
+        setOnboardingChecked(true);
+      });
       return;
     }
     if (!hasSellerAccess(user)) return;
 
-    if (isActiveSellerAccess(user)) {
-      queueMicrotask(() => setFetchState('active'));
+    if (user.sellerStatus === 'suspended') {
+      queueMicrotask(() => {
+        setFetchState('suspended');
+        setOnboardingChecked(true);
+      });
       return;
     }
-    if (user.sellerStatus === 'suspended') {
-      queueMicrotask(() => setFetchState('suspended'));
+
+    // A DB-hydrated true completion flag is safe to reuse. A false value may be
+    // stale within the current session immediately after the Stage 3 server
+    // reconciliation marks onboarding complete, so resolve false/missing state
+    // from the live database before deciding workspace access.
+    if (isActiveSellerAccess(user) && user.onboardingCompleted === true) {
+      queueMicrotask(() => {
+        setFetchState('active');
+        setOnboardingComplete(true);
+        setOnboardingChecked(true);
+      });
       return;
     }
 
     let cancelled = false;
 
     const verifySeller = async () => {
-      const { data, error } = await supabase
-        .from('seller_profiles')
-        .select('sellerStatus')
-        .eq('userId', user.id)
-        .maybeSingle<{ sellerStatus: string | null }>();
+      const [profileRes, userRes] = await Promise.all([
+        supabase
+          .from('seller_profiles')
+          .select('sellerStatus')
+          .eq('userId', user.id)
+          .maybeSingle<{ sellerStatus: string | null }>(),
+        supabase
+          .from('users')
+          .select('onboardingCompleted')
+          .eq('id', user.id)
+          .maybeSingle<{ onboardingCompleted: boolean | null }>(),
+      ]);
 
       if (cancelled) return;
+
+      // Setup completion fails closed on lookup failure. This cannot grant
+      // workspace access; at worst the seller is sent back to onboarding.
+      const setupComplete = !userRes.error && userRes.data?.onboardingCompleted === true;
+      setOnboardingComplete(setupComplete);
+      setOnboardingChecked(true);
+
+      const { data, error } = profileRes;
       if (!error) {
         const dbStatus = data?.sellerStatus;
         if (dbStatus === 'active' || dbStatus === 'suspended') {
@@ -126,6 +168,8 @@ export default function RequireSeller({ children }: Props) {
     void verifySeller().catch((err: unknown) => {
       if (!cancelled) {
         console.warn('RequireSeller: unexpected verification error', err);
+        setOnboardingComplete(false);
+        setOnboardingChecked(true);
         setFetchState('error');
       }
     });
@@ -133,7 +177,10 @@ export default function RequireSeller({ children }: Props) {
     return () => { cancelled = true; };
   }, [user]);
 
-  const loading = isLoading || (user?.role === 'seller' && fetchState === 'loading');
+  const loading = isLoading || (
+    user?.role === 'seller' &&
+    (fetchState === 'loading' || !onboardingChecked)
+  );
 
   if (loading) {
     return (
@@ -172,14 +219,20 @@ export default function RequireSeller({ children }: Props) {
     );
   }
 
-  // Narrow Stage 3 exception: catalogue drafts can be prepared before seller
-  // commercial activation. No other Seller Workspace route is opened here.
+  // Narrow Stage 3 exception: catalogue drafts can be prepared before full
+  // setup/commercial activation. No other Seller Workspace route is opened.
   if (
     allowOnboardingCatalogue &&
-    (fetchState === 'draft' || fetchState === 'submitted')
+    !onboardingComplete &&
+    (fetchState === 'draft' || fetchState === 'submitted' || fetchState === 'active')
   ) {
     return <>{children}</>;
   }
+
+  // Mandatory Stage 3 setup cannot be bypassed through a direct Seller
+  // Workspace URL, even if Stripe/profile facts have already made sellerStatus
+  // active. The onboarding route itself is outside RequireSeller.
+  if (!onboardingComplete) return <Navigate to="/onboarding" replace />;
 
   if (fetchState === 'draft') return <Navigate to="/onboarding" replace />;
 

--- a/src/pages/ProductFormPage.tsx
+++ b/src/pages/ProductFormPage.tsx
@@ -455,54 +455,6 @@ export default function ProductFormPage() {
         }
         const created = await res.json() as { id: string; isApproved: boolean };
 
-        // Mark first product created for onboarding completion tracking.
-        // Non-fatal: onboarding checklist will still derive this from product count.
-        // Fetch all onboarding flags in a single query to avoid extra round trips.
-        const { data: spRow } = await supabase
-          .from('seller_profiles')
-          .select([
-            'firstProductCreated',
-            'profileCompleted',
-            'storeCreated',
-            'hasServiceCapability',
-            'sellerStatus',
-          ].join(', '))
-          .eq('userId', user.id)
-          .maybeSingle<{
-            firstProductCreated: boolean | null;
-            profileCompleted: boolean | null;
-            storeCreated: boolean | null;
-            hasServiceCapability: boolean | null;
-            sellerStatus: string | null;
-          }>();
-
-        if (!spRow?.firstProductCreated) {
-          await supabase
-            .from('seller_profiles')
-            .update({ firstProductCreated: true })
-            .eq('userId', user.id);
-
-          // The DB trigger (trg_sync_seller_onboarding) will auto-set
-          // onboardingCompleted when all other flags are also true.
-          // Force-check here using the flags we already fetched above.
-          // hasServiceCapability will be TRUE after the product insert fires the DB trigger,
-          // so we only gate on profileCompleted + storeCreated + sellerStatus here.
-          if (
-            spRow?.profileCompleted &&
-            spRow?.storeCreated &&
-            spRow?.sellerStatus !== 'suspended' &&
-            spRow?.sellerStatus !== 'rejected'
-          ) {
-            // onboardingStep 8 = all gate flags satisfied (5 wizard UI steps map to
-            // 8 DB sub-steps tracked in seller_profiles; value mirrors ONBOARDING_COMPLETE_STEP
-            // in src/pages/onboarding/SellerOnboarding.tsx).
-            await supabase
-              .from('users')
-              .update({ onboardingCompleted: true, onboardingStep: 8 })
-              .eq('id', user.id);
-          }
-        }
-
         setSuccessMessage(
           publishMode
             ? (created.isApproved
@@ -517,7 +469,7 @@ export default function ProductFormPage() {
       }
 
       // Brief success feedback, then navigate back
-      setTimeout(() => navigate('/seller'), SUCCESS_REDIRECT_DELAY_MS);
+      setTimeout(() => navigate(publishMode ? '/seller' : '/onboarding'), SUCCESS_REDIRECT_DELAY_MS);
     } catch (error) {
       console.error('Error saving product:', error);
       const msg =

--- a/src/pages/onboarding/SellerOnboarding.tsx
+++ b/src/pages/onboarding/SellerOnboarding.tsx
@@ -1,620 +1,509 @@
-import { useState, useEffect } from "react";
-import { useNavigate } from "react-router-dom";
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
 import {
-  CheckCircle2, Circle, ChevronRight, Loader2, ExternalLink,
-  User, Building2, CreditCard, Store, Package
-} from "lucide-react";
-import { Button } from "@/components/ui/button";
-import { supabase } from "@/lib/supabase";
-import { useAuthStore } from "@/store";
-import { hasAdminAccess } from "@/lib/roleUtils";
-import { toast } from "@/hooks/use-toast";
-import { authorizedFetch } from "@/lib/authorizedFetch";
-import { openExternalUrl } from "@/lib/capacitorUtils";
+  Building2,
+  CheckCircle2,
+  Circle,
+  CreditCard,
+  ExternalLink,
+  Loader2,
+  Package,
+  RefreshCw,
+  Store,
+  User,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useAuthStore } from '@/store';
+import { hasAdminAccess } from '@/lib/roleUtils';
+import { toast } from '@/hooks/use-toast';
+import { authorizedFetch } from '@/lib/authorizedFetch';
+import { openExternalUrl } from '@/lib/capacitorUtils';
 
-/** Total number of visible onboarding steps shown in the UI progress flow. */
-const ONBOARDING_TOTAL_STEPS = 5;
-/**
- * Final persisted onboardingStep value written to users.onboardingStep.
- * The DB tracks 8 granular sub-steps (profile/Stripe/shipping/listing flags),
- * while the UI intentionally compresses them into 5 visible steps.
- */
-const ONBOARDING_COMPLETE_SUBSTEP = 8;
+type SellerType = 'individual' | 'sole_trader' | 'company';
 
-/**
- * /onboarding
- *
- * Multi-step seller onboarding wizard. Shown to sellers whose
- * onboardingCompleted flag is false. Admins bypass automatically.
- *
- * Steps:
- *   1 – Account type (individual / business)
- *   2 – Profile details
- *   3 – Stripe Connect
- *   4 – Store + shipping
- *   5 – First product
- *
- * Completion logic: all step-flags must be true → onboardingCompleted=true.
- */
+interface OnboardingReadiness {
+  sellerTypeReady: boolean;
+  profileReady: boolean;
+  storeReady: boolean;
+  catalogueReady: boolean;
+  setupComplete: boolean;
+  stripeReady: boolean;
+  adminReviewPending: boolean;
+  sellerActive: boolean;
+  nextStep: 1 | 2 | 3 | 4 | 5;
+}
 
-interface OnboardingState {
-  accountType: string | null;
-  profileCompleted: boolean;
-  stripeConnectStatus: string | null;
-  stripeChargesEnabled: boolean;
-  stripePayoutsEnabled: boolean;
-  stripeDetailsSubmitted: boolean;
-  storeCreated: boolean;
-  hasServiceCapability: boolean;
+interface OnboardingStatus {
+  sellerType: SellerType | null;
+  sellerStatus: 'draft' | 'submitted' | 'active' | 'suspended' | string;
+  requiresAdminApproval: boolean;
+  isApproved: boolean;
+  profileComplete: boolean;
+  store: {
+    storeName: string;
+    storeSlug: string;
+    storeDescription: string;
+  };
+  productCount: number;
+  stripe: {
+    connected: boolean;
+    status: string | null;
+    chargesEnabled: boolean;
+    payoutsEnabled: boolean;
+    detailsSubmitted: boolean;
+  };
   onboardingCompleted: boolean;
+  onboardingStep: number;
+  readiness: OnboardingReadiness;
 }
 
 const STEPS = [
-  { id: 1, label: "Account type",   icon: User },
-  { id: 2, label: "Profile details", icon: Building2 },
-  { id: 3, label: "Stripe Connect",  icon: CreditCard },
-  { id: 4, label: "Store setup",     icon: Store },
-  { id: 5, label: "First listing",   icon: Package },
-];
+  { id: 1, label: 'Seller type', icon: User },
+  { id: 2, label: 'Business details', icon: Building2 },
+  { id: 3, label: 'Store identity', icon: Store },
+  { id: 4, label: 'Catalogue', icon: Package },
+  { id: 5, label: 'Activation', icon: CreditCard },
+] as const;
 
-function ProgressBar({ current, total }: { current: number; total: number }) {
-  return (
-    <div className="w-full bg-gray-100 rounded-full h-2">
-      <div
-        className="h-2 rounded-full transition-all duration-500 bg-success"
-        style={{
-          width: `${Math.round((current / total) * 100)}%`,
-        }}
-      />
-    </div>
-  );
-}
-
-function StepDot({ step, current, done }: { step: number; current: number; done: boolean }) {
+function StepDot({
+  step,
+  current,
+  done,
+}: {
+  step: number;
+  current: number;
+  done: boolean;
+}) {
   const Icon = STEPS[step - 1].icon;
-  const isActive = step === current;
+  const active = step === current;
   return (
-    <div className={`flex flex-col items-center gap-1 ${step > current && !done ? "opacity-40" : ""}`}>
+    <div className={`flex flex-col items-center gap-1 ${step > current && !done ? 'opacity-45' : ''}`}>
       <div
-        className={`w-9 h-9 rounded-full flex items-center justify-center border-2 transition-all ${
+        className={`flex h-9 w-9 items-center justify-center rounded-full border-2 transition-all ${
           done
-            ? "bg-success border-success text-white"
-            : isActive
-            ? "bg-white border-success text-success"
-            : "bg-white border-gray-200 text-gray-400"
+            ? 'border-success bg-success text-white'
+            : active
+              ? 'border-success bg-white text-success'
+              : 'border-gray-200 bg-white text-gray-400'
         }`}
       >
         {done ? <CheckCircle2 className="h-5 w-5" /> : <Icon className="h-4 w-4" />}
       </div>
-      <span className={`text-[10px] font-medium hidden sm:block ${isActive ? "text-success" : "text-gray-400"}`}>
+      <span className={`hidden text-[10px] font-medium sm:block ${active ? 'text-success' : 'text-gray-400'}`}>
         {STEPS[step - 1].label}
       </span>
     </div>
   );
 }
 
-// ─── Step 1: Account Type ─────────────────────────────────────────────────────
-function StepAccountType({
-  value,
-  onSelect,
-  onNext,
-  saving,
-}: {
-  value: string | null;
-  onSelect: (v: "individual" | "business") => void;
-  onNext: () => void;
-  saving: boolean;
-}) {
+function StatusRow({ label, done, detail }: { label: string; done: boolean; detail?: string }) {
   return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="text-xl font-bold text-gray-900">What type of seller are you?</h2>
-        <p className="text-sm text-gray-500 mt-1">This helps us tailor your experience.</p>
-      </div>
-      <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-        {[
-          { v: "individual" as const, label: "Individual", desc: "Sole trader or private seller" },
-          { v: "business"   as const, label: "Business",   desc: "Registered company or organisation" },
-        ].map(({ v, label, desc }) => (
-          <button
-            key={v}
-            type="button"
-            onClick={() => onSelect(v)}
-            className={`rounded-xl border-2 p-5 text-left transition-all ${
-              value === v
-                ? "border-success bg-success/10"
-                : "border-gray-200 bg-white hover:border-success/40"
-            }`}
-          >
-            <p className="font-semibold text-gray-900">{label}</p>
-            <p className="text-sm text-gray-500 mt-0.5">{desc}</p>
-          </button>
-        ))}
-      </div>
-      <Button
-        onClick={onNext}
-        disabled={!value || saving}
-        className="w-full bg-success hover:bg-success/90 text-white"
-      >
-        {saving ? <Loader2 className="h-4 w-4 animate-spin mr-2" /> : null}
-        Continue <ChevronRight className="h-4 w-4 ml-1" />
-      </Button>
-    </div>
-  );
-}
-
-// ─── Step 2: Profile Details ──────────────────────────────────────────────────
-function StepProfile({
-  done,
-  onNext,
-}: {
-  done: boolean;
-  onNext: () => void;
-}) {
-  return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="text-xl font-bold text-gray-900">Complete your seller profile</h2>
-        <p className="text-sm text-gray-500 mt-1">
-          Add your business name, contact phone, and address so buyers can trust you.
-        </p>
-      </div>
+    <div className="flex items-start gap-3 rounded-xl border border-gray-200 p-4">
       {done ? (
-        <div className="flex items-center gap-3 rounded-xl bg-success/10 border border-success/40 p-4">
-          <CheckCircle2 className="h-5 w-5 text-success shrink-0" />
-          <p className="text-sm text-success font-medium">Profile completed ✓</p>
-        </div>
+        <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-success" />
       ) : (
-        <p className="text-sm text-gray-500">
-          Head to your{" "}
-          <a href="/seller/profile" className="text-success underline font-medium">
-            Seller Profile
-          </a>{" "}
-          page and fill in the required fields.
-        </p>
+        <Circle className="mt-0.5 h-5 w-5 shrink-0 text-gray-300" />
       )}
-      <Button
-        onClick={onNext}
-        disabled={!done}
-        className="w-full bg-success hover:bg-success/90 text-white disabled:opacity-40"
-      >
-        Continue <ChevronRight className="h-4 w-4 ml-1" />
-      </Button>
-      {!done && (
-        <Button asChild variant="outline" className="w-full">
-          <a href="/seller/profile">Go to Profile →</a>
-        </Button>
-      )}
-    </div>
-  );
-}
-
-// ─── Step 3: Stripe Connect ───────────────────────────────────────────────────
-function StepStripe({
-  state,
-  onConnect,
-  onNext,
-  connecting,
-}: {
-  state: OnboardingState;
-  onConnect: () => void;
-  onNext: () => void;
-  connecting: boolean;
-}) {
-  const fullyActive =
-    state.stripeConnectStatus === "active" &&
-    state.stripeChargesEnabled &&
-    state.stripePayoutsEnabled;
-
-  const connected = !!state.stripeConnectStatus;
-  const incomplete = connected && !fullyActive;
-
-  return (
-    <div className="space-y-6">
       <div>
-        <h2 className="text-xl font-bold text-gray-900">Connect Stripe to receive payments</h2>
-        <p className="text-sm text-gray-500 mt-1">
-          Stripe handles all identity verification and payouts. No manual KYC required.
-        </p>
-      </div>
-
-      {fullyActive ? (
-        <div className="flex items-center gap-3 rounded-xl bg-success/10 border border-success/40 p-4">
-          <CheckCircle2 className="h-5 w-5 text-success shrink-0" />
-          <p className="text-sm text-success font-medium">Stripe fully connected ✓</p>
-        </div>
-      ) : incomplete ? (
-        <div className="rounded-xl bg-primary-soft border border-primary/40 p-4 text-sm text-primary">
-          Your Stripe account is connected but not yet fully verified. Continue setup to enable
-          charges and payouts.
-        </div>
-      ) : null}
-
-      <div className="space-y-3">
-        {!fullyActive && (
-          <Button
-            onClick={onConnect}
-            disabled={connecting}
-            className="w-full bg-success hover:bg-success/90 text-white"
-          >
-            {connecting ? (
-              <Loader2 className="h-4 w-4 animate-spin mr-2" />
-            ) : (
-              <ExternalLink className="h-4 w-4 mr-2" />
-            )}
-            {incomplete ? "Continue Stripe setup" : "Connect Stripe"}
-          </Button>
-        )}
-        <Button
-          onClick={onNext}
-          disabled={!fullyActive}
-          variant={fullyActive ? "default" : "outline"}
-          className={`w-full ${fullyActive ? "bg-success hover:bg-success/90 text-white" : ""}`}
-        >
-          Continue <ChevronRight className="h-4 w-4 ml-1" />
-        </Button>
+        <p className="text-sm font-medium text-gray-900">{label}</p>
+        {detail ? <p className="mt-0.5 text-xs text-gray-500">{detail}</p> : null}
       </div>
     </div>
   );
 }
 
-// ─── Step 4: Store Setup ──────────────────────────────────────────────────────
-function StepStore({
-  storeCreated,
-  onNext,
-}: {
-  storeCreated: boolean;
-  onNext: () => void;
-}) {
-  return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="text-xl font-bold text-gray-900">Set up your store</h2>
-        <p className="text-sm text-gray-500 mt-1">Configure your store profile so buyers can find and trust you.</p>
-      </div>
-
-      <div className="space-y-3">
-        <div className={`flex items-center gap-3 rounded-xl border p-4 ${storeCreated ? "bg-success/10 border-success/40" : "border-gray-200"}`}>
-          {storeCreated ? (
-            <CheckCircle2 className="h-5 w-5 text-success shrink-0" />
-          ) : (
-            <Circle className="h-5 w-5 text-gray-300 shrink-0" />
-          )}
-          <div className="flex-1">
-            <p className="text-sm font-medium text-gray-900">Store profile</p>
-            <p className="text-xs text-gray-500">Name, logo, description</p>
-          </div>
-          {!storeCreated && (
-            <a href="/seller/settings" className="text-xs text-success underline shrink-0">
-              Configure →
-            </a>
-          )}
-        </div>
-      </div>
-
-      <Button
-        onClick={onNext}
-        disabled={!storeCreated}
-        className="w-full bg-success hover:bg-success/90 text-white disabled:opacity-40"
-      >
-        Continue <ChevronRight className="h-4 w-4 ml-1" />
-      </Button>
-    </div>
-  );
-}
-
-// ─── Step 5: First Service Listing ───────────────────────────────────────────
-function StepServiceListing({
-  done,
-  onFinish,
-  finishing,
-}: {
-  done: boolean;
-  onFinish: () => void;
-  finishing: boolean;
-}) {
-  return (
-    <div className="space-y-6">
-      <div>
-        <h2 className="text-xl font-bold text-gray-900">Add your first service listing</h2>
-        <p className="text-sm text-gray-500 mt-1">
-          Create your first listing to make your store live for buyers.
-        </p>
-      </div>
-
-      {done ? (
-        <div className="flex items-center gap-3 rounded-xl bg-success/10 border border-success/40 p-4">
-          <CheckCircle2 className="h-5 w-5 text-success shrink-0" />
-          <p className="text-sm text-success font-medium">First listing created ✓</p>
-        </div>
-      ) : (
-        <Button asChild variant="outline" className="w-full">
-          <a href="/seller/products/new">Add a Listing →</a>
-        </Button>
-      )}
-
-      <Button
-        onClick={onFinish}
-        disabled={!done || finishing}
-        className="w-full bg-success hover:bg-success/90 text-white disabled:opacity-40"
-      >
-        {finishing ? (
-          <Loader2 className="h-4 w-4 animate-spin mr-2" />
-        ) : null}
-        Complete Setup 🎉
-      </Button>
-    </div>
-  );
-}
-
-// ─── Main Component ───────────────────────────────────────────────────────────
 const SellerOnboarding = () => {
   const { user } = useAuthStore();
   const navigate = useNavigate();
-  const [step, setStep] = useState(1);
+  const [status, setStatus] = useState<OnboardingStatus | null>(null);
+  const [step, setStep] = useState<1 | 2 | 3 | 4 | 5>(1);
   const [loading, setLoading] = useState(true);
-  const [saving, setSaving] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [savingType, setSavingType] = useState(false);
+  const [savingStore, setSavingStore] = useState(false);
   const [connecting, setConnecting] = useState(false);
-  const [finishing, setFinishing] = useState(false);
-  const [state, setState] = useState<OnboardingState>({
-    accountType: null,
-    profileCompleted: false,
-    stripeConnectStatus: null,
-    stripeChargesEnabled: false,
-    stripePayoutsEnabled: false,
-    stripeDetailsSubmitted: false,
-    storeCreated: false,
-    hasServiceCapability: false,
-    onboardingCompleted: false,
-  });
+  const [storeName, setStoreName] = useState('');
+  const [storeDescription, setStoreDescription] = useState('');
 
-  // Load current onboarding state.
-  useEffect(() => {
-    // Redirects must live inside the effect so hooks are never conditional.
-    if (user && hasAdminAccess(user)) {
-      navigate("/admin", { replace: true });
-      return;
-    }
-    if (user && user.role === "buyer") {
-      navigate("/buyer", { replace: true });
-      return;
-    }
+  const refreshStatus = useCallback(async (quiet = false) => {
     if (!user) return;
-
-    const load = async () => {
-      // Fetch seller profile flags + user onboarding flag.
-      const [spRes, uRes] = await Promise.all([
-        supabase
-          .from("seller_profiles")
-          .select([
-            "accountType",
-            "profileCompleted",
-            "stripeConnectStatus",
-            "stripeChargesEnabled",
-            "stripePayoutsEnabled",
-            "stripeDetailsSubmitted",
-            "storeCreated",
-            "hasServiceCapability",
-            // Fallback fields used to derive completion from real persisted data
-            "storeName", "businessName", "contactPhone", "businessAddress",
-          ].join(", "))
-          .eq("userId", user.id)
-          .maybeSingle(),
-        supabase
-          .from("users")
-          .select("onboardingCompleted, onboardingStep")
-          .eq("id", user.id)
-          .maybeSingle(),
-      ]);
-
-      const sp = spRes.data as Record<string, unknown> | null;
-      const u = uRes.data as Record<string, unknown> | null;
-
-      if (u?.onboardingCompleted === true) {
-        // Already completed — go to seller dashboard.
-        navigate("/seller", { replace: true });
-        return;
-      }
-
-      // Derive profileCompleted if the DB column is not yet populated.
-      const profileCompleted =
-        (sp?.profileCompleted as boolean | null) ??
-        Boolean(
-          ((sp?.storeName as string) ?? (sp?.businessName as string) ?? "").trim().length > 0 &&
-          ((sp?.contactPhone as string) ?? "").trim().length > 0 &&
-          ((sp?.businessAddress as { postcode?: string } | null)?.postcode ?? "").trim().length > 0
-        );
-
-      // Derive hasServiceCapability from flag or products/services count.
-      let hasServiceCapability = Boolean(sp?.hasServiceCapability);
-      if (!hasServiceCapability) {
-        const { count } = await supabase
-          .from("products")
-          .select("id", { count: "exact", head: true })
-          .eq("sellerId", user.id);
-        hasServiceCapability = (count ?? 0) > 0;
-      }
-
-      const newState: OnboardingState = {
-        accountType: (sp?.accountType as string | null) ?? null,
-        profileCompleted,
-        stripeConnectStatus: (sp?.stripeConnectStatus as string | null) ?? null,
-        stripeChargesEnabled: Boolean(sp?.stripeChargesEnabled),
-        stripePayoutsEnabled: Boolean(sp?.stripePayoutsEnabled),
-        stripeDetailsSubmitted: Boolean(sp?.stripeDetailsSubmitted),
-        storeCreated: Boolean(sp?.storeCreated),
-        hasServiceCapability,
-        onboardingCompleted: Boolean(u?.onboardingCompleted),
-      };
-
-      setState(newState);
-
-      // Determine the current step based on what's already done.
-      const inferredStep = inferStep(newState);
-      setStep(inferredStep);
-      setLoading(false);
-    };
-
-    load().catch((err) => {
-      console.error("Onboarding load error:", err);
-      setLoading(false);
-    });
-  }, [user, navigate]);
-
-  function inferStep(s: OnboardingState): number {
-    if (!s.accountType) return 1;
-    if (!s.profileCompleted) return 2;
-    if (s.stripeConnectStatus !== "active" || !s.stripeChargesEnabled || !s.stripePayoutsEnabled) return 3;
-    if (!s.storeCreated) return 4;
-    if (!s.hasServiceCapability) return 5;
-    return 5;
-  }
-
-  // ── Step handlers ─────────────────────────────────────────────────────────
-
-  const saveAccountType = async (type: "individual" | "business") => {
-    setState((prev) => ({ ...prev, accountType: type }));
-    if (!user) return;
-    setSaving(true);
+    if (!quiet) setRefreshing(true);
     try {
-      await supabase
-        .from("seller_profiles")
-        .update({ accountType: type })
-        .eq("userId", user.id);
+      const response = await authorizedFetch('/.netlify/functions/seller-onboarding-status', {
+        method: 'POST',
+      });
+      const payload = await response.json().catch(() => ({})) as OnboardingStatus & { error?: string };
+      if (!response.ok) throw new Error(payload.error || 'Unable to load Seller setup');
+
+      setStatus(payload);
+      setStep(payload.readiness.nextStep);
+      setStoreName(payload.store.storeName ?? '');
+      setStoreDescription(payload.store.storeDescription ?? '');
+    } catch (error) {
+      toast({
+        title: 'Unable to load Seller setup',
+        description: error instanceof Error ? error.message : 'Please try again.',
+        variant: 'destructive',
+      });
     } finally {
-      setSaving(false);
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    if (!user) return;
+    if (hasAdminAccess(user)) {
+      navigate('/admin', { replace: true });
+      return;
+    }
+    if (user.role !== 'seller') {
+      navigate('/buyer', { replace: true });
+      return;
+    }
+    void refreshStatus(true);
+  }, [user, navigate, refreshStatus]);
+
+  const completedSteps = useMemo(() => {
+    if (!status) return [false, false, false, false, false];
+    return [
+      status.readiness.sellerTypeReady,
+      status.readiness.profileReady,
+      status.readiness.storeReady,
+      status.readiness.catalogueReady,
+      status.readiness.sellerActive,
+    ];
+  }, [status]);
+
+  const saveSellerType = async (sellerType: SellerType) => {
+    setSavingType(true);
+    try {
+      const response = await authorizedFetch('/.netlify/functions/set-seller-onboarding', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'seller_type', sellerType }),
+      });
+      const payload = await response.json().catch(() => ({})) as { error?: string };
+      if (!response.ok) throw new Error(payload.error || 'Unable to save Seller type');
+      await refreshStatus(true);
+    } catch (error) {
+      toast({
+        title: 'Seller type not saved',
+        description: error instanceof Error ? error.message : 'Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setSavingType(false);
     }
   };
 
-  const advanceStep = () => setStep((s) => Math.min(s + 1, ONBOARDING_TOTAL_STEPS));
+  const saveStoreIdentity = async () => {
+    setSavingStore(true);
+    try {
+      const response = await authorizedFetch('/.netlify/functions/set-seller-onboarding', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          action: 'store_identity',
+          storeName,
+          storeDescription,
+        }),
+      });
+      const payload = await response.json().catch(() => ({})) as { error?: string };
+      if (!response.ok) throw new Error(payload.error || 'Unable to save store identity');
+      await refreshStatus(true);
+    } catch (error) {
+      toast({
+        title: 'Store identity not saved',
+        description: error instanceof Error ? error.message : 'Please try again.',
+        variant: 'destructive',
+      });
+    } finally {
+      setSavingStore(false);
+    }
+  };
 
-  const handleStripeConnect = async () => {
-    if (!user) return;
+  const connectStripe = async () => {
     setConnecting(true);
     try {
-      const res = await authorizedFetch("/.netlify/functions/connect-onboard", {
-        method: "POST",
+      const response = await authorizedFetch('/.netlify/functions/connect-onboard', {
+        method: 'POST',
       });
-      const data = await res.json();
-      if (!res.ok) throw new Error(data.error || "Failed to start Stripe setup");
-      if (data.url) await openExternalUrl(data.url);
-    } catch (err) {
+      const payload = await response.json().catch(() => ({})) as { url?: string; error?: string };
+      if (!response.ok) throw new Error(payload.error || 'Unable to start Stripe setup');
+      if (!payload.url) throw new Error('Stripe onboarding URL was not returned');
+      await openExternalUrl(payload.url);
+    } catch (error) {
       toast({
-        title: "Stripe Connect error",
-        description: err instanceof Error ? err.message : "Please try again.",
-        variant: "destructive",
+        title: 'Stripe setup failed',
+        description: error instanceof Error ? error.message : 'Please try again.',
+        variant: 'destructive',
       });
     } finally {
       setConnecting(false);
     }
   };
 
-  const handleFinish = async () => {
-    if (!user) return;
-    setFinishing(true);
-    try {
-        await supabase
-          .from("users")
-          .update({ onboardingCompleted: true, onboardingStep: ONBOARDING_COMPLETE_SUBSTEP })
-          .eq("id", user.id);
-      toast({ title: "Setup complete! 🎉", description: "Your seller account is now live." });
-      navigate("/seller", { replace: true });
-    } catch (err) {
-      console.error("Finish onboarding error:", err);
-      toast({ title: "Error", description: "Please try again.", variant: "destructive" });
-    } finally {
-      setFinishing(false);
-    }
-  };
+  if (user && (hasAdminAccess(user) || user.role !== 'seller')) return null;
 
-  // While a redirect is pending (admin/buyer user), render nothing.
-  if (user && (hasAdminAccess(user) || user.role === "buyer")) return null;
-
-  if (loading) {
+  if (loading || !status) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
+      <div className="flex min-h-screen items-center justify-center bg-gray-50">
         <Loader2 className="h-8 w-8 animate-spin text-success" />
       </div>
     );
   }
 
-  const completedSteps = [
-    Boolean(state.accountType),
-    state.profileCompleted,
-    state.stripeConnectStatus === "active" && state.stripeChargesEnabled && state.stripePayoutsEnabled,
-    state.storeCreated,
-    state.hasServiceCapability,
-  ];
+  if (status.sellerStatus === 'suspended') {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-gray-50 px-4">
+        <div className="w-full max-w-lg rounded-2xl border border-red-200 bg-white p-8 text-center shadow-sm">
+          <h1 className="text-2xl font-bold text-gray-900">Seller account suspended</h1>
+          <p className="mt-2 text-sm text-gray-500">
+            Seller onboarding and commercial activation are unavailable while this account is suspended.
+          </p>
+          <Button asChild variant="outline" className="mt-6">
+            <Link to="/contact">Contact support</Link>
+          </Button>
+        </div>
+      </div>
+    );
+  }
 
   return (
-    <div className="min-h-screen bg-gray-50 py-12 px-4">
-      <div className="max-w-xl mx-auto space-y-8">
-        {/* Header */}
-        <div className="text-center">
-          <h1 className="text-2xl font-bold text-gray-900">Seller Setup</h1>
-          <p className="text-sm text-gray-500 mt-1">
-            Step {step} of {STEPS.length}
-          </p>
+    <div className="min-h-screen bg-gray-50 px-4 py-10">
+      <div className="mx-auto max-w-3xl space-y-7">
+        <div className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.16em] text-success">Marketplace Seller</p>
+            <h1 className="mt-1 text-2xl font-bold text-gray-900">Seller setup & activation</h1>
+            <p className="mt-1 max-w-xl text-sm text-gray-500">
+              Complete your marketplace setup from persisted account facts. Payments and account activation are shown separately so no step is marked verified simply because it was visited.
+            </p>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void refreshStatus()}
+            disabled={refreshing}
+          >
+            {refreshing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+            Refresh status
+          </Button>
         </div>
 
-        {/* Progress bar */}
-        <ProgressBar current={completedSteps.filter(Boolean).length} total={STEPS.length} />
-
-        {/* Step dots */}
-        <div className="flex items-start justify-between px-2">
-          {STEPS.map((s) => (
-            <StepDot key={s.id} step={s.id} current={step} done={completedSteps[s.id - 1]} />
-          ))}
+        <div className="rounded-2xl border border-gray-100 bg-white p-5 shadow-sm">
+          <div className="mb-4 flex items-start justify-between gap-2">
+            {STEPS.map((item) => (
+              <StepDot
+                key={item.id}
+                step={item.id}
+                current={step}
+                done={completedSteps[item.id - 1]}
+              />
+            ))}
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-gray-100">
+            <div
+              className="h-full rounded-full bg-success transition-all"
+              style={{ width: `${(completedSteps.filter(Boolean).length / STEPS.length) * 100}%` }}
+            />
+          </div>
         </div>
 
-        {/* Step content */}
-        <div className="bg-white rounded-2xl shadow-sm border border-gray-100 p-8">
+        <div className="rounded-2xl border border-gray-100 bg-white p-6 shadow-sm sm:p-8">
           {step === 1 && (
-            <StepAccountType
-              value={state.accountType}
-              onSelect={saveAccountType}
-              onNext={advanceStep}
-              saving={saving}
-            />
+            <div className="space-y-6">
+              <div>
+                <h2 className="text-xl font-bold text-gray-900">Choose your legal seller type</h2>
+                <p className="mt-1 text-sm text-gray-500">
+                  This describes who is selling on Loadify. It is separate from your public store name.
+                </p>
+              </div>
+              <div className="grid gap-3 sm:grid-cols-3">
+                {([
+                  ['individual', 'Individual', 'Selling in your own name'],
+                  ['sole_trader', 'Sole trader', 'Trading as a self-employed business'],
+                  ['company', 'Company', 'Registered company or organisation'],
+                ] as const).map(([value, label, description]) => (
+                  <button
+                    key={value}
+                    type="button"
+                    disabled={savingType}
+                    onClick={() => void saveSellerType(value)}
+                    className={`rounded-xl border-2 p-4 text-left transition ${
+                      status.sellerType === value
+                        ? 'border-success bg-success/10'
+                        : 'border-gray-200 hover:border-success/40'
+                    }`}
+                  >
+                    <p className="font-semibold text-gray-900">{label}</p>
+                    <p className="mt-1 text-xs text-gray-500">{description}</p>
+                  </button>
+                ))}
+              </div>
+              {savingType ? (
+                <p className="flex items-center text-sm text-gray-500"><Loader2 className="mr-2 h-4 w-4 animate-spin" />Saving…</p>
+              ) : null}
+            </div>
           )}
+
           {step === 2 && (
-            <StepProfile done={state.profileCompleted} onNext={advanceStep} />
+            <div className="space-y-6">
+              <div>
+                <h2 className="text-xl font-bold text-gray-900">Complete your legal & business details</h2>
+                <p className="mt-1 text-sm text-gray-500">
+                  Add the factual identity, contact and address information required for your seller type. Company and VAT details are required only when applicable.
+                </p>
+              </div>
+              <StatusRow
+                label="Business/trader profile"
+                done={status.profileComplete}
+                detail={status.profileComplete ? 'Required persisted profile fields are present.' : 'Your seller profile still has required information missing.'}
+              />
+              <Button asChild className="w-full bg-success text-white hover:bg-success/90">
+                <Link to="/seller/profile">{status.profileComplete ? 'Review Seller Profile' : 'Complete Seller Profile'}</Link>
+              </Button>
+              <Button variant="outline" className="w-full" onClick={() => void refreshStatus()} disabled={refreshing}>
+                Re-check saved details
+              </Button>
+            </div>
           )}
+
           {step === 3 && (
-            <StepStripe
-              state={state}
-              onConnect={handleStripeConnect}
-              onNext={advanceStep}
-              connecting={connecting}
-            />
+            <div className="space-y-6">
+              <div>
+                <h2 className="text-xl font-bold text-gray-900">Create your public store identity</h2>
+                <p className="mt-1 text-sm text-gray-500">
+                  Your store name is customer-facing and remains separate from your legal/business identity.
+                </p>
+              </div>
+              <div className="space-y-4">
+                <div>
+                  <Label htmlFor="store-name">Store name</Label>
+                  <Input
+                    id="store-name"
+                    className="mt-1"
+                    value={storeName}
+                    maxLength={80}
+                    onChange={(event) => setStoreName(event.target.value)}
+                    placeholder="Your public store name"
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="store-description">Store description <span className="text-gray-400">(optional)</span></Label>
+                  <Textarea
+                    id="store-description"
+                    className="mt-1 min-h-28"
+                    value={storeDescription}
+                    maxLength={1000}
+                    onChange={(event) => setStoreDescription(event.target.value)}
+                    placeholder="Tell buyers what your store specialises in."
+                  />
+                </div>
+              </div>
+              <Button
+                className="w-full bg-success text-white hover:bg-success/90"
+                onClick={() => void saveStoreIdentity()}
+                disabled={savingStore || storeName.trim().length < 2}
+              >
+                {savingStore ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <Store className="mr-2 h-4 w-4" />}
+                Save store identity
+              </Button>
+            </div>
           )}
+
           {step === 4 && (
-            <StepStore
-              storeCreated={state.storeCreated}
-              onNext={advanceStep}
-            />
+            <div className="space-y-6">
+              <div>
+                <h2 className="text-xl font-bold text-gray-900">Prepare your first product listing</h2>
+                <p className="mt-1 text-sm text-gray-500">
+                  Add at least one marketplace product. During onboarding you may save it as a draft; public publishing remains locked until your commercial readiness checks pass.
+                </p>
+              </div>
+              <StatusRow
+                label="Catalogue draft"
+                done={status.readiness.catalogueReady}
+                detail={status.productCount > 0 ? `${status.productCount} product listing${status.productCount === 1 ? '' : 's'} saved.` : 'No product listing has been saved yet.'}
+              />
+              <Button asChild className="w-full bg-success text-white hover:bg-success/90">
+                <Link to="/seller/products/new">Add a product draft</Link>
+              </Button>
+              <Button variant="outline" className="w-full" onClick={() => void refreshStatus()} disabled={refreshing}>
+                Re-check catalogue
+              </Button>
+            </div>
           )}
+
           {step === 5 && (
-            <StepServiceListing
-              done={state.hasServiceCapability}
-              onFinish={handleFinish}
-              finishing={finishing}
-            />
+            <div className="space-y-6">
+              <div>
+                <h2 className="text-xl font-bold text-gray-900">Payments & seller activation</h2>
+                <p className="mt-1 text-sm text-gray-500">
+                  Marketplace setup and commercial activation are separate. Stripe provides payment-account readiness signals; Loadify does not treat a Stripe step as a substitute for every platform verification obligation.
+                </p>
+              </div>
+
+              <div className="grid gap-3 sm:grid-cols-2">
+                <StatusRow label="Seller type" done={status.readiness.sellerTypeReady} />
+                <StatusRow label="Business details" done={status.readiness.profileReady} />
+                <StatusRow label="Store identity" done={status.readiness.storeReady} />
+                <StatusRow label="Catalogue draft" done={status.readiness.catalogueReady} />
+                <StatusRow
+                  label="Stripe charges & payouts"
+                  done={status.readiness.stripeReady}
+                  detail={status.stripe.status ? `Stripe status: ${status.stripe.status}` : 'Stripe account not connected yet.'}
+                />
+                <StatusRow
+                  label="Seller account active"
+                  done={status.readiness.sellerActive}
+                  detail={`Current seller status: ${status.sellerStatus}`}
+                />
+              </div>
+
+              {status.readiness.setupComplete && !status.readiness.sellerActive ? (
+                <div className="rounded-xl border border-blue-200 bg-blue-50 p-4 text-sm text-blue-900">
+                  Your marketplace setup is saved. Your Seller Workspace remains locked until the separate activation requirements below are satisfied.
+                </div>
+              ) : null}
+
+              {!status.readiness.stripeReady ? (
+                <Button
+                  onClick={() => void connectStripe()}
+                  disabled={connecting}
+                  className="w-full bg-success text-white hover:bg-success/90"
+                >
+                  {connecting ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <ExternalLink className="mr-2 h-4 w-4" />}
+                  {status.stripe.connected ? 'Continue Stripe setup' : 'Connect Stripe for payments'}
+                </Button>
+              ) : null}
+
+              {status.readiness.adminReviewPending ? (
+                <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+                  Your seller type requires Loadify review under the current platform policy. Stripe readiness does not bypass that review.
+                </div>
+              ) : null}
+
+              {status.readiness.sellerActive ? (
+                <Button className="w-full bg-success text-white hover:bg-success/90" onClick={() => navigate('/seller', { replace: true })}>
+                  Go to Seller Workspace
+                </Button>
+              ) : (
+                <Button variant="outline" className="w-full" onClick={() => void refreshStatus()} disabled={refreshing}>
+                  {refreshing ? <Loader2 className="mr-2 h-4 w-4 animate-spin" /> : <RefreshCw className="mr-2 h-4 w-4" />}
+                  Check activation status
+                </Button>
+              )}
+            </div>
           )}
         </div>
 
-        {/* Skip to dashboard (incomplete sellers allowed into dashboard with warning) */}
-        {step < 5 && (
-          <p className="text-center text-xs text-gray-400">
-            <button
-              type="button"
-              className="underline hover:text-gray-600"
-              onClick={() => navigate("/seller", { replace: true })}
-            >
-              Skip for now — go to dashboard
-            </button>
-          </p>
-        )}
+        <p className="text-center text-xs text-gray-400">
+          Progress is saved from persisted account, store, catalogue and payment facts. There is no skip-to-active shortcut.
+        </p>
       </div>
     </div>
   );

--- a/supabase/672_seller_onboarding_v2_truth.sql
+++ b/supabase/672_seller_onboarding_v2_truth.sql
@@ -1,0 +1,185 @@
+-- 672_seller_onboarding_v2_truth.sql
+-- Loadify Market — Stage 3 Seller Onboarding V2 truth boundary.
+--
+-- PURPOSE
+--   Remove browser-controlled completion semantics from Marketplace Seller
+--   onboarding and make progress flags projections of persisted marketplace
+--   truth. Stripe remains a commercial activation/payment readiness signal; it
+--   is not treated as identity verification and does not define onboarding
+--   completion.
+--
+-- INVARIANTS
+--   * sellerType is canonical: individual | sole_trader | company.
+--   * profileCompleted, storeCreated and firstProductCreated are server-managed.
+--   * users.onboardingCompleted/onboardingStep are server-managed.
+--   * Marketplace onboarding requires legal/profile details, store identity and
+--     at least one product/draft catalogue row.
+--   * Legacy hasServiceCapability remains for compatibility but no longer gates
+--     Marketplace Seller onboarding completion.
+--   * Seller commercial activation continues to use the separate sellerStatus
+--     / Stripe / optional admin-approval contract.
+--   * Supplier Commerce is not touched.
+
+CREATE OR REPLACE FUNCTION private.protect_seller_onboarding_flags_v2()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF auth.role() = 'authenticated' AND NOT public.is_admin() THEN
+    IF TG_OP = 'INSERT' THEN
+      NEW."profileCompleted" := false;
+      NEW."storeCreated" := false;
+      NEW."firstProductCreated" := false;
+    ELSE
+      NEW."profileCompleted" := OLD."profileCompleted";
+      NEW."storeCreated" := OLD."storeCreated";
+      NEW."firstProductCreated" := OLD."firstProductCreated";
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_01_protect_seller_onboarding_flags_v2
+  ON public.seller_profiles;
+CREATE TRIGGER trg_01_protect_seller_onboarding_flags_v2
+BEFORE INSERT OR UPDATE
+ON public.seller_profiles
+FOR EACH ROW
+EXECUTE FUNCTION private.protect_seller_onboarding_flags_v2();
+
+REVOKE ALL ON FUNCTION private.protect_seller_onboarding_flags_v2()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION private.protect_seller_onboarding_flags_v2()
+  TO service_role;
+
+CREATE OR REPLACE FUNCTION private.protect_user_onboarding_flags_v2()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF auth.role() = 'authenticated' AND NOT public.is_admin() THEN
+    IF TG_OP = 'INSERT' THEN
+      NEW."onboardingCompleted" := false;
+      NEW."onboardingStep" := 0;
+    ELSE
+      NEW."onboardingCompleted" := OLD."onboardingCompleted";
+      NEW."onboardingStep" := OLD."onboardingStep";
+    END IF;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_01_protect_user_onboarding_flags_v2
+  ON public.users;
+CREATE TRIGGER trg_01_protect_user_onboarding_flags_v2
+BEFORE INSERT OR UPDATE
+ON public.users
+FOR EACH ROW
+EXECUTE FUNCTION private.protect_user_onboarding_flags_v2();
+
+REVOKE ALL ON FUNCTION private.protect_user_onboarding_flags_v2()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION private.protect_user_onboarding_flags_v2()
+  TO service_role;
+
+-- Marketplace Seller onboarding completion is intentionally separate from
+-- commercial activation. The latter remains sellerStatus/Stripe/admin-policy
+-- governed by the existing server activation boundary.
+CREATE OR REPLACE FUNCTION public.sync_seller_onboarding_completed()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF (
+    NEW."sellerType" IN ('individual', 'sole_trader', 'company') AND
+    NEW."profileCompleted" IS TRUE AND
+    NEW."storeCreated" IS TRUE AND
+    NEW."firstProductCreated" IS TRUE AND
+    COALESCE(NEW."sellerStatus", 'draft') <> 'suspended'
+  ) THEN
+    UPDATE public.users
+    SET "onboardingCompleted" = true,
+        "onboardingStep" = 8
+    WHERE id = NEW."userId"
+      AND (
+        "onboardingCompleted" IS DISTINCT FROM true OR
+        "onboardingStep" IS DISTINCT FROM 8
+      );
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.sync_seller_onboarding_completed()
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.sync_seller_onboarding_completed()
+  TO service_role;
+
+-- Reconcile only factual legacy projections. Existing active sellers are not
+-- demoted and sellerStatus is not changed here.
+UPDATE public.seller_profiles sp
+SET "storeCreated" = true
+WHERE "storeCreated" IS DISTINCT FROM true
+  AND EXISTS (
+    SELECT 1
+    FROM public.seller_stores ss
+    WHERE ss."userId" = sp."userId"
+      AND NULLIF(BTRIM(ss."storeName"), '') IS NOT NULL
+  );
+
+UPDATE public.seller_profiles sp
+SET "firstProductCreated" = true
+WHERE "firstProductCreated" IS DISTINCT FROM true
+  AND EXISTS (
+    SELECT 1
+    FROM public.products p
+    WHERE p."sellerId" = sp."userId"
+  );
+
+DO $$
+BEGIN
+  IF has_function_privilege(
+    'anon',
+    'private.protect_seller_onboarding_flags_v2()',
+    'EXECUTE'
+  ) OR has_function_privilege(
+    'authenticated',
+    'private.protect_seller_onboarding_flags_v2()',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION '672 onboarding protection failed: seller flag trigger helper exposed to client role';
+  END IF;
+
+  IF has_function_privilege(
+    'anon',
+    'private.protect_user_onboarding_flags_v2()',
+    'EXECUTE'
+  ) OR has_function_privilege(
+    'authenticated',
+    'private.protect_user_onboarding_flags_v2()',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION '672 onboarding protection failed: user flag trigger helper exposed to client role';
+  END IF;
+
+  IF has_function_privilege(
+    'anon',
+    'public.sync_seller_onboarding_completed()',
+    'EXECUTE'
+  ) OR has_function_privilege(
+    'authenticated',
+    'public.sync_seller_onboarding_completed()',
+    'EXECUTE'
+  ) THEN
+    RAISE EXCEPTION '672 onboarding protection failed: completion trigger helper exposed to client role';
+  END IF;
+END $$;


### PR DESCRIPTION
## Stage 3 — Seller Onboarding V2

Implements the canonical Marketplace Seller onboarding flow on top of the merged/deployed Stage 2 identity capability foundation.

### Exact validation baseline
- base `main`: `dcd54b061352d3062d29f9a6903b439eb3586358`
- head: `a1ce88e9bf694609129b3da7dc3a6c4a8feeb90e`
- Branch Guard: ahead 10 / behind 0
- exact diff: 9 files

### Scope
- canonical seller types: `individual`, `sole_trader`, `company`
- legal/business profile separated from public store identity
- catalogue draft readiness separated from seller commercial activation
- Stripe readiness is not treated as a substitute for Loadify verification/admin policy
- trusted server boundaries for seller type/store identity
- server-derived onboarding truth and completion reconciliation
- browser cannot own or forge onboarding-completion flags
- draft/submitted Sellers may access only catalogue create/edit during onboarding
- Seller Workspace remains locked until mandatory onboarding is complete
- removes legacy service/supplier/skip-to-active onboarding semantics
- migration `672_seller_onboarding_v2_truth.sql`

### Final local evidence
- targeted Stage 3 tests: PASS
- delta lint: PASS
- exact TypeScript/production build: PASS
- legacy semantics guard: PASS
- URL-bypass guard: PASS
- browser completion ownership: PASS
- isolated local DB contract for exact migration 672: PASS

### Boundaries
- production was NOT modified by validation
- Supplier Commerce was NOT activated or changed
- Marketplace Seller != Supplier Partner / Fulfilment Provider
- no Workspace/Admin/Super Admin visual redesign
- PR is intentionally DRAFT
- DO NOT MERGE until separate merge-readiness evaluation and explicit authorization
- deployment of migration 672 is a separate step after an authorized merge

Historical repository-wide fresh-bootstrap migration debt remains a separate Release Gate blocker and is not represented as a Stage 3 regression.