### PR TITLE
Remove legacy dark surfaces outside footer

### DIFF
--- a/docs/visual-light-cleanup-2026-08-25.md
+++ b/docs/visual-light-cleanup-2026-08-25.md
@@ -1,0 +1,16 @@
+# Loadify Market — light compatibility cleanup
+
+Date: 25 August 2026
+
+Scope:
+- remove legacy dark page/account/mobile/auth surfaces through a compatibility layer;
+- preserve the current footer exactly as-is;
+- retain brand-colour buttons/badges and avoid a global `text-white` rewrite;
+- preserve functional behaviour.
+
+Branch guard:
+- base: `5be0d112eb8b7d531f3881699f605d18844c1837`;
+- footer component is not modified;
+- only `src/light-compat.css`, its load in `src/main.tsx`, this guard note and a focused guard test are introduced.
+
+Acceptance requires build/test/preview verification before merge.

--- a/netlify/functions-modern/seller-onboarding-status.ts
+++ b/netlify/functions-modern/seller-onboarding-status.ts
@@ -1,0 +1,3 @@
+import { handler } from '../functions/seller-onboarding-status';
+import { withLambda } from '../function-runtime/lambdaCompat';
+export default withLambda(handler);

--- a/netlify/functions-modern/set-seller-onboarding.ts
+++ b/netlify/functions-modern/set-seller-onboarding.ts
@@ -1,0 +1,3 @@
+import { handler } from '../functions/set-seller-onboarding';
+import { withLambda } from '../function-runtime/lambdaCompat';
+export default withLambda(handler);

--- a/netlify/functions-modern/start-seller-activation.ts
+++ b/netlify/functions-modern/start-seller-activation.ts
@@ -1,0 +1,3 @@
+import { handler } from '../functions/start-seller-activation';
+import { withLambda } from '../function-runtime/lambdaCompat';
+export default withLambda(handler);

--- a/src/__tests__/light-compatibility-guard.test.ts
+++ b/src/__tests__/light-compatibility-guard.test.ts
@@ -1,0 +1,30 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const css = readFileSync('src/light-compat.css', 'utf8');
+const main = readFileSync('src/main.tsx', 'utf8');
+
+describe('global light compatibility guard', () => {
+  it('loads the compatibility layer after the base theme', () => {
+    expect(main.indexOf('"./light-compat.css"')).toBeGreaterThan(main.indexOf('"./index.css"'));
+  });
+
+  it('keeps footer outside every compatibility selector', () => {
+    expect(css).toContain(':not(footer):not(footer *)');
+    expect(css).not.toMatch(/\nfooter\s*\{/);
+    expect(css).not.toMatch(/\n\.\w*footer/i);
+  });
+
+  it('neutralises legacy dark page surfaces without globally rewriting white text', () => {
+    for (const token of ['bg-slate-950', 'bg-slate-900', 'bg-gray-950', 'bg-gray-900', 'bg-black', 'bg-[#0A0E1A]', 'bg-[#121A2B]', 'bg-[#182235]']) {
+      expect(css).toContain(token);
+    }
+    expect(css).not.toContain(':not(footer):not(footer *)[class*="text-white"] {');
+  });
+
+  it('keeps placeholder and disabled states visible on light surfaces', () => {
+    expect(css).toContain('input::placeholder');
+    expect(css).toContain('textarea::placeholder');
+    expect(css).toContain(':disabled');
+  });
+});

--- a/src/__tests__/netlify-modern-wrapper-guard.test.ts
+++ b/src/__tests__/netlify-modern-wrapper-guard.test.ts
@@ -1,0 +1,33 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+const criticalHandlers = [
+  'register',
+  'start-seller-activation',
+  'seller-onboarding-status',
+  'set-seller-onboarding',
+  'recheck-activation',
+  'connect-onboard',
+  'connect-status',
+  'create-checkout',
+  'create-payment-intent',
+  'create-product',
+  'update-product',
+  'admin-user-status',
+  'admin-sellers',
+  'admin-orders',
+] as const;
+
+describe('Netlify modern function deployment guard', () => {
+  it.each(criticalHandlers)('%s has a published functions-modern wrapper', (name) => {
+    const modernPath = `netlify/functions-modern/${name}.ts`;
+    const sourcePath = `netlify/functions/${name}.ts`;
+
+    expect(existsSync(sourcePath), `${sourcePath} should exist`).toBe(true);
+    expect(existsSync(modernPath), `${modernPath} should exist because netlify.toml publishes functions-modern`).toBe(true);
+
+    const wrapper = readFileSync(modernPath, 'utf8');
+    expect(wrapper).toContain(`../functions/${name}`);
+    expect(wrapper).toContain('withLambda');
+  });
+});

--- a/src/light-compat.css
+++ b/src/light-compat.css
@@ -6,7 +6,8 @@
  * - neutralise old dark-theme Tailwind utility classes that still appear in
  *   functional/mobile/auth/account surfaces;
  * - preserve the Footer exactly as authored;
- * - preserve the Login page exactly as authored.
+ * - preserve the Login page exactly as authored;
+ * - keep the marketplace navbar in the canonical Seller identity: navy + blue depth + gold accents.
  *
  * Login opt-out is detected by its canonical #login-email control. This avoids
  * editing Login.tsx while ensuring no compatibility override reaches that route.
@@ -17,134 +18,126 @@
   color: #0a234f;
 }
 
-/* Marketplace header / category shell: remove the remaining dark chrome. */
+/*
+ * Marketplace navbar identity.
+ * Mirrors the Seller Signup identity panel without changing navbar structure:
+ * #0A234F navy base, #1D57D8 blue depth, white copy and #F5A300 gold accents.
+ * Login is excluded so /login remains visually identical to pre-PR #592.
+ */
 :root.market-light-root body:not(:has(#login-email)) > div header {
-  background: #ffffff !important;
-  border-color: #dce3ed !important;
-  box-shadow: 0 8px 25px rgba(10, 35, 79, 0.10) !important;
-  color: #0a234f !important;
+  background:
+    radial-gradient(circle at 22% -90%, rgba(29, 87, 216, 0.30), transparent 44%),
+    #0A234F !important;
+  border-color: rgba(255, 255, 255, 0.10) !important;
+  box-shadow: 0 8px 25px rgba(10, 35, 79, 0.28) !important;
+  color: #ffffff !important;
 }
 
 :root.market-light-root body:not(:has(#login-email)) header nav {
-  border-color: #e2e8f0 !important;
-}
-
-:root.market-light-root body:not(:has(#login-email)) header [class*="text-white"] {
-  color: #0a234f !important;
-}
-
-:root.market-light-root body:not(:has(#login-email)) header [class*="bg-white/"] {
-  background-color: #f4f6f8 !important;
-}
-
-:root.market-light-root body:not(:has(#login-email)) header [class*="border-white"],
-:root.market-light-root body:not(:has(#login-email)) header [class*="ring-white"] {
-  border-color: #d7e0ea !important;
-  --tw-ring-color: #d7e0ea !important;
+  border-color: rgba(255, 255, 255, 0.10) !important;
 }
 
 :root.market-light-root body:not(:has(#login-email)) header input[type="search"] {
-  background: #f7f9fc !important;
-  border-color: #cfd8e5 !important;
-  color: #0a234f !important;
+  background: rgba(255, 255, 255, 0.07) !important;
+  border-color: rgba(255, 255, 255, 0.15) !important;
+  color: #ffffff !important;
 }
 
 :root.market-light-root body:not(:has(#login-email)) header input[type="search"]::placeholder {
-  color: #64748b !important;
+  color: rgba(255, 255, 255, 0.55) !important;
   opacity: 1;
 }
 
 :root.market-light-root body:not(:has(#login-email)) header [class*="bg-[#0A234F]"] {
-  background-color: #ffffff !important;
+  background-color: #0A234F !important;
 }
 
 :root.market-light-root body:not(:has(#login-email)) header .nav-cat-link:hover,
 :root.market-light-root body:not(:has(#login-email)) header a[class*="text-white"]:hover,
 :root.market-light-root body:not(:has(#login-email)) header button[class*="text-white"]:hover {
-  color: #f5a300 !important;
+  color: #F5A300 !important;
 }
 
 /* Legacy full-surface dark backgrounds. */
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-slate-950"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-slate-900"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-gray-950"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-gray-900"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-zinc-950"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-zinc-900"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-neutral-950"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-neutral-900"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-black"] {
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-slate-950"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-slate-900"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-gray-950"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-gray-900"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-zinc-950"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-zinc-900"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-neutral-950"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-neutral-900"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-black"] {
   background-color: #ffffff !important;
   color: #0a234f;
 }
 
 /* Historical Loadify dark palette literals used by older mobile/auth screens. */
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#0A0E1A]"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#0a0e1a]"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#07080B]"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#07080b]"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#12121A]"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#12121a]"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#121A2B]"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#121a2b]"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#182235]"] {
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-[#0A0E1A]"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-[#0a0e1a]"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-[#07080B]"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-[#07080b]"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-[#12121A]"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-[#12121a]"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-[#121A2B]"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-[#121a2b]"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-[#182235]"] {
   background-color: #ffffff !important;
   color: #0a234f;
 }
 
 /* Dark translucent panels which become muddy on the light identity. */
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-black/"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-slate-950/"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-slate-900/"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-gray-950/"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-gray-900/"] {
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-black/"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-slate-950/"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-slate-900/"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-gray-950/"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-gray-900/"] {
   background-color: rgba(255, 255, 255, 0.96) !important;
 }
 
-/* Legacy dark-era hairlines. Do not touch coloured status borders. */
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="border-white/"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="border-slate-700"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="border-slate-800"] {
+/* Legacy dark-era hairlines. Header and Footer preserve their own identity. */
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="border-white/"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="border-slate-700"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="border-slate-800"] {
   border-color: #dce3ed !important;
 }
 
 /*
  * Text repair is deliberately scoped to elements that themselves carried a
- * dark surface. We do NOT globally rewrite text-white because white text is
- * correct on primary buttons, badges and other intentional brand accents.
+ * dark surface. Header/Footer remain intentional navy surfaces and keep white copy.
  */
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-slate-950"][class*="text-white"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-slate-900"][class*="text-white"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-gray-950"][class*="text-white"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-gray-900"][class*="text-white"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-zinc-950"][class*="text-white"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-zinc-900"][class*="text-white"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-neutral-950"][class*="text-white"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-neutral-900"][class*="text-white"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-black"][class*="text-white"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#0A0E1A]"][class*="text-white"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#121A2B]"][class*="text-white"],
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#182235]"][class*="text-white"] {
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-slate-950"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-slate-900"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-gray-950"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-gray-900"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-zinc-950"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-zinc-900"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-neutral-950"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-neutral-900"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-black"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-[#0A0E1A]"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-[#121A2B]"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *)[class*="bg-[#182235]"][class*="text-white"] {
   color: #0a234f !important;
 }
 
 /* Ensure generic semantic surfaces remain bright even on old routes. */
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *).bg-background {
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *).bg-background {
   background-color: #f7f9fc !important;
 }
 
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *).bg-card,
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *).bg-popover {
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *).bg-card,
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *).bg-popover {
   background-color: #ffffff !important;
 }
 
-/* Accessible placeholder/disabled contrast on light inputs. */
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *) input::placeholder,
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *) textarea::placeholder {
+/* Accessible placeholder/disabled contrast on light inputs outside preserved chrome. */
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *) input::placeholder,
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *) textarea::placeholder {
   color: #64748b;
   opacity: 1;
 }
 
-:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *) :disabled {
+:root.market-light-root body:not(:has(#login-email)) :not(header):not(header *):not(footer):not(footer *) :disabled {
   opacity: 0.62;
 }

--- a/src/light-compat.css
+++ b/src/light-compat.css
@@ -1,0 +1,104 @@
+/*
+ * Loadify Market — global light compatibility layer.
+ *
+ * Purpose:
+ * - keep the current light marketplace identity consistent across legacy routes;
+ * - neutralise old dark-theme Tailwind utility classes that still appear in
+ *   functional/mobile/auth/account surfaces;
+ * - preserve the Footer exactly as authored. Every selector below explicitly
+ *   excludes footer and its descendants.
+ *
+ * This file is intentionally loaded after index.css so it only acts as a
+ * compatibility layer. Brand-colour buttons and status colours are not
+ * globally recoloured.
+ */
+
+:root.market-light-root body {
+  background: #f7f9fc !important;
+  color: #0a234f;
+}
+
+/* Legacy full-surface dark backgrounds. */
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-slate-950"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-slate-900"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-gray-950"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-gray-900"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-zinc-950"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-zinc-900"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-neutral-950"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-neutral-900"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-black"] {
+  background-color: #ffffff !important;
+  color: #0a234f;
+}
+
+/* Historical Loadify dark palette literals used by older mobile/auth screens. */
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#0A0E1A]"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#0a0e1a]"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#07080B]"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#07080b]"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#12121A]"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#12121a]"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#121A2B]"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#121a2b]"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#182235]"] {
+  background-color: #ffffff !important;
+  color: #0a234f;
+}
+
+/* Dark translucent panels which become muddy on the light identity. */
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-black/"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-slate-950/"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-slate-900/"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-gray-950/"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-gray-900/"] {
+  background-color: rgba(255, 255, 255, 0.96) !important;
+}
+
+/* Legacy dark-era hairlines. Do not touch coloured status borders. */
+:root.market-light-root body :not(footer):not(footer *)[class*="border-white/"],
+:root.market-light-root body :not(footer):not(footer *)[class*="border-slate-700"],
+:root.market-light-root body :not(footer):not(footer *)[class*="border-slate-800"] {
+  border-color: #dce3ed !important;
+}
+
+/*
+ * Text repair is deliberately scoped to elements that themselves carried a
+ * dark surface. We do NOT globally rewrite text-white because white text is
+ * correct on primary buttons, badges and other intentional brand accents.
+ */
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-slate-950"][class*="text-white"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-slate-900"][class*="text-white"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-gray-950"][class*="text-white"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-gray-900"][class*="text-white"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-zinc-950"][class*="text-white"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-zinc-900"][class*="text-white"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-neutral-950"][class*="text-white"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-neutral-900"][class*="text-white"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-black"][class*="text-white"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#0A0E1A]"][class*="text-white"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#121A2B]"][class*="text-white"],
+:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#182235]"][class*="text-white"] {
+  color: #0a234f !important;
+}
+
+/* Ensure generic semantic surfaces remain bright even on old routes. */
+:root.market-light-root body :not(footer):not(footer *).bg-background {
+  background-color: #f7f9fc !important;
+}
+
+:root.market-light-root body :not(footer):not(footer *).bg-card,
+:root.market-light-root body :not(footer):not(footer *).bg-popover {
+  background-color: #ffffff !important;
+}
+
+/* Accessible placeholder/disabled contrast on light inputs. */
+:root.market-light-root body :not(footer):not(footer *) input::placeholder,
+:root.market-light-root body :not(footer):not(footer *) textarea::placeholder {
+  color: #64748b;
+  opacity: 1;
+}
+
+:root.market-light-root body :not(footer):not(footer *) :disabled {
+  opacity: 0.62;
+}

--- a/src/light-compat.css
+++ b/src/light-compat.css
@@ -5,60 +5,106 @@
  * - keep the current light marketplace identity consistent across legacy routes;
  * - neutralise old dark-theme Tailwind utility classes that still appear in
  *   functional/mobile/auth/account surfaces;
- * - preserve the Footer exactly as authored. Every selector below explicitly
- *   excludes footer and its descendants.
+ * - preserve the Footer exactly as authored;
+ * - preserve the Login page exactly as authored.
  *
- * This file is intentionally loaded after index.css so it only acts as a
- * compatibility layer. Brand-colour buttons and status colours are not
- * globally recoloured.
+ * Login opt-out is detected by its canonical #login-email control. This avoids
+ * editing Login.tsx while ensuring no compatibility override reaches that route.
  */
 
-:root.market-light-root body {
+:root.market-light-root body:not(:has(#login-email)) {
   background: #f7f9fc !important;
   color: #0a234f;
 }
 
+/* Marketplace header / category shell: remove the remaining dark chrome. */
+:root.market-light-root body:not(:has(#login-email)) > div header {
+  background: #ffffff !important;
+  border-color: #dce3ed !important;
+  box-shadow: 0 8px 25px rgba(10, 35, 79, 0.10) !important;
+  color: #0a234f !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) header nav {
+  border-color: #e2e8f0 !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) header [class*="text-white"] {
+  color: #0a234f !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) header [class*="bg-white/"] {
+  background-color: #f4f6f8 !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) header [class*="border-white"],
+:root.market-light-root body:not(:has(#login-email)) header [class*="ring-white"] {
+  border-color: #d7e0ea !important;
+  --tw-ring-color: #d7e0ea !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) header input[type="search"] {
+  background: #f7f9fc !important;
+  border-color: #cfd8e5 !important;
+  color: #0a234f !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) header input[type="search"]::placeholder {
+  color: #64748b !important;
+  opacity: 1;
+}
+
+:root.market-light-root body:not(:has(#login-email)) header [class*="bg-[#0A234F]"] {
+  background-color: #ffffff !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) header .nav-cat-link:hover,
+:root.market-light-root body:not(:has(#login-email)) header a[class*="text-white"]:hover,
+:root.market-light-root body:not(:has(#login-email)) header button[class*="text-white"]:hover {
+  color: #f5a300 !important;
+}
+
 /* Legacy full-surface dark backgrounds. */
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-slate-950"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-slate-900"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-gray-950"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-gray-900"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-zinc-950"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-zinc-900"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-neutral-950"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-neutral-900"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-black"] {
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-slate-950"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-slate-900"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-gray-950"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-gray-900"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-zinc-950"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-zinc-900"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-neutral-950"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-neutral-900"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-black"] {
   background-color: #ffffff !important;
   color: #0a234f;
 }
 
 /* Historical Loadify dark palette literals used by older mobile/auth screens. */
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#0A0E1A]"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#0a0e1a]"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#07080B]"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#07080b]"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#12121A]"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#12121a]"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#121A2B]"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#121a2b]"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#182235]"] {
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#0A0E1A]"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#0a0e1a]"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#07080B]"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#07080b]"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#12121A]"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#12121a]"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#121A2B]"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#121a2b]"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#182235]"] {
   background-color: #ffffff !important;
   color: #0a234f;
 }
 
 /* Dark translucent panels which become muddy on the light identity. */
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-black/"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-slate-950/"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-slate-900/"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-gray-950/"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-gray-900/"] {
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-black/"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-slate-950/"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-slate-900/"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-gray-950/"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-gray-900/"] {
   background-color: rgba(255, 255, 255, 0.96) !important;
 }
 
 /* Legacy dark-era hairlines. Do not touch coloured status borders. */
-:root.market-light-root body :not(footer):not(footer *)[class*="border-white/"],
-:root.market-light-root body :not(footer):not(footer *)[class*="border-slate-700"],
-:root.market-light-root body :not(footer):not(footer *)[class*="border-slate-800"] {
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="border-white/"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="border-slate-700"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="border-slate-800"] {
   border-color: #dce3ed !important;
 }
 
@@ -67,38 +113,38 @@
  * dark surface. We do NOT globally rewrite text-white because white text is
  * correct on primary buttons, badges and other intentional brand accents.
  */
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-slate-950"][class*="text-white"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-slate-900"][class*="text-white"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-gray-950"][class*="text-white"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-gray-900"][class*="text-white"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-zinc-950"][class*="text-white"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-zinc-900"][class*="text-white"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-neutral-950"][class*="text-white"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-neutral-900"][class*="text-white"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-black"][class*="text-white"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#0A0E1A]"][class*="text-white"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#121A2B]"][class*="text-white"],
-:root.market-light-root body :not(footer):not(footer *)[class*="bg-[#182235]"][class*="text-white"] {
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-slate-950"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-slate-900"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-gray-950"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-gray-900"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-zinc-950"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-zinc-900"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-neutral-950"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-neutral-900"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-black"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#0A0E1A]"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#121A2B]"][class*="text-white"],
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *)[class*="bg-[#182235]"][class*="text-white"] {
   color: #0a234f !important;
 }
 
 /* Ensure generic semantic surfaces remain bright even on old routes. */
-:root.market-light-root body :not(footer):not(footer *).bg-background {
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *).bg-background {
   background-color: #f7f9fc !important;
 }
 
-:root.market-light-root body :not(footer):not(footer *).bg-card,
-:root.market-light-root body :not(footer):not(footer *).bg-popover {
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *).bg-card,
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *).bg-popover {
   background-color: #ffffff !important;
 }
 
 /* Accessible placeholder/disabled contrast on light inputs. */
-:root.market-light-root body :not(footer):not(footer *) input::placeholder,
-:root.market-light-root body :not(footer):not(footer *) textarea::placeholder {
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *) input::placeholder,
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *) textarea::placeholder {
   color: #64748b;
   opacity: 1;
 }
 
-:root.market-light-root body :not(footer):not(footer *) :disabled {
+:root.market-light-root body:not(:has(#login-email)) :not(footer):not(footer *) :disabled {
   opacity: 0.62;
 }

--- a/src/light-semantic-compat.css
+++ b/src/light-semantic-compat.css
@@ -2,7 +2,7 @@
  * PR #592 — semantic light compatibility.
  *
  * Tailwind's custom semantic colours are currently hard-coded to the historical
- * dark palette.  That means classes such as text-foreground and border-border
+ * dark palette. That means classes such as text-foreground and border-border
  * do not follow the light CSS variables already defined by market-public-light.
  * Repair those utilities here without touching preserved chrome.
  *
@@ -27,6 +27,32 @@
 :root.market-light-root body:not(:has(#login-email))
   :not(header):not(header *):not(footer):not(footer *).text-muted-foreground {
   color: #64748B !important;
+}
+
+/* Legacy light-surface copy that still carries dark-theme literals. */
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *).text-slate-400 {
+  color: #64748B !important;
+}
+
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *).text-slate-500 {
+  color: #475569 !important;
+}
+
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *)h1.text-white,
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *)h2.text-white,
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *)h3.text-white,
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *)h4.text-white,
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *)p.text-white,
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *)td .text-white {
+  color: #0A234F !important;
 }
 
 /* Semantic surfaces and hairlines. */
@@ -54,6 +80,17 @@
   border-color: #DCE3ED !important;
 }
 
+/* Tables inherited several dark-era white hairlines and white row hover states. */
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *) table tr {
+  border-color: #E2E8F0 !important;
+}
+
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *) tr[class*="hover:bg-white/"]:hover {
+  background-color: #F8FAFC !important;
+}
+
 /* Inputs/selects that use hard-coded semantic utilities. */
 :root.market-light-root body:not(:has(#login-email))
   :not(header):not(header *):not(footer):not(footer *) input.bg-background,
@@ -67,7 +104,7 @@
 }
 
 /*
- * Functional backdrops are not page surfaces.  The earlier compatibility rule
+ * Functional backdrops are not page surfaces. The earlier compatibility rule
  * intentionally lightens legacy panels, but fixed full-screen backdrops must
  * continue to dim the page rather than turning 96% opaque white.
  */

--- a/src/light-semantic-compat.css
+++ b/src/light-semantic-compat.css
@@ -1,0 +1,83 @@
+/*
+ * PR #592 — semantic light compatibility.
+ *
+ * Tailwind's custom semantic colours are currently hard-coded to the historical
+ * dark palette.  That means classes such as text-foreground and border-border
+ * do not follow the light CSS variables already defined by market-public-light.
+ * Repair those utilities here without touching preserved chrome.
+ *
+ * Preserved by contract:
+ * - /login (detected by #login-email)
+ * - marketplace header/navbar
+ * - footer
+ */
+
+/* Core semantic text contrast on light surfaces. */
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *).text-foreground,
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *).text-card-foreground,
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *).text-popover-foreground,
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *).text-secondary-foreground {
+  color: #0A234F !important;
+}
+
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *).text-muted-foreground {
+  color: #64748B !important;
+}
+
+/* Semantic surfaces and hairlines. */
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *).bg-background {
+  background-color: #F7F9FC !important;
+}
+
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *).bg-card,
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *).bg-popover {
+  background-color: #FFFFFF !important;
+}
+
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *).bg-muted {
+  background-color: #F1F5F9 !important;
+}
+
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *).border-border,
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *).border-input {
+  border-color: #DCE3ED !important;
+}
+
+/* Inputs/selects that use hard-coded semantic utilities. */
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *) input.bg-background,
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *) textarea.bg-background,
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *) select.bg-background {
+  background-color: #FFFFFF !important;
+  color: #0A234F !important;
+  border-color: #CBD5E1 !important;
+}
+
+/*
+ * Functional backdrops are not page surfaces.  The earlier compatibility rule
+ * intentionally lightens legacy panels, but fixed full-screen backdrops must
+ * continue to dim the page rather than turning 96% opaque white.
+ */
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *)[class*="fixed"][class*="inset-0"][class*="bg-black/"] {
+  background-color: rgba(10, 35, 79, 0.42) !important;
+}
+
+/* Preserve readable hover/focus surfaces without creating new dark panels. */
+:root.market-light-root body:not(:has(#login-email))
+  :not(header):not(header *):not(footer):not(footer *)[class*="hover:bg-muted"]:hover {
+  background-color: #EEF3F8 !important;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import { patchCapacitorFetch } from "./lib/capacitorFetchPatch.ts";
 import { isCapacitorContext } from "./lib/capacitorUtils.ts";
 import "./index.css";
 import "./light-compat.css";
+import "./light-semantic-compat.css";
 import "./mobile-drawer-identity.css";
 import "./native.css";
 
@@ -112,7 +113,7 @@ if ('serviceWorker' in navigator) {
       return;
     }
 
-    navigator.serviceWorker.register('/sw.js').catch(() => {
+    window.navigator.serviceWorker.register('/sw.js').catch(() => {
       // Non-fatal — the website remains functional without offline caching.
     });
   });

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -21,6 +21,29 @@ if (isCapacitorContext()) {
   document.documentElement.classList.add('capacitor-native');
 }
 
+// PR #592 visual cleanup must never affect the pre-existing /login design.
+// Keep the global compatibility class disabled on /login and restore it on all
+// other SPA routes. Header/Login.tsx themselves remain untouched.
+const syncMarketLightScope = () => {
+  const isLoginRoute = window.location.pathname === '/login';
+  document.documentElement.classList.toggle('market-light-root', !isLoginRoute);
+};
+
+syncMarketLightScope();
+window.addEventListener('popstate', syncMarketLightScope);
+
+const originalPushState = window.history.pushState.bind(window.history);
+window.history.pushState = (...args) => {
+  originalPushState(...args);
+  syncMarketLightScope();
+};
+
+const originalReplaceState = window.history.replaceState.bind(window.history);
+window.history.replaceState = (...args) => {
+  originalReplaceState(...args);
+  syncMarketLightScope();
+};
+
 // On Capacitor APK, relative /.netlify/functions/ URLs resolve to
 // https://localhost (the local WebView file server) instead of the Netlify
 // backend.  This patch rewrites them to absolute URLs so every component
@@ -38,6 +61,12 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     </HelmetProvider>
   </React.StrictMode>
 );
+
+// App.tsx currently adds the compatibility class once at mount. Re-assert the
+// route exclusion after React effects run so /login stays byte-for-byte styled
+// by the pre-592 CSS/classes rather than by the compatibility layer.
+queueMicrotask(syncMarketLightScope);
+requestAnimationFrame(syncMarketLightScope);
 
 // DEV-ONLY: Overflow detector to identify elements causing horizontal overflow
 if (import.meta.env.DEV) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,7 @@ import { patchCapacitorFetch } from "./lib/capacitorFetchPatch.ts";
 import { isCapacitorContext } from "./lib/capacitorUtils.ts";
 import "./index.css";
 import "./light-compat.css";
+import "./mobile-drawer-identity.css";
 import "./native.css";
 
 // Initialise global error tracking (unhandled errors + unhandled rejections).

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -22,29 +22,6 @@ if (isCapacitorContext()) {
   document.documentElement.classList.add('capacitor-native');
 }
 
-// PR #592 visual cleanup must never affect the pre-existing /login design.
-// Keep the global compatibility class disabled on /login and restore it on all
-// other SPA routes. Header/Login.tsx themselves remain untouched.
-const syncMarketLightScope = () => {
-  const isLoginRoute = window.location.pathname === '/login';
-  document.documentElement.classList.toggle('market-light-root', !isLoginRoute);
-};
-
-syncMarketLightScope();
-window.addEventListener('popstate', syncMarketLightScope);
-
-const originalPushState = window.history.pushState.bind(window.history);
-window.history.pushState = (...args) => {
-  originalPushState(...args);
-  syncMarketLightScope();
-};
-
-const originalReplaceState = window.history.replaceState.bind(window.history);
-window.history.replaceState = (...args) => {
-  originalReplaceState(...args);
-  syncMarketLightScope();
-};
-
 // On Capacitor APK, relative /.netlify/functions/ URLs resolve to
 // https://localhost (the local WebView file server) instead of the Netlify
 // backend.  This patch rewrites them to absolute URLs so every component
@@ -62,12 +39,6 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
     </HelmetProvider>
   </React.StrictMode>
 );
-
-// App.tsx currently adds the compatibility class once at mount. Re-assert the
-// route exclusion after React effects run so /login stays byte-for-byte styled
-// by the pre-592 CSS/classes rather than by the compatibility layer.
-queueMicrotask(syncMarketLightScope);
-requestAnimationFrame(syncMarketLightScope);
 
 // DEV-ONLY: Overflow detector to identify elements causing horizontal overflow
 if (import.meta.env.DEV) {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -8,6 +8,7 @@ import { initErrorTracking } from "./lib/errorTracking.ts";
 import { patchCapacitorFetch } from "./lib/capacitorFetchPatch.ts";
 import { isCapacitorContext } from "./lib/capacitorUtils.ts";
 import "./index.css";
+import "./light-compat.css";
 import "./native.css";
 
 // Initialise global error tracking (unhandled errors + unhandled rejections).

--- a/src/mobile-drawer-identity.css
+++ b/src/mobile-drawer-identity.css
@@ -1,0 +1,51 @@
+/* Mobile / hamburger navigation identity.
+ * Keeps navigation chrome aligned with the Seller Signup navy/gold panel and
+ * repairs the drawer overlay after the global light compatibility pass.
+ * /login is explicitly excluded from these overrides.
+ */
+
+:root.market-light-root body:not(:has(#login-email)):has([role="dialog"][aria-label="Navigation menu"]) > div[class*="bg-black/40"] {
+  background: rgba(10, 35, 79, 0.42) !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) [role="dialog"][aria-label="Navigation menu"] {
+  background:
+    radial-gradient(circle at 18% -8%, rgba(29, 87, 216, 0.30), transparent 35%),
+    #0A234F !important;
+  border-color: rgba(255, 255, 255, 0.12) !important;
+  color: #ffffff !important;
+  box-shadow: 18px 0 50px rgba(10, 35, 79, 0.32) !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) [role="dialog"][aria-label="Navigation menu"] [class*="border-slate"] {
+  border-color: rgba(255, 255, 255, 0.10) !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) [role="dialog"][aria-label="Navigation menu"] [class*="bg-slate"],
+:root.market-light-root body:not(:has(#login-email)) [role="dialog"][aria-label="Navigation menu"] [class*="bg-white"] {
+  background-color: rgba(255, 255, 255, 0.06) !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) [role="dialog"][aria-label="Navigation menu"] [class*="text-[#0A234F]"],
+:root.market-light-root body:not(:has(#login-email)) [role="dialog"][aria-label="Navigation menu"] [class*="text-slate-600"],
+:root.market-light-root body:not(:has(#login-email)) [role="dialog"][aria-label="Navigation menu"] [class*="text-slate-500"] {
+  color: rgba(255, 255, 255, 0.80) !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) [role="dialog"][aria-label="Navigation menu"] [class*="text-slate-400"] {
+  color: rgba(255, 255, 255, 0.60) !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) [role="dialog"][aria-label="Navigation menu"] [class*="text-[#1D57D8]"] {
+  color: #F5A300 !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) [role="dialog"][aria-label="Navigation menu"] a:hover,
+:root.market-light-root body:not(:has(#login-email)) [role="dialog"][aria-label="Navigation menu"] button:hover {
+  background-color: rgba(255, 255, 255, 0.08) !important;
+}
+
+:root.market-light-root body:not(:has(#login-email)) [role="dialog"][aria-label="Navigation menu"] a:hover [class*="text-"],
+:root.market-light-root body:not(:has(#login-email)) [role="dialog"][aria-label="Navigation menu"] button:hover [class*="text-"] {
+  color: #F5A300 !important;
+}


### PR DESCRIPTION
## Scope
- apply a light compatibility layer across legacy public/mobile/account/workspace content surfaces
- preserve the Login page exactly as pre-PR #592
- preserve Footer exactly as authored
- keep marketplace navbar/drawer in the Seller Signup navy/blue/gold identity
- repair dark-era semantic text, borders, placeholders, table rows and functional overlays
- restore missing Netlify `functions-modern` wrappers discovered during E2E audit for Seller onboarding/activation

## Functional fixes discovered by audit
- publish `seller-onboarding-status`
- publish `set-seller-onboarding`
- publish `start-seller-activation`
- add automated deployment guard for critical `functions-modern` wrappers

## Guardrails
- no Supplier Commerce activation or provider changes
- no Footer component changes
- no Login component changes
- no global text-white rewrite
- no database data rewrite or role mutation

## Audit notes
- hosted `active_account_access` RLS policies are RESTRICTIVE and therefore preserve specific row policies
- auth/public user mapping and core commerce relationships have no orphan records in the hosted audit
- historical Seller onboarding projections remain fail-closed by canonical design

## Branch Guard
Base: `5be0d112eb8b7d531f3881699f605d18844c1837`

Acceptance requires build/test/deploy-preview plus final visual/runtime verification before merge.