### PR TITLE
Repair light semantic selector syntax

### DIFF
--- a/src/light-semantic-compat.css
+++ b/src/light-semantic-compat.css
@@ -41,17 +41,17 @@
 }
 
 :root.market-light-root body:not(:has(#login-email))
-  :not(header):not(header *):not(footer):not(footer *)h1.text-white,
+  h1.text-white:not(header):not(header *):not(footer):not(footer *),
 :root.market-light-root body:not(:has(#login-email))
-  :not(header):not(header *):not(footer):not(footer *)h2.text-white,
+  h2.text-white:not(header):not(header *):not(footer):not(footer *),
 :root.market-light-root body:not(:has(#login-email))
-  :not(header):not(header *):not(footer):not(footer *)h3.text-white,
+  h3.text-white:not(header):not(header *):not(footer):not(footer *),
 :root.market-light-root body:not(:has(#login-email))
-  :not(header):not(header *):not(footer):not(footer *)h4.text-white,
+  h4.text-white:not(header):not(header *):not(footer):not(footer *),
 :root.market-light-root body:not(:has(#login-email))
-  :not(header):not(header *):not(footer):not(footer *)p.text-white,
+  p.text-white:not(header):not(header *):not(footer):not(footer *),
 :root.market-light-root body:not(:has(#login-email))
-  :not(header):not(header *):not(footer):not(footer *)td .text-white {
+  td:not(header):not(header *):not(footer):not(footer *) .text-white {
   color: #0A234F !important;
 }
 


### PR DESCRIPTION
## Scope

Isolated syntax repair for the Loadify Market light semantic compatibility layer.

- repairs six malformed CSS selectors
- removes the Vite/esbuild css-syntax-error warning
- preserves the existing light compatibility behaviour
- leaves Footer unchanged

## Validation

- exact one-file scope: src/light-semantic-compat.css
- Light Compatibility Guard: 4/4 PASS
- full suite: 76/76 files, 621/621 tests PASS
- typecheck PASS
- production build PASS
- CSS syntax warning CLOSED
- malformed-selector absence proof PASS
- Footer unchanged
- diff checks PASS

## Guardrails

- No Auth changes
- No Security migration changes
- No Supabase changes
- No Avasam changes
- No production mutation
- No merge performed

## Stack note

This fix should be integrated before final closure of PR #595 and PR #596 so their final build validation runs against the corrected visual baseline.