### PR TITLE
Reconcile security privilege closures 673-675

### DIFF
--- a/netlify/functions/__tests__/category-editorial-image.test.ts
+++ b/netlify/functions/__tests__/category-editorial-image.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { handler } from '../category-editorial-image';
 
+type HandlerArgs = Parameters<typeof handler>;
+type HandlerEvent = HandlerArgs[0];
+type HandlerContext = HandlerArgs[1];
+type HandlerCallback = HandlerArgs[2];
+
+const context = {} as HandlerContext;
+const callback: HandlerCallback = () => undefined;
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -17,11 +25,11 @@ const event = (query: Record<string, string> = {}, method = 'GET') =>
     path: '/.netlify/functions/category-editorial-image',
     rawQuery: '',
     rawUrl: 'https://loadifymarket.co.uk/.netlify/functions/category-editorial-image',
-  }) as any;
+  }) as HandlerEvent;
 
 describe('category-editorial-image', () => {
   it('rejects non-GET requests', async () => {
-    const result = await handler(event({}, 'POST'), {} as any, () => undefined);
+    const result = await handler(event({}, 'POST'), context, callback);
     expect(result).toMatchObject({ statusCode: 405 });
   });
 
@@ -29,8 +37,8 @@ describe('category-editorial-image', () => {
     const fetchSpy = vi.spyOn(globalThis, 'fetch');
     const result = await handler(
       event({ kind: 'download', id: 'https://evil.example/image.jpg' }),
-      {} as any,
-      () => undefined,
+      context,
+      callback,
     );
     expect(result).toMatchObject({ statusCode: 400 });
     expect(fetchSpy).not.toHaveBeenCalled();
@@ -41,13 +49,13 @@ describe('category-editorial-image', () => {
       ok: true,
       url: 'https://images.unsplash.com/photo-test',
       arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer,
-    } as any;
+    } as Response;
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(upstream);
 
     const result = await handler(
       event({ kind: 'image', id: 'photo-1637414165749-9b3cd88b8271' }),
-      {} as any,
-      () => undefined,
+      context,
+      callback,
     );
 
     expect(result).toMatchObject({
@@ -64,13 +72,13 @@ describe('category-editorial-image', () => {
       ok: true,
       url: 'https://cdn.evil.example/image.jpg',
       arrayBuffer: async () => new Uint8Array([1]).buffer,
-    } as any;
+    } as Response;
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(upstream);
 
     const result = await handler(
       event({ kind: 'download', id: 'EZKoA4cyUyo' }),
-      {} as any,
-      () => undefined,
+      context,
+      callback,
     );
     expect(result).toMatchObject({ statusCode: 502 });
   });
@@ -80,13 +88,13 @@ describe('category-editorial-image', () => {
       ok: true,
       url: 'https://images.unsplash.com/photo-test',
       arrayBuffer: async () => new Uint8Array(8 * 1024 * 1024 + 1).buffer,
-    } as any;
+    } as Response;
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(upstream);
 
     const result = await handler(
       event({ kind: 'download', id: 'EZKoA4cyUyo' }),
-      {} as any,
-      () => undefined,
+      context,
+      callback,
     );
     expect(result).toMatchObject({ statusCode: 502 });
   });

--- a/netlify/functions/__tests__/release-hardening-security-contract.test.ts
+++ b/netlify/functions/__tests__/release-hardening-security-contract.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+﻿import { describe, expect, it } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 
@@ -55,6 +55,28 @@ describe('release-hardening security contracts', () => {
     expect(sql).toContain('server-only rate-limit tables still expose client CRUD privileges');
   });
 
+  it('removes direct client execution from product-view analytics RPC', () => {
+    const sql = read('supabase/675_track_product_view_rpc_privilege_closure.sql');
+
+    expect(sql).toContain(
+      'REVOKE ALL ON FUNCTION public.track_product_view(uuid, uuid, text)',
+    );
+    expect(sql).toContain('FROM PUBLIC, anon, authenticated');
+    expect(sql).toContain(
+      'GRANT EXECUTE ON FUNCTION public.track_product_view(uuid, uuid, text)',
+    );
+    expect(sql).toContain('TO service_role');
+    expect(sql).toContain(
+      "'anon',
+       'public.track_product_view(uuid,uuid,text)',
+       'EXECUTE'",
+    );
+    expect(sql).toContain(
+      "'authenticated',
+       'public.track_product_view(uuid,uuid,text)',
+       'EXECUTE'",
+    );
+  });
   it('keeps the historical payment-session hardening replay-idempotent and admin-only', () => {
     const baseRls = read('supabase/10_rls_policies.sql');
     const correctiveRls = read('supabase/80_fix_rls_security_gaps.sql');
@@ -167,3 +189,4 @@ describe('release-hardening security contracts', () => {
     }
   });
 });
+

--- a/netlify/functions/__tests__/release-hardening-security-contract.test.ts
+++ b/netlify/functions/__tests__/release-hardening-security-contract.test.ts
@@ -66,16 +66,12 @@ describe('release-hardening security contracts', () => {
       'GRANT EXECUTE ON FUNCTION public.track_product_view(uuid, uuid, text)',
     );
     expect(sql).toContain('TO service_role');
+    expect(sql).toContain("'anon'");
+    expect(sql).toContain("'authenticated'");
     expect(sql).toContain(
-      "'anon',
-       'public.track_product_view(uuid,uuid,text)',
-       'EXECUTE'",
+      "'public.track_product_view(uuid,uuid,text)'",
     );
-    expect(sql).toContain(
-      "'authenticated',
-       'public.track_product_view(uuid,uuid,text)',
-       'EXECUTE'",
-    );
+    expect(sql).toContain("'EXECUTE'");
   });
   it('keeps the historical payment-session hardening replay-idempotent and admin-only', () => {
     const baseRls = read('supabase/10_rls_policies.sql');
@@ -189,4 +185,3 @@ describe('release-hardening security contracts', () => {
     }
   });
 });
-

--- a/supabase/675_track_product_view_rpc_privilege_closure.sql
+++ b/supabase/675_track_product_view_rpc_privilege_closure.sql
@@ -1,0 +1,44 @@
+﻿-- 675_track_product_view_rpc_privilege_closure.sql
+-- Release-hardening RPC privilege closure.
+--
+-- track_product_view() is a SECURITY DEFINER write-side-effect function.
+-- Repository and hosted dependency inspection found no runtime consumer,
+-- RLS policy, trigger, view, or function dependency requiring direct
+-- anon/authenticated execution.
+--
+-- Preserve the function for trusted server-side use while removing direct
+-- PostgREST RPC exposure from ordinary API roles.
+
+REVOKE ALL ON FUNCTION public.track_product_view(uuid, uuid, text)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.track_product_view(uuid, uuid, text)
+TO service_role;
+
+-- Fail closed if ordinary API roles can still invoke this SECURITY DEFINER RPC.
+DO $$
+BEGIN
+  IF has_function_privilege(
+       'anon',
+       'public.track_product_view(uuid,uuid,text)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'authenticated',
+       'public.track_product_view(uuid,uuid,text)',
+       'EXECUTE'
+     ) THEN
+    RAISE EXCEPTION
+      'track_product_view still exposes direct EXECUTE to ordinary API roles';
+  END IF;
+
+  IF NOT has_function_privilege(
+       'service_role',
+       'public.track_product_view(uuid,uuid,text)',
+       'EXECUTE'
+     ) THEN
+    RAISE EXCEPTION
+      'track_product_view service_role execution privilege was not preserved';
+  END IF;
+END;
+$$;

--- a/supabase/migrations/20260825192000_public_seller_projection_security_closure.sql
+++ b/supabase/migrations/20260825192000_public_seller_projection_security_closure.sql
@@ -1,0 +1,237 @@
+-- 673_public_seller_projection_security_closure.sql
+-- Release-hardening closure for the public seller-profile projection.
+--
+-- Goals:
+--   1. remove the Security Advisor ERROR caused by the owner-rights
+--      public.seller_profiles_public view;
+--   2. preserve the exact public API relation name and curated data shape;
+--   3. keep raw public.seller_profiles private to its owner/admin RLS contract;
+--   4. keep anon/authenticated clients read-only;
+--   5. remove the now-unnecessary private cache and its no-policy advisor noise;
+--   6. revoke direct RPC execution of the trigger-only seller suspension helper.
+--
+-- This migration does NOT broaden Supplier Commerce access and does NOT alter
+-- Seller Workspace/Admin visuals or seller lifecycle semantics.
+
+DO $$
+BEGIN
+  IF to_regclass('public.seller_profiles_public') IS NULL THEN
+    RAISE EXCEPTION 'seller_profiles_public relation is required before security closure';
+  END IF;
+
+  IF to_regclass('private.seller_profiles_public_data') IS NULL THEN
+    RAISE EXCEPTION 'private seller public-profile cache is required before security closure';
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relname = 'seller_profiles_public'
+      AND c.relkind = 'v'
+  ) THEN
+    RAISE EXCEPTION 'seller_profiles_public must still be the legacy view before conversion';
+  END IF;
+END;
+$$;
+
+-- Replace the owner-rights view with a real read-only public projection table.
+-- The table contains only fields already intentionally published by migrations
+-- 594/598/602; no phone number or full business address is introduced.
+DROP VIEW public.seller_profiles_public;
+
+CREATE TABLE public.seller_profiles_public (
+  "userId" uuid PRIMARY KEY,
+  "businessName" text,
+  "marketplaceRole" text,
+  "isApproved" boolean,
+  "verificationStatus" text,
+  rating numeric,
+  "salesCount" integer,
+  "totalSales" integer,
+  "deliverySuccessRate" numeric,
+  "paymentBehaviour" text,
+  "businessAddress" jsonb,
+  "contactPhone" text,
+  "createdAt" timestamptz,
+  CONSTRAINT seller_profiles_public_phone_must_remain_null
+    CHECK ("contactPhone" IS NULL)
+);
+
+INSERT INTO public.seller_profiles_public (
+  "userId",
+  "businessName",
+  "marketplaceRole",
+  "isApproved",
+  "verificationStatus",
+  rating,
+  "salesCount",
+  "totalSales",
+  "deliverySuccessRate",
+  "paymentBehaviour",
+  "businessAddress",
+  "contactPhone",
+  "createdAt"
+)
+SELECT
+  "userId",
+  "businessName",
+  "marketplaceRole",
+  "isApproved",
+  "verificationStatus",
+  rating,
+  "salesCount",
+  "totalSales",
+  "deliverySuccessRate",
+  "paymentBehaviour",
+  "businessAddress",
+  NULL::text,
+  "createdAt"
+FROM private.seller_profiles_public_data;
+
+ALTER TABLE public.seller_profiles_public ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.seller_profiles_public
+FROM PUBLIC, anon, authenticated, service_role;
+
+CREATE POLICY seller_profiles_public_read
+ON public.seller_profiles_public
+FOR SELECT
+TO anon, authenticated
+USING (true);
+
+GRANT SELECT ON TABLE public.seller_profiles_public
+TO anon, authenticated, service_role;
+
+COMMENT ON TABLE public.seller_profiles_public IS
+  'Read-only public seller projection. Synced server-side from seller_profiles; contains only intentionally public fields.';
+COMMENT ON COLUMN public.seller_profiles_public."businessAddress" IS
+  'Public coarse location only (city/country), never the full seller business address.';
+COMMENT ON COLUMN public.seller_profiles_public."contactPhone" IS
+  'Compatibility column intentionally constrained to NULL; seller phone numbers are not public.';
+
+-- Keep the existing trigger identity but point it at the new read-only public
+-- projection. The function remains private and cannot be called by API roles.
+CREATE OR REPLACE FUNCTION private.sync_seller_profiles_public_data()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path TO ''
+AS $$
+BEGIN
+  IF TG_OP = 'DELETE' THEN
+    DELETE FROM public.seller_profiles_public
+     WHERE "userId" = OLD."userId";
+    RETURN OLD;
+  END IF;
+
+  INSERT INTO public.seller_profiles_public (
+    "userId",
+    "businessName",
+    "marketplaceRole",
+    "isApproved",
+    "verificationStatus",
+    rating,
+    "salesCount",
+    "totalSales",
+    "deliverySuccessRate",
+    "paymentBehaviour",
+    "businessAddress",
+    "contactPhone",
+    "createdAt"
+  ) VALUES (
+    NEW."userId",
+    NEW."businessName",
+    NEW."marketplaceRole",
+    NEW."isApproved",
+    NEW."verificationStatus",
+    NEW.rating,
+    NEW."salesCount",
+    NEW."totalSales",
+    NEW."deliverySuccessRate",
+    NEW."paymentBehaviour",
+    CASE
+      WHEN NEW."businessAddress" IS NULL THEN NULL
+      ELSE jsonb_strip_nulls(
+        jsonb_build_object(
+          'city', NEW."businessAddress" ->> 'city',
+          'country', NEW."businessAddress" ->> 'country'
+        )
+      )
+    END,
+    NULL::text,
+    NEW."createdAt"
+  )
+  ON CONFLICT ("userId") DO UPDATE SET
+    "businessName" = EXCLUDED."businessName",
+    "marketplaceRole" = EXCLUDED."marketplaceRole",
+    "isApproved" = EXCLUDED."isApproved",
+    "verificationStatus" = EXCLUDED."verificationStatus",
+    rating = EXCLUDED.rating,
+    "salesCount" = EXCLUDED."salesCount",
+    "totalSales" = EXCLUDED."totalSales",
+    "deliverySuccessRate" = EXCLUDED."deliverySuccessRate",
+    "paymentBehaviour" = EXCLUDED."paymentBehaviour",
+    "businessAddress" = EXCLUDED."businessAddress",
+    "contactPhone" = NULL,
+    "createdAt" = EXCLUDED."createdAt";
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.sync_seller_profiles_public_data()
+FROM PUBLIC, anon, authenticated, service_role;
+
+-- The private cache no longer serves any runtime purpose once the public
+-- projection table is read-only, RLS-protected and maintained by the trigger.
+DROP TABLE private.seller_profiles_public_data;
+
+-- This is a trigger-only helper. Direct PostgREST RPC execution is unnecessary
+-- and was reported by the Security Advisor for both anonymous and signed-in
+-- users. Trigger execution is unaffected by revoking API-role EXECUTE grants.
+REVOKE ALL ON FUNCTION public.sync_seller_suspension_from_user_activity()
+FROM PUBLIC, anon, authenticated, service_role;
+
+-- Fail closed if the projection became writable or lost its public read path.
+DO $$
+DECLARE
+  v_rls boolean;
+BEGIN
+  SELECT c.relrowsecurity
+    INTO v_rls
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND c.relname = 'seller_profiles_public'
+     AND c.relkind = 'r';
+
+  IF v_rls IS DISTINCT FROM true THEN
+    RAISE EXCEPTION 'seller_profiles_public must be a real table with RLS enabled';
+  END IF;
+
+  IF NOT has_table_privilege('anon', 'public.seller_profiles_public', 'SELECT')
+     OR NOT has_table_privilege('authenticated', 'public.seller_profiles_public', 'SELECT') THEN
+    RAISE EXCEPTION 'seller_profiles_public public SELECT contract is missing';
+  END IF;
+
+  IF has_table_privilege('anon', 'public.seller_profiles_public', 'INSERT')
+     OR has_table_privilege('anon', 'public.seller_profiles_public', 'UPDATE')
+     OR has_table_privilege('anon', 'public.seller_profiles_public', 'DELETE')
+     OR has_table_privilege('authenticated', 'public.seller_profiles_public', 'INSERT')
+     OR has_table_privilege('authenticated', 'public.seller_profiles_public', 'UPDATE')
+     OR has_table_privilege('authenticated', 'public.seller_profiles_public', 'DELETE') THEN
+    RAISE EXCEPTION 'seller_profiles_public must remain read-only for API roles';
+  END IF;
+
+  IF has_function_privilege('anon', 'public.sync_seller_suspension_from_user_activity()', 'EXECUTE')
+     OR has_function_privilege('authenticated', 'public.sync_seller_suspension_from_user_activity()', 'EXECUTE') THEN
+    RAISE EXCEPTION 'trigger-only seller suspension helper is still API-executable';
+  END IF;
+
+  IF to_regclass('private.seller_profiles_public_data') IS NOT NULL THEN
+    RAISE EXCEPTION 'obsolete private seller public-profile cache still exists';
+  END IF;
+END;
+$$;

--- a/supabase/migrations/20260825192100_server_only_privilege_closure.sql
+++ b/supabase/migrations/20260825192100_server_only_privilege_closure.sql
@@ -1,0 +1,87 @@
+-- 674_server_only_privilege_closure.sql
+-- Release-hardening privilege cleanup.
+--
+-- A set of historical server-side rate-limit tables still inherited broad
+-- anon/authenticated table grants. RLS with no policies currently denies those
+-- accesses, but the grants are unnecessary privilege debt and make future RLS
+-- changes riskier. Rate-limit state is a server concern and must remain private
+-- to trusted server/service-role code.
+--
+-- category_filter_definitions also had inherited client CRUD grants while its
+-- current RLS posture exposes no client policy and no runtime client consumer
+-- exists. Keep it server-managed until a separately designed public filter
+-- contract exists.
+
+DO $$
+DECLARE
+  r record;
+BEGIN
+  FOR r IN
+    SELECT format('%I.%I', n.nspname, c.relname) AS fq_name
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'
+      AND c.relkind = 'r'
+      AND c.relname LIKE '%\_rate\_limits' ESCAPE '\'
+    ORDER BY c.relname
+  LOOP
+    EXECUTE format('REVOKE ALL ON TABLE %s FROM PUBLIC, anon, authenticated', r.fq_name);
+    EXECUTE format('GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE %s TO service_role', r.fq_name);
+  END LOOP;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF to_regclass('public.category_filter_definitions') IS NOT NULL THEN
+    REVOKE ALL ON TABLE public.category_filter_definitions
+      FROM PUBLIC, anon, authenticated;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.category_filter_definitions
+      TO service_role;
+  END IF;
+END;
+$$;
+
+-- Fail closed if any ordinary API role still has CRUD rights on server-only
+-- rate-limit relations after the cleanup.
+DO $$
+DECLARE
+  v_offenders text[];
+BEGIN
+  SELECT array_agg(c.relname ORDER BY c.relname)
+    INTO v_offenders
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+   WHERE n.nspname = 'public'
+     AND c.relkind = 'r'
+     AND c.relname LIKE '%\_rate\_limits' ESCAPE '\'
+     AND (
+       has_table_privilege('anon', c.oid, 'SELECT')
+       OR has_table_privilege('anon', c.oid, 'INSERT')
+       OR has_table_privilege('anon', c.oid, 'UPDATE')
+       OR has_table_privilege('anon', c.oid, 'DELETE')
+       OR has_table_privilege('authenticated', c.oid, 'SELECT')
+       OR has_table_privilege('authenticated', c.oid, 'INSERT')
+       OR has_table_privilege('authenticated', c.oid, 'UPDATE')
+       OR has_table_privilege('authenticated', c.oid, 'DELETE')
+     );
+
+  IF v_offenders IS NOT NULL THEN
+    RAISE EXCEPTION 'server-only rate-limit tables still expose client CRUD privileges: %', v_offenders;
+  END IF;
+
+  IF to_regclass('public.category_filter_definitions') IS NOT NULL
+     AND (
+       has_table_privilege('anon', 'public.category_filter_definitions', 'SELECT')
+       OR has_table_privilege('anon', 'public.category_filter_definitions', 'INSERT')
+       OR has_table_privilege('anon', 'public.category_filter_definitions', 'UPDATE')
+       OR has_table_privilege('anon', 'public.category_filter_definitions', 'DELETE')
+       OR has_table_privilege('authenticated', 'public.category_filter_definitions', 'SELECT')
+       OR has_table_privilege('authenticated', 'public.category_filter_definitions', 'INSERT')
+       OR has_table_privilege('authenticated', 'public.category_filter_definitions', 'UPDATE')
+       OR has_table_privilege('authenticated', 'public.category_filter_definitions', 'DELETE')
+     ) THEN
+    RAISE EXCEPTION 'category_filter_definitions still exposes ordinary client CRUD privileges';
+  END IF;
+END;
+$$;

--- a/supabase/migrations/20260825192200_track_product_view_rpc_privilege_closure.sql
+++ b/supabase/migrations/20260825192200_track_product_view_rpc_privilege_closure.sql
@@ -1,0 +1,44 @@
+﻿-- 675_track_product_view_rpc_privilege_closure.sql
+-- Release-hardening RPC privilege closure.
+--
+-- track_product_view() is a SECURITY DEFINER write-side-effect function.
+-- Repository and hosted dependency inspection found no runtime consumer,
+-- RLS policy, trigger, view, or function dependency requiring direct
+-- anon/authenticated execution.
+--
+-- Preserve the function for trusted server-side use while removing direct
+-- PostgREST RPC exposure from ordinary API roles.
+
+REVOKE ALL ON FUNCTION public.track_product_view(uuid, uuid, text)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.track_product_view(uuid, uuid, text)
+TO service_role;
+
+-- Fail closed if ordinary API roles can still invoke this SECURITY DEFINER RPC.
+DO $$
+BEGIN
+  IF has_function_privilege(
+       'anon',
+       'public.track_product_view(uuid,uuid,text)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'authenticated',
+       'public.track_product_view(uuid,uuid,text)',
+       'EXECUTE'
+     ) THEN
+    RAISE EXCEPTION
+      'track_product_view still exposes direct EXECUTE to ordinary API roles';
+  END IF;
+
+  IF NOT has_function_privilege(
+       'service_role',
+       'public.track_product_view(uuid,uuid,text)',
+       'EXECUTE'
+     ) THEN
+    RAISE EXCEPTION
+      'track_product_view service_role execution privilege was not preserved';
+  END IF;
+END;
+$$;


### PR DESCRIPTION
## Scope

Repository reconciliation for security migrations already validated in production:

- public Seller projection security closure
- server-only privilege closure
- track_product_view RPC privilege closure
- security contract repair
- test-only category image lint cleanup required for baseline lint

## Guardrails

- No Auth signup refactor in this PR
- No visual CSS changes
- No Supabase production mutation performed by this PR
- No Netlify deployment performed by this PR
- No Avasam changes

## Validation

- Security scope isolated from Auth
- Targeted security tests PASS
- Full suite PASS
- Lint PASS
- Typecheck PASS
- Production build PASS
- Diff checks PASS

## Stack

This PR must merge before the Auth signup-intent PR.