### PR TITLE
Stage 7: harden cross-platform auth and recovery

### DIFF
--- a/netlify/functions/__tests__/cross-platform-auth-security.test.ts
+++ b/netlify/functions/__tests__/cross-platform-auth-security.test.ts
@@ -1,0 +1,193 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+function source(path: string): string {
+  return readFileSync(join(process.cwd(), path), 'utf8');
+}
+
+describe('Stage 7 cross-platform auth/security contract', () => {
+  it('fails closed when authoritative platform-user hydration is unavailable', () => {
+    const app = source('src/App.tsx');
+
+    expect(app).not.toContain(
+      'function userFromSession(',
+    );
+
+    expect(app).not.toContain(
+      'setUser(userFromSession(',
+    );
+    expect(app).not.toContain(
+      'falling back to auth session',
+    );
+
+    expect(app).toContain(
+      "signOut({ scope: 'local' })",
+    );
+
+    expect(app).toContain(
+      'setUser(null)',
+    );
+  });
+
+  it('delegates dashboard Seller readiness to canonical route guards', () => {
+    const app = source('src/App.tsx');
+
+    expect(app).toContain(
+      'if (hasSellerAccess(user))',
+    );
+
+    expect(app).toContain(
+      'if (hasBuyerAccess(user))',
+    );
+
+    expect(app).not.toContain(
+      'user.onboardingCompleted === false',
+    );
+  });
+
+  it('accepts only trusted native deep-link origins', () => {
+    const app = source('src/App.tsx');
+
+    expect(app).toContain(
+      "parsed.protocol === 'loadifymarket:'",
+    );
+
+    expect(app).toContain(
+      "parsed.hostname === 'app'",
+    );
+
+    expect(app).toContain(
+      "parsed.protocol === 'https:'",
+    );
+
+    expect(app).toContain(
+      "parsed.hostname === 'loadifymarket.co.uk'",
+    );
+
+    expect(app).toContain(
+      'Ignored untrusted URL origin',
+    );
+  });
+
+  it('uses the native callback for both Google and Facebook inside the APK', () => {
+    const login = source(
+      'src/pages/pixel-perfect/Login.tsx',
+    );
+
+    expect(login).toContain(
+      'const NATIVE_OAUTH_CALLBACK = "loadifymarket://app/auth/callback";',
+    );
+
+    const nativeCallbackUses =
+      login.match(/redirectTo: NATIVE_OAUTH_CALLBACK/g) ?? [];
+
+    expect(nativeCallbackUses).toHaveLength(2);
+
+    expect(login).toContain(
+      'skipBrowserRedirect: true',
+    );
+  });
+
+  it('recovers password-reset sessions explicitly from app-link credentials', () => {
+    const reset = source(
+      'src/pages/pixel-perfect/ResetPassword.tsx',
+    );
+
+    expect(reset).toContain(
+      'exchangeCodeForSession(authCode)',
+    );
+
+    expect(reset).toContain(
+      'supabase.auth.setSession',
+    );
+
+    expect(reset).toContain(
+      "recoveryType === 'recovery'",
+    );
+
+    expect(reset).toContain(
+      "window.history.replaceState",
+    );
+  });
+
+  it('blocks explicitly inactive accounts at every protected UI boundary', () => {
+    const guardedFiles = [
+      'src/components/auth/RequireAuth.tsx',
+      'src/components/auth/RequireBuyer.tsx',
+      'src/components/auth/RequireAdmin.tsx',
+      'src/components/auth/RequireSellerAny.tsx',
+      'src/components/auth/RequireSeller.tsx',
+    ];
+
+    for (const path of guardedFiles) {
+      expect(source(path)).toContain(
+        'user.isActive !== true',
+      );
+    }
+  });
+
+  it('keeps Android OAuth/App-Link identity configuration aligned', () => {
+    const manifest = source(
+      'android/app/src/main/AndroidManifest.xml',
+    );
+
+    const assetLinks = source(
+      'public/.well-known/assetlinks.json',
+    );
+
+    const capacitor = source(
+      'capacitor.config.ts',
+    );
+
+    expect(manifest).toContain(
+      'android:scheme="loadifymarket"',
+    );
+
+    expect(manifest).toContain(
+      'android:host="app"',
+    );
+
+    expect(manifest).toContain(
+      'android:pathPrefix="/auth/callback"',
+    );
+
+    expect(manifest).toContain(
+      'android:host="loadifymarket.co.uk"',
+    );
+
+    expect(assetLinks).toContain(
+      '"package_name": "co.uk.loadifymarket.app"',
+    );
+
+    expect(capacitor).toContain(
+      "appId: 'co.uk.loadifymarket.app'",
+    );
+
+    expect(capacitor).toContain(
+      'cleartext: false',
+    );
+  });
+
+  it('preserves Stage 3-5 canonical Seller flow while hardening cross-platform auth', () => {
+    const onboarding = source(
+      'src/pages/onboarding/SellerOnboarding.tsx',
+    );
+
+    const connect = source(
+      'netlify/functions/connect-onboard.ts',
+    );
+
+    expect(onboarding).toContain(
+      'to="/seller/products/new"',
+    );
+
+    expect(connect).toContain(
+      'return_url: `${appUrl}/onboarding?connect=success`',
+    );
+
+    expect(connect).toContain(
+      'refresh_url: `${appUrl}/onboarding?connect=refresh`',
+    );
+  });
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,7 @@
 import { Routes, Route, Navigate, useParams, useNavigate, useLocation } from 'react-router-dom';
 import { useEffect, lazy, Suspense, useState } from 'react';
 import { useAuthStore } from './store';
-import { hasAdminAccess } from './lib/roleUtils';
+import { hasAdminAccess, hasBuyerAccess, hasSellerAccess } from './lib/roleUtils';
 import { CartProvider } from './contexts/CartContext';
 import CookieConsent from './components/CookieConsent';
 import Header from './components/Header';
@@ -161,16 +161,31 @@ function PageLoader() {
  */
 function DashboardRedirect() {
   const { user, isLoading } = useAuthStore();
+
   if (isLoading) return <PageLoader />;
   if (!user) return <Navigate to="/login" replace />;
-  if (user.role === 'admin') return <Navigate to="/admin" replace />;
-  // Sellers with incomplete onboarding go to the wizard first.
-  // `onboardingCompleted` is loaded from the DB in App.tsx auth listener.
-  if (user.role === 'seller') {
-    if (user.onboardingCompleted === false) return <Navigate to="/onboarding" replace />;
+
+  // Account-level activity is authoritative. Do not route a blocked or
+  // incompletely hydrated identity into a commerce workspace.
+  if (user.isActive !== true) {
+    return <Navigate to="/login?error=account_inactive" replace />;
+  }
+
+  if (hasAdminAccess(user)) {
+    return <Navigate to="/admin" replace />;
+  }
+
+  // Delegate Seller onboarding/readiness truth to RequireSeller instead of
+  // trusting the historical users.onboardingCompleted projection here.
+  if (hasSellerAccess(user)) {
     return <Navigate to="/seller" replace />;
   }
-  return <Navigate to="/buyer" replace />;
+
+  if (hasBuyerAccess(user)) {
+    return <Navigate to="/buyer" replace />;
+  }
+
+  return <Navigate to="/login" replace />;
 }
 
 /** Redirects legacy /tracking/:orderNumber to /track-order?orderNumber=:orderNumber */
@@ -182,6 +197,20 @@ function TrackingRedirect() {
 function CategoryRedirect() {
   const { slug } = useParams<{ slug: string }>();
   return <Navigate to={`/category/${slug ?? ''}`} replace />;
+}
+
+function isTrustedNativeDeepLink(parsed: URL): boolean {
+  if (parsed.protocol === 'loadifymarket:') {
+    return (
+      parsed.hostname === 'app' &&
+      parsed.pathname.startsWith('/auth/callback')
+    );
+  }
+
+  return (
+    parsed.protocol === 'https:' &&
+    parsed.hostname === 'loadifymarket.co.uk'
+  );
 }
 
 
@@ -268,6 +297,14 @@ function App() {
         try {
           const parsed = new URL(url);
 
+          // Never route arbitrary external origins through the native app.
+          // OAuth uses the dedicated custom scheme; normal app links must be
+          // HTTPS links from the production Loadify Market host.
+          if (!isTrustedNativeDeepLink(parsed)) {
+            console.warn('[DeepLink] Ignored untrusted URL origin');
+            return;
+          }
+
           // OAuth callback — exchange the code/token with Supabase and
           // let onAuthStateChange update the store automatically.
           if (parsed.pathname.startsWith('/auth/callback')) {
@@ -292,40 +329,6 @@ function App() {
   }, [navigate]);
 
   useEffect(() => {
-    // Build a minimal User object from Supabase auth session metadata when the
-    // public.users table query fails or returns no row (e.g. the live database
-    // hasn't had the 20_fix_users_table.sql migration applied yet).
-    function userFromSession(authUser: {
-      id: string;
-      email?: string | null;
-      user_metadata?: Record<string, unknown>;
-      app_metadata?: Record<string, unknown>;
-      email_confirmed_at?: string | null;
-    }): import('./types').User {
-      const userMeta = authUser.user_metadata || {};
-      const appMeta = authUser.app_metadata || {};
-      const strVal = (obj: Record<string, unknown>, key: string) =>
-        typeof obj[key] === 'string' ? (obj[key] as string) : undefined;
-      const candidateRole = strVal(appMeta, 'role');
-      const role: import('./types').UserRole =
-        candidateRole === 'admin' || candidateRole === 'seller' || candidateRole === 'buyer'
-          ? candidateRole
-          : 'buyer';
-      return {
-        id: authUser.id,
-        email: authUser.email ?? '',
-        role,
-        firstName: strVal(userMeta, 'first_name'),
-        lastName: strVal(userMeta, 'last_name'),
-        // Derive from Supabase Auth state — email_confirmed_at is set when the
-        // email address has been confirmed, regardless of the custom users table.
-        isEmailVerified: authUser.email_confirmed_at != null,
-        isActive: true,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-      };
-    }
-
     // Lift the joined seller_profiles row (if any) into a flat sellerStatus field
     // on the user object, and remove the raw join array.  This is called after
     // every users query so RequireSeller can use the cached value immediately
@@ -391,23 +394,48 @@ function App() {
                   (data as Record<string, unknown>).role === 'admin';
                 setUser(data);
               } else {
+                // Stage 7 fail-closed boundary: an authenticated Supabase
+                // session is not sufficient proof that the platform account is
+                // active. If the authoritative public.users row cannot be read,
+                // do not invent role/activity truth from session metadata.
                 if (error) {
-                  console.warn('users table query failed, falling back to auth session:', error.message);
-                  setUser(userFromSession(session.user));
+                  console.warn(
+                    '[Auth] Authoritative user profile lookup failed; denying protected access:',
+                    error.message,
+                  );
                 } else {
-                  // Row not yet found — e.g. the DB insert trigger hasn't fired
-                  // yet on a fresh sign-up, or a transient query failure.  Fall
-                  // back to auth-session metadata so the user is not incorrectly
-                  // kicked back to the login page.
-                  setUser(userFromSession(session.user));
+                  console.warn(
+                    '[Auth] Authoritative user profile is missing; denying protected access',
+                  );
                 }
+
+                void supabase.auth
+                  .signOut({ scope: 'local' })
+                  .catch((signOutError) => {
+                    console.warn(
+                      '[Auth] Local fail-closed sign-out failed',
+                      signOutError,
+                    );
+                  });
+
+                setUser(null);
               }
             })
             .catch((err: unknown) => {
-              // Network error during profile fetch — unblock loading so the
-              // app does not hang on a spinner indefinitely.
+              // An unexpected profile-hydration failure must also fail closed.
+              // Never preserve a stale or session-derived commerce identity.
               console.error('[Auth] Profile fetch threw unexpectedly:', err);
-              setLoading(false);
+
+              void supabase.auth
+                .signOut({ scope: 'local' })
+                .catch((signOutError) => {
+                  console.warn(
+                    '[Auth] Local fail-closed sign-out failed',
+                    signOutError,
+                  );
+                });
+
+              setUser(null);
             });
         } else {
           setUser(null);

--- a/src/components/auth/RequireAdmin.tsx
+++ b/src/components/auth/RequireAdmin.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import type { ReactNode } from 'react';
-import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useNavigate, useLocation, Link, Navigate } from 'react-router-dom';
 import { useAuthStore } from '../../store';
 import { hasAdminAccess } from '../../lib/roleUtils';
 
@@ -39,6 +39,10 @@ export default function RequireAdmin({ children }: Props) {
   }
 
   if (!user) return null;
+
+  if (user.isActive !== true) {
+    return <Navigate to="/login?error=account_inactive" replace />;
+  }
 
   if (!hasAdminAccess(user)) {
     return (

--- a/src/components/auth/RequireAuth.tsx
+++ b/src/components/auth/RequireAuth.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import type { ReactNode } from 'react';
-import { useNavigate, useLocation } from 'react-router-dom';
+import { useNavigate, useLocation, Navigate } from 'react-router-dom';
 import { useAuthStore } from '../../store';
 
 interface RequireAuthProps {
@@ -37,11 +37,15 @@ export default function RequireAuth({ children }: RequireAuthProps) {
     );
   }
 
-  // If authenticated, render children
-  if (user) {
-    return <>{children}</>;
+  if (!user) {
+    return null;
   }
 
-  // Return null while redirecting
-  return null;
+  // Defence in depth: an authenticated Supabase session is not sufficient
+  // when the platform account is explicitly inactive or not fully hydrated.
+  if (user.isActive !== true) {
+    return <Navigate to="/login?error=account_inactive" replace />;
+  }
+
+  return <>{children}</>;
 }

--- a/src/components/auth/RequireBuyer.tsx
+++ b/src/components/auth/RequireBuyer.tsx
@@ -42,6 +42,10 @@ export default function RequireBuyer({ children }: Props) {
 
   if (!user) return null;
 
+  if (user.isActive !== true) {
+    return <Navigate to="/login?error=account_inactive" replace />;
+  }
+
   if (hasAdminAccess(user)) return <Navigate to="/admin" replace />;
 
   if (hasBuyerAccess(user)) return <>{children}</>;

--- a/src/components/auth/RequireSeller.tsx
+++ b/src/components/auth/RequireSeller.tsx
@@ -195,6 +195,7 @@ export default function RequireSeller({ children }: Props) {
   }, [user]);
 
   const loading = isLoading || (
+    user?.isActive === true &&
     user?.role === 'seller' &&
     (fetchState === 'loading' || !onboardingChecked)
   );
@@ -207,6 +208,10 @@ export default function RequireSeller({ children }: Props) {
     );
   }
   if (!user) return null;
+
+  if (user.isActive !== true) {
+    return <Navigate to="/login?error=account_inactive" replace />;
+  }
 
   if (!hasSellerAccess(user) && !hasAdminAccess(user)) {
     return (

--- a/src/components/auth/RequireSellerAny.tsx
+++ b/src/components/auth/RequireSellerAny.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import type { ReactNode } from 'react';
-import { useNavigate, useLocation, Link } from 'react-router-dom';
+import { useNavigate, useLocation, Link, Navigate } from 'react-router-dom';
 import { useAuthStore } from '../../store';
 import { hasAdminAccess, hasSellerAccess } from '../../lib/roleUtils';
 
@@ -44,6 +44,10 @@ export default function RequireSellerAny({ children }: Props) {
   }
 
   if (!user) return null;
+
+  if (user.isActive !== true) {
+    return <Navigate to="/login?error=account_inactive" replace />;
+  }
 
   // Admin can access for inspection
   if (hasAdminAccess(user)) return <>{children}</>;

--- a/src/pages/pixel-perfect/Login.tsx
+++ b/src/pages/pixel-perfect/Login.tsx
@@ -23,6 +23,8 @@ const FacebookIcon = () => (
   </svg>
 );
 
+const NATIVE_OAUTH_CALLBACK = "loadifymarket://app/auth/callback";
+
 const Login = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [email, setEmail] = useState("");
@@ -43,15 +45,12 @@ const Login = () => {
   const oauthFailed = searchParams.get("error") === "oauth_failed";
 
   useEffect(() => {
-    if (user) {
-      const nextUrl = sanitizeRedirectUrl(searchParams.get("next"));
-      if (nextUrl) navigate(nextUrl, { replace: true });
-      else if (user.role === "seller") navigate("/seller", { replace: true });
-      else if (user.role === "admin") navigate("/admin", { replace: true });
-      else if (user.role === "buyer") navigate("/buyer", { replace: true });
-      // For any other/unknown role value, do not navigate — wait for the
-      // Zustand store to receive a corrected profile from the DB query.
-    }
+    // Only a fully hydrated active platform account may leave the login page.
+    // /dashboard owns canonical role/workspace routing.
+    if (!user || user.isActive !== true) return;
+
+    const nextUrl = sanitizeRedirectUrl(searchParams.get("next"));
+    navigate(nextUrl ?? "/dashboard", { replace: true });
   }, [user, searchParams, navigate]);
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -92,7 +91,7 @@ const Login = () => {
         const { data, error: oauthErr } = await supabase.auth.signInWithOAuth({
           provider: "google",
           options: {
-            redirectTo: "loadifymarket://app/auth/callback",
+            redirectTo: NATIVE_OAUTH_CALLBACK,
             skipBrowserRedirect: true,
           },
         });
@@ -131,7 +130,7 @@ const Login = () => {
         const { data, error: oauthErr } = await supabase.auth.signInWithOAuth({
           provider: "facebook",
           options: {
-            redirectTo: `${window.location.origin}/auth/callback`,
+            redirectTo: NATIVE_OAUTH_CALLBACK,
             skipBrowserRedirect: true,
           },
         });

--- a/src/pages/pixel-perfect/ResetPassword.tsx
+++ b/src/pages/pixel-perfect/ResetPassword.tsx
@@ -22,42 +22,155 @@ const ResetPassword = () => {
   const navigate = useNavigate();
 
   useEffect(() => {
-    // Listen for the PASSWORD_RECOVERY event that Supabase fires when a user
-    // arrives via the reset-password email link (the token is in the URL hash).
-    const { data: { subscription } } = supabase.auth.onAuthStateChange((event) => {
-      if (event === "PASSWORD_RECOVERY") {
-        setHasSession(true);
-        setSessionChecking(false);
-      }
-    });
-
+    let cancelled = false;
     let timeoutId: ReturnType<typeof setTimeout> | undefined;
 
-    // Fallback: user may already have an active session (e.g. still logged in)
-    supabase.auth.getSession().then(({ data: { session } }) => {
-      if (session) {
+    const clearRecoveryCredentialsFromUrl = () => {
+      if (window.location.search || window.location.hash) {
+        window.history.replaceState(
+          window.history.state,
+          document.title,
+          '/reset-password',
+        );
+      }
+    };
+
+    const scheduleInvalidLink = () => {
+      timeoutId = setTimeout(() => {
+        if (cancelled) return;
+
+        setSessionChecking((checking) => {
+          if (checking) {
+            setError(
+              "This password reset link is invalid or has expired. Please request a new one.",
+            );
+          }
+
+          return false;
+        });
+      }, PASSWORD_RECOVERY_WAIT_MS);
+    };
+
+    // Browser page-load recovery can still arrive through Supabase's normal
+    // PASSWORD_RECOVERY event.
+    const {
+      data: { subscription },
+    } = supabase.auth.onAuthStateChange((event, session) => {
+      if (
+        event === "PASSWORD_RECOVERY" &&
+        session &&
+        !cancelled
+      ) {
         setHasSession(true);
         setSessionChecking(false);
-      } else {
-        // Don't show the error immediately — wait for the auth state change
-        // event which fires shortly after mount when the hash token is processed.
-        timeoutId = setTimeout(() => {
-          setSessionChecking((checking) => {
-            if (checking) {
-              setError("This password reset link is invalid or has expired. Please request a new one.");
-            }
-            return false;
-          });
-        }, PASSWORD_RECOVERY_WAIT_MS);
+        clearRecoveryCredentialsFromUrl();
       }
-    }).catch(() => {
-      setError("Failed to verify reset link. Please try again.");
-      setSessionChecking(false);
     });
 
+    const completeRecovery = async () => {
+      try {
+        const currentUrl = new URL(window.location.href);
+        const authCode = currentUrl.searchParams.get('code');
+
+        const hashParams = new URLSearchParams(
+          currentUrl.hash.replace(/^#/, ''),
+        );
+
+        const accessToken = hashParams.get('access_token');
+        const refreshToken = hashParams.get('refresh_token');
+
+        const recoveryType =
+          hashParams.get('type') ??
+          currentUrl.searchParams.get('type');
+
+        const hasRecoveryCredentials = Boolean(
+          authCode ||
+          (
+            recoveryType === 'recovery' &&
+            accessToken &&
+            refreshToken
+          ),
+        );
+
+        // Capacitor App Links can reach this route after the Supabase client
+        // has already initialized. Explicitly consume the recovery credentials
+        // instead of relying only on detectSessionInUrl at client startup.
+        if (authCode) {
+          const { error: exchangeError } =
+            await supabase.auth.exchangeCodeForSession(authCode);
+
+          if (exchangeError) {
+            const {
+              data: { session: alreadyRecovered },
+            } = await supabase.auth.getSession();
+
+            if (!alreadyRecovered) {
+              throw exchangeError;
+            }
+          }
+        } else if (
+          recoveryType === 'recovery' &&
+          accessToken &&
+          refreshToken
+        ) {
+          const { error: sessionError } =
+            await supabase.auth.setSession({
+              access_token: accessToken,
+              refresh_token: refreshToken,
+            });
+
+          if (sessionError) {
+            throw sessionError;
+          }
+        }
+
+        const {
+          data: { session },
+          error: getSessionError,
+        } = await supabase.auth.getSession();
+
+        if (getSessionError) {
+          throw getSessionError;
+        }
+
+        if (cancelled) return;
+
+        if (session) {
+          setHasSession(true);
+          setSessionChecking(false);
+
+          if (hasRecoveryCredentials) {
+            clearRecoveryCredentialsFromUrl();
+          }
+
+          return;
+        }
+
+        scheduleInvalidLink();
+      } catch (recoveryError) {
+        console.error(
+          '[ResetPassword] Recovery session verification failed:',
+          recoveryError,
+        );
+
+        if (!cancelled) {
+          setError(
+            "Failed to verify reset link. Please request a new one.",
+          );
+          setSessionChecking(false);
+        }
+      }
+    };
+
+    void completeRecovery();
+
     return () => {
+      cancelled = true;
       subscription.unsubscribe();
-      clearTimeout(timeoutId);
+
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
     };
   }, []);
 


### PR DESCRIPTION
## Stage 7 — Cross-Platform Auth / Security

This PR hardens the shared web + Android authentication boundary without changing marketplace visuals or database schema.

### Scope
- fail-closes auth hydration when the authoritative `public.users` profile cannot be read
- removes session-metadata fallback as an access source of truth
- delegates `/dashboard` routing to canonical Buyer/Seller/Admin guards
- blocks explicitly inactive accounts at protected UI boundaries
- enforces trusted native deep-link origins
- uses the native OAuth callback for both Google and Facebook inside the APK
- explicitly recovers password-reset sessions received through Android App Links
- preserves Stage 3–5 canonical Seller onboarding/readiness flow
- adds Stage 7 cross-platform auth/security contract tests

### Validation
- local Stage 7 gate: PASS
- targeted tests: 26/26 PASS
- delta lint: PASS
- exact production build: PASS
- branch guard: ahead 1 / behind 0
- exact diff: 9 files
- npm audit during clean install: 0 vulnerabilities

### Guardrails
- no Supabase migration
- production not modified by this PR
- Supabase production not modified
- Supplier Commerce not modified
- no Admin/Super Admin visual redesign
- existing source Android modifications preserved
- no PR auto-merge

DRAFT — do not merge until remote checks / preview and separate merge-readiness evaluation pass.