### PR TITLE
Complete provider-bound Google signup foundation for #596

### DIFF
--- a/netlify/functions-modern/register-social-intent.ts
+++ b/netlify/functions-modern/register-social-intent.ts
@@ -1,0 +1,1 @@
+export { handler } from '../functions/register-social-intent';

--- a/netlify/functions/__tests__/auth-before-user-created-hook-contract.test.ts
+++ b/netlify/functions/__tests__/auth-before-user-created-hook-contract.test.ts
@@ -36,23 +36,17 @@ describe("Before User Created signup-intent hook contract", () => {
 
   it("grants execution only to supabase_auth_admin", () => {
     expect(sql).toContain("to supabase_auth_admin");
-    expect(sql).toContain(
-      "from public, anon, authenticated, service_role",
-    );
-
+    expect(sql).toContain("from public, anon, authenticated, service_role");
     expect(sql).toContain(
       "'supabase_auth_admin must execute before_user_created_validate_signup_intent'",
     );
   });
 
   it("does not expose the private schema to clients", () => {
-    expect(sql).toContain(
-      "has_schema_privilege('anon', 'private', 'USAGE')",
-    );
+    expect(sql).toContain("has_schema_privilege('anon', 'private', 'USAGE')");
     expect(sql).toContain(
       "has_schema_privilege('authenticated', 'private', 'USAGE')",
     );
-
     expect(sql).not.toMatch(
       /grant\s+usage\s+on\s+schema\s+private\s+to\s+(anon|authenticated)/i,
     );
@@ -64,17 +58,27 @@ describe("Before User Created signup-intent hook contract", () => {
     expect(sql).toContain("client role metadata is forbidden");
   });
 
-  it("rejects fresh OAuth creation from generic sign-in", () => {
-    expect(sql).toContain("v_provider in ('google', 'facebook')");
-    expect(sql).toContain(
-      "social signup requires registration authorization",
-    );
-    expect(sql).toContain("unsupported auth provider");
+  it("requires provider-bound authorization for fresh Google creation", () => {
+    expect(sql).toContain("if v_provider = 'google' then");
+    expect(sql).toContain("v_user_metadata->>'sub'");
+    expect(sql).toContain("si.auth_provider = 'google'");
+    expect(sql).toContain("si.provider_subject = v_provider_subject");
+    expect(sql).toContain("lower(trim(si.email)) = v_email");
+    expect(sql).toContain("Google registration authorization not found");
   });
 
-  it("requires an intent for email signup", () => {
-    expect(sql).toContain("v_provider <> 'email'");
+  it("keeps fresh Facebook account creation fail-closed", () => {
+    expect(sql).toContain("elsif v_provider = 'facebook' then");
+    expect(sql).toContain(
+      "Facebook signup requires registration authorization",
+    );
+  });
+
+  it("requires an email-only intent for email signup", () => {
+    expect(sql).toContain("elsif v_provider = 'email' then");
     expect(sql).toContain("v_user_metadata->>'intent_id'");
+    expect(sql).toContain("si.auth_provider = 'email'");
+    expect(sql).toContain("si.provider_subject is null");
     expect(sql).toContain("signup intent is required");
     expect(sql).toContain("signup intent not found");
   });
@@ -92,16 +96,12 @@ describe("Before User Created signup-intent hook contract", () => {
   });
 
   it("accepts only Buyer or Seller signup intents", () => {
-    expect(sql).toContain(
-      "v_intent.requested_role not in ('buyer', 'seller')",
-    );
+    expect(sql).toContain("v_intent.requested_role not in ('buyer', 'seller')");
     expect(sql).toContain("unsupported signup role");
   });
 
   it("validates seller type invariants", () => {
-    expect(sql).toContain(
-      "('individual', 'sole_trader', 'company')",
-    );
+    expect(sql).toContain("('individual', 'sole_trader', 'company')");
     expect(sql).toContain("seller signup intent is incomplete");
     expect(sql).toContain("buyer signup intent is invalid");
   });
@@ -129,40 +129,27 @@ describe("Before User Created signup-intent hook contract", () => {
     expect(sql).toContain(
       "coalesce(jsonb_typeof(v_feature_flags->'sellerRegistration'), '') <> 'boolean'",
     );
-    expect(sql).toContain(
-      "registration availability could not be verified",
-    );
+    expect(sql).toContain("registration availability could not be verified");
   });
 
-  it("does not default fresh OAuth creation to Buyer", () => {
-    expect(sql).toContain("v_provider in ('google', 'facebook')");
-    expect(sql).toContain(
-      "social signup requires registration authorization",
-    );
+  it("does not derive Google Buyer or Seller authority from client metadata", () => {
+    const googleSection =
+      sql.split("if v_provider = 'google' then")[1]
+        ?.split("elsif v_provider = 'facebook' then")[0] ?? "";
 
-    const oauthSection =
-      sql.split("if v_provider in ('google', 'facebook') then")[1]
-        ?.split("if v_provider <> 'email' then")[0] ?? "";
-
-    expect(oauthSection).not.toContain("v_buyer_registration");
-    expect(oauthSection).not.toContain(
-      "buyer registration is temporarily disabled",
-    );
-    expect(oauthSection).not.toContain("return '{}'::jsonb");
+    expect(googleSection).toContain("private.signup_intents");
+    expect(googleSection).toContain("v_user_metadata->>'sub'");
+    expect(googleSection).not.toContain("requested_role := 'buyer'");
+    expect(googleSection).not.toContain("requested_role := 'seller'");
+    expect(googleSection).not.toContain("return '{}'::jsonb");
   });
 
   it("rechecks current Buyer and Seller policy after intent creation", () => {
-    expect(sql).toContain(
-      "v_intent.requested_role = 'buyer'",
-    );
-    expect(sql).toContain(
-      "v_intent.requested_role = 'seller'",
-    );
+    expect(sql).toContain("v_intent.requested_role = 'buyer'");
+    expect(sql).toContain("v_intent.requested_role = 'seller'");
     expect(sql).toContain("not v_buyer_registration");
     expect(sql).toContain("not v_seller_registration");
-    expect(sql).toContain(
-      "seller registration is temporarily disabled",
-    );
+    expect(sql).toContain("seller registration is temporarily disabled");
   });
 
   it("does not activate hosted Auth hook configuration in SQL", () => {

--- a/netlify/functions/__tests__/auth-signup-intent-contract.test.ts
+++ b/netlify/functions/__tests__/auth-signup-intent-contract.test.ts
@@ -16,41 +16,21 @@ const migration677 = read(
 );
 
 describe('Auth signup intent SQL contract', () => {
-  it('keeps signup intents in the private schema', () => {
+  it('keeps signup intents private and service-governed', () => {
     expect(migration676).toContain(
       'CREATE TABLE IF NOT EXISTS private.signup_intents',
     );
-
     expect(migration676).toContain(
       'REVOKE ALL ON TABLE private.signup_intents',
     );
-
     expect(migration676).toContain(
       'FROM PUBLIC, anon, authenticated',
     );
-  });
-
-  it('does not expose private signup_intents through the Data API', () => {
     expect(migration676).not.toContain(
-      "GRANT USAGE ON SCHEMA private TO anon",
+      'GRANT USAGE ON SCHEMA private TO anon',
     );
-
     expect(migration676).not.toContain(
-      "GRANT USAGE ON SCHEMA private TO authenticated",
-    );
-
-    expect(migration676).toContain(
-      'public.create_signup_intent',
-    );
-  });
-
-  it('makes create_signup_intent service-role only', () => {
-    expect(migration676).toContain(
-      'TO service_role',
-    );
-
-    expect(migration676).toContain(
-      'signup intent RPC security failure: client role can execute RPC',
+      'GRANT USAGE ON SCHEMA private TO authenticated',
     );
   });
 
@@ -59,155 +39,82 @@ describe('Auth signup intent SQL contract', () => {
       migration676.split(
         'CREATE TABLE IF NOT EXISTS private.signup_intents',
       )[1]?.split('CREATE INDEX')[0] ?? '';
-
     expect(tableSection.toLowerCase()).not.toContain('password');
   });
 
   it('projects later Auth email confirmation into public.users', () => {
-    expect(migration676).toContain(
-      'AFTER UPDATE OF email_confirmed_at',
-    );
+    expect(migration676).toContain('AFTER UPDATE OF email_confirmed_at');
+    expect(migration676).toContain('OLD.email_confirmed_at IS NULL');
+    expect(migration676).toContain('NEW.email_confirmed_at IS NOT NULL');
+    expect(migration676).toContain('SET "isEmailVerified" = true');
+  });
 
-    expect(migration676).toContain(
-      'OLD.email_confirmed_at IS NULL',
-    );
+  it('keeps email signup bound to an email-only intent', () => {
+    expect(migration677).toContain("ELSIF v_provider = 'email' THEN");
+    expect(migration677).toContain("auth_provider = 'email'");
+    expect(migration677).toContain('provider_subject IS NULL');
+    expect(migration677).toContain('signup intent is required');
+    expect(migration677).toContain('signup intent not found');
+    expect(migration677).toContain('signup intent expired');
+    expect(migration677).toContain('signup intent email mismatch');
+  });
 
+  it('binds fresh Google creation to provider + subject + verified email', () => {
     expect(migration676).toContain(
-      'NEW.email_confirmed_at IS NOT NULL',
+      "auth_provider IN ('email', 'google', 'facebook')",
     );
-
-    expect(migration676).toContain(
-      'SET "isEmailVerified" = true',
+    expect(migration676).toContain('provider_subject text NULL');
+    expect(migration676).toContain('public.create_social_signup_intent');
+    expect(migration677).toContain("IF v_provider = 'google' THEN");
+    expect(migration677).toContain("NEW.raw_user_meta_data ->> 'sub'");
+    expect(migration677).toContain("auth_provider = 'google'");
+    expect(migration677).toContain('provider_subject = v_provider_subject');
+    expect(migration677).toContain('AND email = v_email');
+    expect(migration677).toContain(
+      'Google registration authorization not found',
     );
   });
 
-  it('requires email/password signup to carry a valid intent', () => {
+  it('keeps fresh Facebook account creation fail-closed', () => {
+    expect(migration677).toContain("ELSIF v_provider = 'facebook' THEN");
     expect(migration677).toContain(
-      "IF v_provider <> 'email'",
-    );
-
-    expect(migration677).toContain(
-      'signup intent is required',
-    );
-
-    expect(migration677).toContain(
-      'signup intent not found',
-    );
-
-    expect(migration677).toContain(
-      'signup intent expired',
-    );
-
-    expect(migration677).toContain(
-      'signup intent email mismatch',
+      'Facebook signup requires registration authorization',
     );
   });
 
   it('locks and consumes signup intent exactly inside provisioning', () => {
     expect(migration677).toContain('FOR UPDATE');
-
-    expect(migration677).toContain(
-      'SET consumed_at = now()',
-    );
-
-    expect(migration677).toContain(
-      'signup intent already consumed',
-    );
-
-    expect(migration677).toContain(
-      'signup intent replay detected',
-    );
+    expect(migration677).toContain('SET consumed_at = now()');
+    expect(migration677).toContain('signup intent already consumed');
+    expect(migration677).toContain('signup intent replay detected');
   });
 
-  it('never accepts client user_metadata role authority', () => {
-    expect(migration677).toContain(
-      "NEW.raw_user_meta_data ? 'role'",
-    );
-
-    expect(migration677).toContain(
-      'client role metadata is forbidden',
-    );
-
-    expect(migration677).not.toContain(
-      "raw_user_meta_data->>'role') IN",
-    );
-  });
-
-  it('does not allow public email signup to carry app role metadata', () => {
-    expect(migration677).toContain(
-      "NEW.raw_app_meta_data ? 'role'",
-    );
-
+  it('never accepts client role metadata authority', () => {
+    expect(migration677).toContain("NEW.raw_user_meta_data ? 'role'");
+    expect(migration677).toContain('client role metadata is forbidden');
+    expect(migration677).toContain("NEW.raw_app_meta_data ? 'role'");
     expect(migration677).toContain(
       'public email signup cannot carry app role metadata',
     );
-
-    expect(migration677).not.toContain(
-      "raw_app_meta_data->>'role') IN",
-    );
+    expect(migration677).not.toContain("raw_user_meta_data->>'role') IN");
+    expect(migration677).not.toContain("raw_app_meta_data->>'role') IN");
   });
 
-  it('rejects fresh Google/Facebook identities from generic sign-in', () => {
-    expect(migration677).toContain(
-      "v_provider IN ('google', 'facebook')",
-    );
-
-    expect(migration677).toContain(
-      'signup rejected: social signup requires registration authorization',
-    );
-
-    const oauthSection =
-      migration677.split(
-        "IF v_provider IN ('google', 'facebook') THEN",
-      )[1]?.split(
-        "IF v_provider <> 'email' THEN",
-      )[0] ?? '';
-
-    expect(oauthSection).not.toContain('INSERT INTO public.users');
-    expect(oauthSection).not.toContain("'buyer'");
-    expect(oauthSection).not.toContain("'seller'");
-    expect(oauthSection).not.toContain("'admin'");
-  });
-
-  it('fails closed for unknown Auth providers', () => {
-    expect(migration677).toContain(
-      'signup rejected: unsupported auth provider',
-    );
-  });
-
-  it('fails closed when downstream profile provisioning is incomplete', () => {
-    expect(migration677).toContain(
-      'Buyer profile provisioning failed',
-    );
-
-    expect(migration677).toContain(
-      'Seller profile provisioning failed',
-    );
-
-    expect(migration677).toContain(
-      'Seller store provisioning failed',
-    );
+  it('fails closed for unknown providers and incomplete provisioning', () => {
+    expect(migration677).toContain('signup rejected: unsupported auth provider');
+    expect(migration677).toContain('Buyer profile provisioning failed');
+    expect(migration677).toContain('Seller profile provisioning failed');
+    expect(migration677).toContain('Seller store provisioning failed');
   });
 
   it('contains no catch-all non-fatal Auth provisioning path', () => {
-    expect(migration677).not.toContain(
-      'EXCEPTION WHEN OTHERS',
-    );
-
-    expect(migration677).not.toContain(
-      'RAISE WARNING',
-    );
+    expect(migration677).not.toContain('EXCEPTION WHEN OTHERS');
+    expect(migration677).not.toContain('RAISE WARNING');
   });
 
   it('keeps the Auth trigger installed', () => {
-    expect(migration677).toContain(
-      'CREATE TRIGGER on_auth_user_created',
-    );
-
-    expect(migration677).toContain(
-      'AFTER INSERT ON auth.users',
-    );
-
+    expect(migration677).toContain('CREATE TRIGGER on_auth_user_created');
+    expect(migration677).toContain('AFTER INSERT ON auth.users');
     expect(migration677).toContain(
       'EXECUTE FUNCTION public.handle_new_auth_user()',
     );

--- a/netlify/functions/__tests__/register-social-intent-contract.test.ts
+++ b/netlify/functions/__tests__/register-social-intent-contract.test.ts
@@ -1,0 +1,78 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const root = process.cwd();
+const read = (relativePath: string) =>
+  fs.readFileSync(path.join(root, relativePath), 'utf8');
+
+const fn = read('netlify/functions/register-social-intent.ts');
+const modern = read('netlify/functions-modern/register-social-intent.ts');
+const signupEntry = read('src/pages/pixel-perfect/SignupEntry.tsx');
+
+describe('verified social registration contract', () => {
+  it('keeps the modern function as a thin wrapper', () => {
+    expect(modern).toContain("export { handler } from '../functions/register-social-intent'");
+  });
+
+  it('supports Google only and rejects other social providers', () => {
+    expect(fn).toContain("provider: 'google'");
+    expect(fn).toContain('Unsupported social registration provider');
+    expect(fn).not.toContain("provider: 'facebook'");
+  });
+
+  it('requires explicit server configuration', () => {
+    expect(fn).toContain('GOOGLE_CLIENT_ID');
+    expect(fn).toContain('SUPABASE_SERVICE_ROLE_KEY');
+    expect(fn).toContain('Social registration is not configured');
+  });
+
+  it('verifies Google JWT signature against the official JWKS', () => {
+    expect(fn).toContain('https://www.googleapis.com/oauth2/v3/certs');
+    expect(fn).toContain("header.alg !== 'RS256'");
+    expect(fn).toContain("createPublicKey({ key, format: 'jwk' })");
+    expect(fn).toContain("verifySignature('RSA-SHA256'");
+    expect(fn).toContain('Invalid Google credential signature');
+  });
+
+  it('validates issuer, audience, expiry and token age', () => {
+    expect(fn).toContain('https://accounts.google.com');
+    expect(fn).toContain('audienceMatches');
+    expect(fn).toContain('Invalid Google credential audience');
+    expect(fn).toContain('Google credential has expired');
+    expect(fn).toContain('MAX_TOKEN_AGE_SECONDS');
+  });
+
+  it('binds the credential to the raw nonce through SHA-256', () => {
+    expect(fn).toContain("createHash('sha256')");
+    expect(fn).toContain('claims.nonce !== sha256Hex(rawNonce)');
+    expect(fn).toContain('Google credential nonce mismatch');
+  });
+
+  it('requires verified provider identity data', () => {
+    expect(fn).toContain('Google email is not verified');
+    expect(fn).toContain("claims.sub?.trim()");
+    expect(fn).toContain("claims.email?.trim()");
+    expect(fn).toContain('Google credential identity is incomplete');
+  });
+
+  it('persists authorization through the service-role social intent RPC', () => {
+    expect(fn).toContain("supabase.rpc('create_social_signup_intent'");
+    expect(fn).toContain("p_auth_provider: 'google'");
+    expect(fn).toContain('p_provider_subject: claims.sub!.trim()');
+    expect(fn).toContain('p_requested_role: body.requestedRole');
+  });
+
+  it('keeps Buyer and Seller selection constrained', () => {
+    expect(fn).toContain("!['buyer', 'seller'].includes(body.requestedRole)");
+    expect(fn).toContain('A valid Seller legal type is required');
+    expect(fn).toContain('Buyer registration cannot include Seller identity');
+  });
+
+  it('requires account type before the signup form route', () => {
+    expect(signupEntry).toContain("requestedType === \"buyer\" || requestedType === \"seller\"");
+    expect(signupEntry).toContain('Choose your account type first');
+    expect(signupEntry).toContain('/register?type=buyer');
+    expect(signupEntry).toContain('/register?type=seller');
+  });
+});

--- a/netlify/functions/register-social-intent.ts
+++ b/netlify/functions/register-social-intent.ts
@@ -1,0 +1,323 @@
+import type { Handler } from '@netlify/functions';
+import { createHash, createPublicKey, verify as verifySignature } from 'node:crypto';
+import { createClient } from '@supabase/supabase-js';
+import { checkRateLimit } from './_shared/rateLimiter';
+import { getClientIp } from './_shared/getClientIp';
+import { getFeatureFlagsStrict } from './_shared/platformFlags';
+
+type RequestedRole = 'buyer' | 'seller';
+type SellerType = 'individual' | 'sole_trader' | 'company';
+
+interface SocialIntentRequest {
+  provider: 'google';
+  credential: string;
+  nonce: string;
+  requestedRole: RequestedRole;
+  sellerType?: SellerType;
+}
+
+interface GoogleHeader {
+  alg?: string;
+  kid?: string;
+  typ?: string;
+}
+
+interface GoogleClaims {
+  iss?: string;
+  aud?: string | string[];
+  sub?: string;
+  email?: string;
+  email_verified?: boolean | string;
+  nonce?: string;
+  exp?: number;
+  iat?: number;
+  given_name?: string;
+  family_name?: string;
+  name?: string;
+}
+
+interface GoogleJwk extends JsonWebKey {
+  kid?: string;
+  alg?: string;
+  use?: string;
+}
+
+const GOOGLE_JWKS_URL = 'https://www.googleapis.com/oauth2/v3/certs';
+const GOOGLE_ISSUERS = new Set(['https://accounts.google.com', 'accounts.google.com']);
+const MAX_TOKEN_AGE_SECONDS = 10 * 60;
+
+let jwksCache: { keys: GoogleJwk[]; expiresAt: number } | null = null;
+
+const base64UrlDecode = (value: string): Buffer => {
+  const normalized = value.replace(/-/g, '+').replace(/_/g, '/');
+  const padding = normalized.length % 4 === 0 ? '' : '='.repeat(4 - (normalized.length % 4));
+  return Buffer.from(normalized + padding, 'base64');
+};
+
+const parseJwtPart = <T>(part: string): T => {
+  return JSON.parse(base64UrlDecode(part).toString('utf8')) as T;
+};
+
+const parseCacheMaxAge = (value: string | null): number => {
+  const match = value?.match(/(?:^|,)\s*max-age=(\d+)/i);
+  return match ? Number(match[1]) : 300;
+};
+
+const getGoogleJwks = async (): Promise<GoogleJwk[]> => {
+  if (jwksCache && jwksCache.expiresAt > Date.now()) {
+    return jwksCache.keys;
+  }
+
+  const response = await fetch(GOOGLE_JWKS_URL, {
+    method: 'GET',
+    headers: { Accept: 'application/json' },
+  });
+
+  if (!response.ok) {
+    throw new Error('Google signing keys could not be loaded');
+  }
+
+  const payload = (await response.json()) as { keys?: GoogleJwk[] };
+  const keys = Array.isArray(payload.keys) ? payload.keys : [];
+  if (keys.length === 0) {
+    throw new Error('Google signing keys are unavailable');
+  }
+
+  const maxAge = Math.max(60, Math.min(parseCacheMaxAge(response.headers.get('cache-control')), 3600));
+  jwksCache = {
+    keys,
+    expiresAt: Date.now() + maxAge * 1000,
+  };
+
+  return keys;
+};
+
+const audienceMatches = (audience: string | string[] | undefined, expected: string): boolean => {
+  if (typeof audience === 'string') return audience === expected;
+  return Array.isArray(audience) && audience.includes(expected);
+};
+
+const sha256Hex = (value: string): string =>
+  createHash('sha256').update(value, 'utf8').digest('hex');
+
+const deriveNames = (claims: GoogleClaims): { firstName: string; lastName: string } => {
+  const firstName = claims.given_name?.trim() ?? '';
+  const lastName = claims.family_name?.trim() ?? '';
+  if (firstName && lastName) return { firstName, lastName };
+
+  const nameParts = claims.name?.trim().split(/\s+/).filter(Boolean) ?? [];
+  if (nameParts.length >= 2) {
+    return {
+      firstName: firstName || nameParts[0],
+      lastName: lastName || nameParts.slice(1).join(' '),
+    };
+  }
+
+  throw new Error('Google profile must provide first and last name');
+};
+
+const verifyGoogleCredential = async (
+  credential: string,
+  rawNonce: string,
+  expectedAudience: string,
+): Promise<GoogleClaims> => {
+  const parts = credential.split('.');
+  if (parts.length !== 3) throw new Error('Invalid Google credential');
+
+  const [encodedHeader, encodedPayload, encodedSignature] = parts;
+  const header = parseJwtPart<GoogleHeader>(encodedHeader);
+  const claims = parseJwtPart<GoogleClaims>(encodedPayload);
+
+  if (header.alg !== 'RS256' || !header.kid) {
+    throw new Error('Unsupported Google credential signature');
+  }
+
+  const keys = await getGoogleJwks();
+  const key = keys.find(
+    (candidate) =>
+      candidate.kid === header.kid &&
+      (!candidate.alg || candidate.alg === 'RS256') &&
+      (!candidate.use || candidate.use === 'sig'),
+  );
+
+  if (!key) throw new Error('Google signing key was not found');
+
+  const publicKey = createPublicKey({ key, format: 'jwk' });
+  const signingInput = Buffer.from(`${encodedHeader}.${encodedPayload}`, 'utf8');
+  const signature = base64UrlDecode(encodedSignature);
+
+  if (!verifySignature('RSA-SHA256', signingInput, publicKey, signature)) {
+    throw new Error('Invalid Google credential signature');
+  }
+
+  const now = Math.floor(Date.now() / 1000);
+
+  if (!claims.iss || !GOOGLE_ISSUERS.has(claims.iss)) {
+    throw new Error('Invalid Google credential issuer');
+  }
+
+  if (!audienceMatches(claims.aud, expectedAudience)) {
+    throw new Error('Invalid Google credential audience');
+  }
+
+  if (!claims.exp || claims.exp <= now) {
+    throw new Error('Google credential has expired');
+  }
+
+  if (!claims.iat || claims.iat > now + 60 || now - claims.iat > MAX_TOKEN_AGE_SECONDS) {
+    throw new Error('Google credential is outside the accepted age window');
+  }
+
+  if (!rawNonce || claims.nonce !== sha256Hex(rawNonce)) {
+    throw new Error('Google credential nonce mismatch');
+  }
+
+  const emailVerified = claims.email_verified === true || claims.email_verified === 'true';
+  if (!emailVerified) {
+    throw new Error('Google email is not verified');
+  }
+
+  if (!claims.sub?.trim() || !claims.email?.trim()) {
+    throw new Error('Google credential identity is incomplete');
+  }
+
+  return claims;
+};
+
+export const handler: Handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return { statusCode: 405, body: JSON.stringify({ error: 'Method not allowed' }) };
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL || process.env.VITE_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  const googleClientId = process.env.GOOGLE_CLIENT_ID || process.env.VITE_GOOGLE_CLIENT_ID;
+
+  if (!supabaseUrl || !serviceRoleKey || !googleClientId) {
+    console.error('register-social-intent: server configuration is missing');
+    return {
+      statusCode: 503,
+      body: JSON.stringify({ error: 'Social registration is not configured. Please contact support.' }),
+    };
+  }
+
+  let body: SocialIntentRequest;
+  try {
+    body = JSON.parse(event.body || '{}') as SocialIntentRequest;
+  } catch {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid request body' }) };
+  }
+
+  if (body.provider !== 'google') {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Unsupported social registration provider' }) };
+  }
+
+  if (typeof body.credential !== 'string' || typeof body.nonce !== 'string') {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Missing Google registration credential' }) };
+  }
+
+  if (!['buyer', 'seller'].includes(body.requestedRole)) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Invalid requested role' }) };
+  }
+
+  const validSellerTypes = new Set<SellerType>(['individual', 'sole_trader', 'company']);
+  if (
+    body.requestedRole === 'seller' &&
+    (!body.sellerType || !validSellerTypes.has(body.sellerType))
+  ) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'A valid Seller legal type is required' }) };
+  }
+
+  if (body.requestedRole === 'buyer' && body.sellerType) {
+    return { statusCode: 400, body: JSON.stringify({ error: 'Buyer registration cannot include Seller identity' }) };
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+
+  const ip = getClientIp(event);
+  if (ip) {
+    const rateLimit = await checkRateLimit({
+      supabase,
+      tableName: 'register_rate_limits',
+      identifier: `social:${ip}`,
+      windowMinutes: 60,
+      maxAttempts: 10,
+      policy: 'fail-soft',
+    });
+
+    if (rateLimit.exceeded) {
+      return { statusCode: 429, body: JSON.stringify({ error: 'Too many sign-up attempts. Please try again later.' }) };
+    }
+  }
+
+  let featureFlags: Awaited<ReturnType<typeof getFeatureFlagsStrict>>;
+  try {
+    featureFlags = await getFeatureFlagsStrict(supabase);
+  } catch (error) {
+    console.error('register-social-intent: registration availability lookup failed', error);
+    return { statusCode: 503, body: JSON.stringify({ error: 'Registration availability could not be verified. Please try again later.' }) };
+  }
+
+  if (body.requestedRole === 'buyer' && featureFlags.buyerRegistration === false) {
+    return { statusCode: 403, body: JSON.stringify({ error: 'Buyer registration is temporarily disabled. Please try again later.' }) };
+  }
+
+  if (body.requestedRole === 'seller' && featureFlags.sellerRegistration === false) {
+    return { statusCode: 403, body: JSON.stringify({ error: 'Seller registration is temporarily disabled. Please try again later.' }) };
+  }
+
+  let claims: GoogleClaims;
+  try {
+    claims = await verifyGoogleCredential(body.credential, body.nonce, googleClientId);
+  } catch (error) {
+    console.warn(
+      'register-social-intent: Google credential rejected:',
+      error instanceof Error ? error.message : 'unknown verification failure',
+    );
+    return { statusCode: 403, body: JSON.stringify({ error: 'Google registration could not be verified.' }) };
+  }
+
+  let names: { firstName: string; lastName: string };
+  try {
+    names = deriveNames(claims);
+  } catch (error) {
+    return {
+      statusCode: 400,
+      body: JSON.stringify({ error: error instanceof Error ? error.message : 'Google profile is incomplete' }),
+    };
+  }
+
+  const expiresAt = new Date(Date.now() + 15 * 60 * 1000).toISOString();
+  const { data, error } = await supabase.rpc('create_social_signup_intent', {
+    p_auth_provider: 'google',
+    p_provider_subject: claims.sub!.trim(),
+    p_email: claims.email!.trim().toLowerCase(),
+    p_requested_role: body.requestedRole,
+    p_first_name: names.firstName,
+    p_last_name: names.lastName,
+    p_seller_type: body.requestedRole === 'seller' ? body.sellerType ?? null : null,
+    p_expires_at: expiresAt,
+  });
+
+  const intent =
+    Array.isArray(data) && data.length === 1
+      ? (data[0] as { id: string; expires_at: string })
+      : null;
+
+  if (error || !intent) {
+    console.error('register-social-intent: failed to persist verified social intent', error?.message ?? 'missing row');
+    return { statusCode: 503, body: JSON.stringify({ error: 'Social registration could not be initialized. Please try again.' }) };
+  }
+
+  return {
+    statusCode: 201,
+    body: JSON.stringify({
+      provider: 'google',
+      intentId: intent.id,
+      expiresAt: intent.expires_at,
+      email: claims.email!.trim().toLowerCase(),
+    }),
+  };
+};

--- a/src/pages/pixel-perfect/SignupEntry.tsx
+++ b/src/pages/pixel-perfect/SignupEntry.tsx
@@ -1,0 +1,93 @@
+import { Link, useSearchParams } from "react-router-dom";
+import { ArrowRight, CheckCircle2, ShoppingBag, Store } from "lucide-react";
+import MainLayout from "@/layouts/MainLayout";
+import SEO from "@/components/SEO";
+import Signup from "./Signup";
+
+const SignupEntry = () => {
+  const [searchParams] = useSearchParams();
+  const requestedType = searchParams.get("type");
+
+  if (requestedType === "buyer" || requestedType === "seller") {
+    return <Signup />;
+  }
+
+  return (
+    <MainLayout>
+      <SEO
+        title="Choose Account Type | Loadify Market"
+        description="Choose whether you want to join Loadify as a Buyer or begin Marketplace Seller setup before selecting your sign-up method."
+        robots="noindex, nofollow"
+      />
+
+      <main
+        id="main-content"
+        className="min-h-screen bg-[#F7F9FC] pb-14 pt-6 text-[#0A234F] md:pt-[150px]"
+      >
+        <div className="mx-auto w-full max-w-[920px] px-4 sm:px-6 lg:px-8">
+          <div className="rounded-[26px] border border-[#0A234F]/10 bg-white p-6 shadow-[0_22px_65px_rgba(10,35,79,0.10)] sm:p-9 lg:p-12">
+            <div className="mx-auto max-w-2xl text-center">
+              <p className="text-[10px] font-black uppercase tracking-[0.18em] text-[#0E3FA9]">
+                Create your Loadify account
+              </p>
+              <h1 className="mt-3 text-3xl font-black tracking-[-0.035em] text-[#0A234F] sm:text-4xl">
+                Choose your account type first
+              </h1>
+              <p className="mt-4 text-sm font-medium leading-6 text-[#64748B] sm:text-base">
+                Your choice is made before Google, Facebook or email registration. Seller accounts keep Buyer access on the same Loadify identity.
+              </p>
+            </div>
+
+            <div className="mt-9 grid gap-5 md:grid-cols-2">
+              <Link
+                to="/register?type=buyer"
+                className="group rounded-2xl border border-[#0A234F]/12 bg-white p-6 transition hover:-translate-y-0.5 hover:border-[#0E3FA9]/35 hover:shadow-lg"
+              >
+                <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[#0E3FA9]/10">
+                  <ShoppingBag className="h-6 w-6 text-[#0E3FA9]" aria-hidden="true" />
+                </div>
+                <h2 className="mt-5 text-xl font-black text-[#0A234F]">Buyer</h2>
+                <p className="mt-2 text-sm leading-6 text-[#64748B]">
+                  Shop approved listings, save favourites, manage orders, follow deliveries and request returns.
+                </p>
+                <div className="mt-5 space-y-2 text-xs font-semibold text-[#475569]">
+                  <p className="flex items-start gap-2"><CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[#0E3FA9]" /> Buyer Space access</p>
+                  <p className="flex items-start gap-2"><CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[#0E3FA9]" /> Seller access can be added later</p>
+                </div>
+                <span className="mt-6 inline-flex items-center gap-2 text-sm font-extrabold text-[#0E3FA9]">
+                  Continue as Buyer <ArrowRight className="h-4 w-4 transition group-hover:translate-x-0.5" />
+                </span>
+              </Link>
+
+              <Link
+                to="/register?type=seller"
+                className="group rounded-2xl border border-[#0A234F]/12 bg-white p-6 transition hover:-translate-y-0.5 hover:border-[#F5A300]/55 hover:shadow-lg"
+              >
+                <div className="flex h-12 w-12 items-center justify-center rounded-xl bg-[#F5A300]/15">
+                  <Store className="h-6 w-6 text-[#B96D00]" aria-hidden="true" />
+                </div>
+                <h2 className="mt-5 text-xl font-black text-[#0A234F]">Marketplace Seller</h2>
+                <p className="mt-2 text-sm leading-6 text-[#64748B]">
+                  Start Seller setup, then complete legal details, verification, store readiness and eligible payout setup.
+                </p>
+                <div className="mt-5 space-y-2 text-xs font-semibold text-[#475569]">
+                  <p className="flex items-start gap-2"><CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[#B96D00]" /> Buyer + Seller capability on one identity</p>
+                  <p className="flex items-start gap-2"><CheckCircle2 className="mt-0.5 h-4 w-4 shrink-0 text-[#B96D00]" /> Seller readiness remains controlled</p>
+                </div>
+                <span className="mt-6 inline-flex items-center gap-2 text-sm font-extrabold text-[#B96D00]">
+                  Continue as Seller <ArrowRight className="h-4 w-4 transition group-hover:translate-x-0.5" />
+                </span>
+              </Link>
+            </div>
+
+            <p className="mt-8 text-center text-xs text-[#64748B]">
+              Already registered? <Link to="/login" className="font-extrabold text-[#0E3FA9] hover:underline">Sign in</Link>
+            </p>
+          </div>
+        </div>
+      </main>
+    </MainLayout>
+  );
+};
+
+export default SignupEntry;

--- a/supabase/676_signup_intent_auth_foundation.sql
+++ b/supabase/676_signup_intent_auth_foundation.sql
@@ -11,6 +11,7 @@
 --   * requested_role is intent only; authorization remains server-derived
 --   * intents expire and are single-use
 --   * email confirmation does NOT approve or activate a Seller
+--   * social intents bind to provider + verified provider subject
 
 CREATE SCHEMA IF NOT EXISTS private;
 
@@ -18,6 +19,12 @@ CREATE TABLE IF NOT EXISTS private.signup_intents (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
 
   email text NOT NULL,
+
+  auth_provider text NOT NULL DEFAULT 'email'
+    CHECK (auth_provider IN ('email', 'google', 'facebook')),
+
+  provider_subject text NULL,
+
   requested_role text NOT NULL
     CHECK (requested_role IN ('buyer', 'seller')),
 
@@ -52,11 +59,34 @@ CREATE TABLE IF NOT EXISTS private.signup_intents (
       (requested_role = 'seller' AND seller_type IS NOT NULL)
       OR
       (requested_role = 'buyer' AND seller_type IS NULL)
+    ),
+
+  CONSTRAINT signup_intents_provider_subject_contract
+    CHECK (
+      (
+        auth_provider = 'email'
+        AND provider_subject IS NULL
+      )
+      OR
+      (
+        auth_provider IN ('google', 'facebook')
+        AND length(btrim(provider_subject)) BETWEEN 1 AND 255
+      )
     )
 );
 
 CREATE INDEX IF NOT EXISTS idx_signup_intents_email_created
   ON private.signup_intents (email, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_signup_intents_social_identity
+  ON private.signup_intents (
+    auth_provider,
+    provider_subject,
+    email,
+    created_at DESC
+  )
+  WHERE consumed_at IS NULL
+    AND provider_subject IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_signup_intents_pending_expiry
   ON private.signup_intents (expires_at)
@@ -72,10 +102,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE
   TO service_role;
 
 -- ---------------------------------------------------------------------------
--- Server-only Data API boundary.
---
--- The private schema MUST NOT be exposed through PostgREST.
--- Netlify service-role callers use this tightly scoped public RPC instead.
+-- Server-only Data API boundary for email/password registration.
 -- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION public.create_signup_intent(
@@ -143,6 +170,8 @@ BEGIN
   RETURN QUERY
   INSERT INTO private.signup_intents AS si (
     email,
+    auth_provider,
+    provider_subject,
     requested_role,
     first_name,
     last_name,
@@ -157,6 +186,8 @@ BEGIN
   )
   VALUES (
     v_email,
+    'email',
+    NULL,
     p_requested_role,
     btrim(p_first_name),
     btrim(p_last_name),
@@ -208,11 +239,145 @@ GRANT EXECUTE ON FUNCTION public.create_signup_intent(
 TO service_role;
 
 -- ---------------------------------------------------------------------------
--- Ongoing email-confirmation projection.
+-- Server-only verified social registration intent boundary.
 --
--- Existing trg_sync_email_verified on public.users only handles INSERT-time
--- correction. It cannot react when auth.users.email_confirmed_at changes later.
--- This trigger closes that gap.
+-- The caller MUST verify the external provider credential before invoking
+-- this RPC. Browser-controlled provider subjects are never authorization.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.create_social_signup_intent(
+  p_auth_provider text,
+  p_provider_subject text,
+  p_email text,
+  p_requested_role text,
+  p_first_name text,
+  p_last_name text,
+  p_seller_type text DEFAULT NULL,
+  p_expires_at timestamptz DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  expires_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_provider text;
+  v_subject text;
+  v_email text;
+  v_expires_at timestamptz;
+BEGIN
+  v_provider := lower(btrim(COALESCE(p_auth_provider, '')));
+  v_subject := btrim(COALESCE(p_provider_subject, ''));
+  v_email := lower(btrim(COALESCE(p_email, '')));
+  v_expires_at := COALESCE(
+    p_expires_at,
+    now() + interval '15 minutes'
+  );
+
+  IF v_provider NOT IN ('google', 'facebook') THEN
+    RAISE EXCEPTION 'invalid social signup provider';
+  END IF;
+
+  IF v_subject = '' OR length(v_subject) > 255 THEN
+    RAISE EXCEPTION 'invalid social provider subject';
+  END IF;
+
+  IF v_email = '' THEN
+    RAISE EXCEPTION 'invalid social signup email';
+  END IF;
+
+  IF p_requested_role NOT IN ('buyer', 'seller') THEN
+    RAISE EXCEPTION 'invalid signup intent role';
+  END IF;
+
+  IF btrim(COALESCE(p_first_name, '')) = ''
+     OR btrim(COALESCE(p_last_name, '')) = ''
+  THEN
+    RAISE EXCEPTION 'invalid signup intent identity';
+  END IF;
+
+  IF p_requested_role = 'seller'
+     AND p_seller_type NOT IN ('individual', 'sole_trader', 'company')
+  THEN
+    RAISE EXCEPTION 'invalid seller type';
+  END IF;
+
+  IF p_requested_role = 'buyer'
+     AND p_seller_type IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'buyer intent cannot carry seller type';
+  END IF;
+
+  IF v_expires_at <= now() THEN
+    RAISE EXCEPTION 'signup intent expiry must be in the future';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(v_provider || ':' || v_subject, 0)
+  );
+
+  UPDATE private.signup_intents
+  SET consumed_at = now()
+  WHERE auth_provider = v_provider
+    AND provider_subject = v_subject
+    AND consumed_at IS NULL;
+
+  RETURN QUERY
+  INSERT INTO private.signup_intents AS si (
+    email,
+    auth_provider,
+    provider_subject,
+    requested_role,
+    first_name,
+    last_name,
+    seller_type,
+    expires_at
+  )
+  VALUES (
+    v_email,
+    v_provider,
+    v_subject,
+    p_requested_role,
+    btrim(p_first_name),
+    btrim(p_last_name),
+    p_seller_type,
+    v_expires_at
+  )
+  RETURNING
+    si.id,
+    si.expires_at;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_social_signup_intent(
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  timestamptz
+)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.create_social_signup_intent(
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  timestamptz
+)
+TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- Ongoing email-confirmation projection.
 -- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION private.sync_public_email_verified_from_auth()
@@ -295,6 +460,31 @@ BEGIN
   THEN
     RAISE EXCEPTION
       '676 signup intent RPC security failure: service role cannot execute RPC';
+  END IF;
+
+  IF has_function_privilege(
+       'anon',
+       'public.create_social_signup_intent(text,text,text,text,text,text,text,timestamptz)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'authenticated',
+       'public.create_social_signup_intent(text,text,text,text,text,text,text,timestamptz)',
+       'EXECUTE'
+     )
+  THEN
+    RAISE EXCEPTION
+      '676 social signup intent security failure: client role can execute RPC';
+  END IF;
+
+  IF NOT has_function_privilege(
+       'service_role',
+       'public.create_social_signup_intent(text,text,text,text,text,text,text,timestamptz)',
+       'EXECUTE'
+     )
+  THEN
+    RAISE EXCEPTION
+      '676 social signup intent security failure: service role cannot execute RPC';
   END IF;
 
   IF has_function_privilege(

--- a/supabase/677_auth_signup_intent_consumption.sql
+++ b/supabase/677_auth_signup_intent_consumption.sql
@@ -5,9 +5,12 @@
 --   Requires a valid server-owned signup intent.
 --   Buyer/Seller relationship is derived only from private.signup_intents.
 --
--- OAUTH
---   Generic Google/Facebook sign-in cannot create a new Loadify account.
---   Fresh social registration requires dedicated registration authorization.
+-- GOOGLE
+--   Fresh account creation requires a provider-bound social signup intent.
+--
+-- FACEBOOK
+--   Fresh creation remains fail-closed until its dedicated registration
+--   boundary is implemented and verified independently.
 --
 -- UNKNOWN PROVIDERS
 --   Fail closed.
@@ -22,6 +25,7 @@ SET search_path = ''
 AS $$
 DECLARE
   v_provider text;
+  v_provider_subject text;
   v_intent_id uuid;
   v_intent private.signup_intents%ROWTYPE;
   v_email text;
@@ -43,64 +47,82 @@ BEGIN
       'signup rejected: auth email is missing';
   END IF;
 
-  -- No public identity may choose its authorization role through metadata.
   IF NEW.raw_user_meta_data ? 'role' THEN
     RAISE EXCEPTION
       'signup rejected: client role metadata is forbidden';
   END IF;
 
-  -- -------------------------------------------------------------------------
-  -- OAuth identity creation.
-  --
-  -- Generic Google/Facebook sign-in may authenticate an EXISTING identity,
-  -- but it may not create a new Loadify account. Fresh social registration
-  -- must first pass through the dedicated Buyer/Seller registration boundary.
-  -- -------------------------------------------------------------------------
-  IF v_provider IN ('google', 'facebook') THEN
-    RAISE EXCEPTION
-      'signup rejected: social signup requires registration authorization';
-  END IF;
+  IF v_provider = 'google' THEN
+    v_provider_subject :=
+      btrim(COALESCE(NEW.raw_user_meta_data ->> 'sub', ''));
 
-  -- -------------------------------------------------------------------------
-  -- Public email/password signup.
-  -- -------------------------------------------------------------------------
-  IF v_provider <> 'email' THEN
+    IF v_provider_subject = '' THEN
+      RAISE EXCEPTION
+        'signup rejected: verified Google subject is missing';
+    END IF;
+
+    SELECT *
+    INTO v_intent
+    FROM private.signup_intents
+    WHERE auth_provider = 'google'
+      AND provider_subject = v_provider_subject
+      AND email = v_email
+      AND consumed_at IS NULL
+      AND expires_at > now()
+    ORDER BY created_at DESC
+    LIMIT 1
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION
+        'signup rejected: Google registration authorization not found';
+    END IF;
+
+    v_intent_id := v_intent.id;
+
+  ELSIF v_provider = 'facebook' THEN
+    RAISE EXCEPTION
+      'signup rejected: Facebook signup requires registration authorization';
+
+  ELSIF v_provider = 'email' THEN
+    IF NEW.raw_app_meta_data ? 'role' THEN
+      RAISE EXCEPTION
+        'signup rejected: public email signup cannot carry app role metadata';
+    END IF;
+
+    BEGIN
+      v_intent_id :=
+        NULLIF(
+          NEW.raw_user_meta_data ->> 'intent_id',
+          ''
+        )::uuid;
+    EXCEPTION
+      WHEN invalid_text_representation THEN
+        RAISE EXCEPTION
+          'signup rejected: invalid signup intent';
+    END;
+
+    IF v_intent_id IS NULL THEN
+      RAISE EXCEPTION
+        'signup rejected: signup intent is required';
+    END IF;
+
+    SELECT *
+    INTO v_intent
+    FROM private.signup_intents
+    WHERE id = v_intent_id
+      AND auth_provider = 'email'
+      AND provider_subject IS NULL
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION
+        'signup rejected: signup intent not found';
+    END IF;
+
+  ELSE
     RAISE EXCEPTION
       'signup rejected: unsupported auth provider';
-  END IF;
-
-  -- app_metadata role is also forbidden on public email signup.
-  IF NEW.raw_app_meta_data ? 'role' THEN
-    RAISE EXCEPTION
-      'signup rejected: public email signup cannot carry app role metadata';
-  END IF;
-
-  BEGIN
-    v_intent_id :=
-      NULLIF(
-        NEW.raw_user_meta_data ->> 'intent_id',
-        ''
-      )::uuid;
-  EXCEPTION
-    WHEN invalid_text_representation THEN
-      RAISE EXCEPTION
-        'signup rejected: invalid signup intent';
-  END;
-
-  IF v_intent_id IS NULL THEN
-    RAISE EXCEPTION
-      'signup rejected: signup intent is required';
-  END IF;
-
-  SELECT *
-  INTO v_intent
-  FROM private.signup_intents
-  WHERE id = v_intent_id
-  FOR UPDATE;
-
-  IF NOT FOUND THEN
-    RAISE EXCEPTION
-      'signup rejected: signup intent not found';
   END IF;
 
   IF v_intent.consumed_at IS NOT NULL THEN
@@ -142,11 +164,7 @@ BEGIN
     v_intent.phone
   );
 
-  -- public.users AFTER INSERT provisioning is synchronous, so the canonical
-  -- buyer/seller profile rows exist before execution continues here.
-
   IF v_intent.requested_role = 'buyer' THEN
-
     UPDATE public.buyer_profiles
     SET
       "customerType" = COALESCE(
@@ -165,7 +183,6 @@ BEGIN
     END IF;
 
   ELSIF v_intent.requested_role = 'seller' THEN
-
     UPDATE public.seller_profiles
     SET
       "sellerType" = v_intent.seller_type,
@@ -220,7 +237,7 @@ END;
 $$;
 
 COMMENT ON FUNCTION public.handle_new_auth_user() IS
-  'Fail-closed Auth provisioning: email signup requires a valid single-use private intent; Google/Facebook provision Buyer-only; client role metadata is never authorization.';
+  'Fail-closed Auth provisioning: email signup requires a private intent; Google requires provider-bound authorization; Facebook remains fail-closed; client role metadata is never authorization.';
 
 REVOKE ALL ON FUNCTION public.handle_new_auth_user()
 FROM PUBLIC, anon, authenticated;

--- a/supabase/678_auth_before_user_created_hook.sql
+++ b/supabase/678_auth_before_user_created_hook.sql
@@ -10,7 +10,8 @@
 --   * It does NOT activate/configure the hosted Auth hook.
 --   * Email signup intents are validated here but NOT consumed here.
 --   * Consumption remains atomic in handle_new_auth_user() migration 677.
---   * Fresh Google/Facebook creation requires dedicated registration authorization.
+--   * Fresh Google creation requires provider-bound registration authorization.
+--   * Fresh Facebook creation remains fail-closed.
 --   * Client-supplied role metadata is forbidden.
 
 create or replace function public.before_user_created_validate_signup_intent(event jsonb)
@@ -26,6 +27,7 @@ declare
 
   v_email text;
   v_provider text;
+  v_provider_subject text;
   v_intent_id_text text;
   v_intent_id uuid;
 
@@ -98,9 +100,6 @@ begin
   v_seller_registration :=
     (v_feature_flags->>'sellerRegistration')::boolean;
 
-  -- Role selection is server-governed. Neither user_metadata nor
-  -- app_metadata may be used by a public client to authorize Buyer,
-  -- Seller or Admin access.
   if v_user_metadata ? 'role'
      or v_app_metadata ? 'role' then
     return jsonb_build_object(
@@ -112,57 +111,91 @@ begin
     );
   end if;
 
-  -- Generic social sign-in remains valid for EXISTING identities.
-  -- Fresh Google/Facebook account creation is not allowed through
-  -- the generic sign-in path. It must use dedicated Buyer/Seller
-  -- social-registration authorization.
-  if v_provider in ('google', 'facebook') then
+  if v_provider = 'google' then
+    v_provider_subject :=
+      btrim(coalesce(v_user_metadata->>'sub', ''));
+
+    if v_provider_subject = '' then
+      return jsonb_build_object(
+        'error',
+        jsonb_build_object(
+          'http_code', 403,
+          'message', 'verified Google subject is missing'
+        )
+      );
+    end if;
+
+    select si.*
+    into v_intent
+    from private.signup_intents as si
+    where si.auth_provider = 'google'
+      and si.provider_subject = v_provider_subject
+      and lower(trim(si.email)) = v_email
+      and si.consumed_at is null
+      and si.expires_at > now()
+    order by si.created_at desc
+    limit 1;
+
+    if not found then
+      return jsonb_build_object(
+        'error',
+        jsonb_build_object(
+          'http_code', 403,
+          'message', 'Google registration authorization not found'
+        )
+      );
+    end if;
+
+    v_intent_id := v_intent.id;
+
+  elsif v_provider = 'facebook' then
     return jsonb_build_object(
       'error',
       jsonb_build_object(
         'http_code', 403,
-        'message', 'social signup requires registration authorization'
+        'message', 'Facebook signup requires registration authorization'
       )
     );
-  end if;
-  -- Public email/password signup must be backed by a short-lived
-  -- server-created signup intent.
-  if v_provider <> 'email' then
+
+  elsif v_provider = 'email' then
+    v_intent_id_text := trim(coalesce(v_user_metadata->>'intent_id', ''));
+
+    if v_intent_id_text = ''
+       or v_intent_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
+      return jsonb_build_object(
+        'error',
+        jsonb_build_object(
+          'http_code', 400,
+          'message', 'signup intent is required'
+        )
+      );
+    end if;
+
+    v_intent_id := v_intent_id_text::uuid;
+
+    select si.*
+    into v_intent
+    from private.signup_intents as si
+    where si.id = v_intent_id
+      and si.auth_provider = 'email'
+      and si.provider_subject is null;
+
+    if not found then
+      return jsonb_build_object(
+        'error',
+        jsonb_build_object(
+          'http_code', 400,
+          'message', 'signup intent not found'
+        )
+      );
+    end if;
+
+  else
     return jsonb_build_object(
       'error',
       jsonb_build_object(
         'http_code', 403,
         'message', 'unsupported auth provider'
-      )
-    );
-  end if;
-
-  v_intent_id_text := trim(coalesce(v_user_metadata->>'intent_id', ''));
-
-  if v_intent_id_text = ''
-     or v_intent_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
-    return jsonb_build_object(
-      'error',
-      jsonb_build_object(
-        'http_code', 400,
-        'message', 'signup intent is required'
-      )
-    );
-  end if;
-
-  v_intent_id := v_intent_id_text::uuid;
-
-  select si.*
-  into v_intent
-  from private.signup_intents as si
-  where si.id = v_intent_id;
-
-  if not found then
-    return jsonb_build_object(
-      'error',
-      jsonb_build_object(
-        'http_code', 400,
-        'message', 'signup intent not found'
       )
     );
   end if;
@@ -251,9 +284,6 @@ begin
     );
   end if;
 
-  -- Validation only.
-  -- DO NOT mark consumed_at here. The AFTER INSERT provisioning trigger
-  -- owns atomic intent consumption in the auth.users insert transaction.
   return '{}'::jsonb;
 end;
 $function$;

--- a/supabase/migrations/20260825200500_signup_intent_auth_foundation.sql
+++ b/supabase/migrations/20260825200500_signup_intent_auth_foundation.sql
@@ -11,6 +11,7 @@
 --   * requested_role is intent only; authorization remains server-derived
 --   * intents expire and are single-use
 --   * email confirmation does NOT approve or activate a Seller
+--   * social intents bind to provider + verified provider subject
 
 CREATE SCHEMA IF NOT EXISTS private;
 
@@ -18,6 +19,12 @@ CREATE TABLE IF NOT EXISTS private.signup_intents (
   id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
 
   email text NOT NULL,
+
+  auth_provider text NOT NULL DEFAULT 'email'
+    CHECK (auth_provider IN ('email', 'google', 'facebook')),
+
+  provider_subject text NULL,
+
   requested_role text NOT NULL
     CHECK (requested_role IN ('buyer', 'seller')),
 
@@ -52,11 +59,34 @@ CREATE TABLE IF NOT EXISTS private.signup_intents (
       (requested_role = 'seller' AND seller_type IS NOT NULL)
       OR
       (requested_role = 'buyer' AND seller_type IS NULL)
+    ),
+
+  CONSTRAINT signup_intents_provider_subject_contract
+    CHECK (
+      (
+        auth_provider = 'email'
+        AND provider_subject IS NULL
+      )
+      OR
+      (
+        auth_provider IN ('google', 'facebook')
+        AND length(btrim(provider_subject)) BETWEEN 1 AND 255
+      )
     )
 );
 
 CREATE INDEX IF NOT EXISTS idx_signup_intents_email_created
   ON private.signup_intents (email, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_signup_intents_social_identity
+  ON private.signup_intents (
+    auth_provider,
+    provider_subject,
+    email,
+    created_at DESC
+  )
+  WHERE consumed_at IS NULL
+    AND provider_subject IS NOT NULL;
 
 CREATE INDEX IF NOT EXISTS idx_signup_intents_pending_expiry
   ON private.signup_intents (expires_at)
@@ -72,10 +102,7 @@ GRANT SELECT, INSERT, UPDATE, DELETE
   TO service_role;
 
 -- ---------------------------------------------------------------------------
--- Server-only Data API boundary.
---
--- The private schema MUST NOT be exposed through PostgREST.
--- Netlify service-role callers use this tightly scoped public RPC instead.
+-- Server-only Data API boundary for email/password registration.
 -- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION public.create_signup_intent(
@@ -143,6 +170,8 @@ BEGIN
   RETURN QUERY
   INSERT INTO private.signup_intents AS si (
     email,
+    auth_provider,
+    provider_subject,
     requested_role,
     first_name,
     last_name,
@@ -157,6 +186,8 @@ BEGIN
   )
   VALUES (
     v_email,
+    'email',
+    NULL,
     p_requested_role,
     btrim(p_first_name),
     btrim(p_last_name),
@@ -208,11 +239,145 @@ GRANT EXECUTE ON FUNCTION public.create_signup_intent(
 TO service_role;
 
 -- ---------------------------------------------------------------------------
--- Ongoing email-confirmation projection.
+-- Server-only verified social registration intent boundary.
 --
--- Existing trg_sync_email_verified on public.users only handles INSERT-time
--- correction. It cannot react when auth.users.email_confirmed_at changes later.
--- This trigger closes that gap.
+-- The caller MUST verify the external provider credential before invoking
+-- this RPC. Browser-controlled provider subjects are never authorization.
+-- ---------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.create_social_signup_intent(
+  p_auth_provider text,
+  p_provider_subject text,
+  p_email text,
+  p_requested_role text,
+  p_first_name text,
+  p_last_name text,
+  p_seller_type text DEFAULT NULL,
+  p_expires_at timestamptz DEFAULT NULL
+)
+RETURNS TABLE (
+  id uuid,
+  expires_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_provider text;
+  v_subject text;
+  v_email text;
+  v_expires_at timestamptz;
+BEGIN
+  v_provider := lower(btrim(COALESCE(p_auth_provider, '')));
+  v_subject := btrim(COALESCE(p_provider_subject, ''));
+  v_email := lower(btrim(COALESCE(p_email, '')));
+  v_expires_at := COALESCE(
+    p_expires_at,
+    now() + interval '15 minutes'
+  );
+
+  IF v_provider NOT IN ('google', 'facebook') THEN
+    RAISE EXCEPTION 'invalid social signup provider';
+  END IF;
+
+  IF v_subject = '' OR length(v_subject) > 255 THEN
+    RAISE EXCEPTION 'invalid social provider subject';
+  END IF;
+
+  IF v_email = '' THEN
+    RAISE EXCEPTION 'invalid social signup email';
+  END IF;
+
+  IF p_requested_role NOT IN ('buyer', 'seller') THEN
+    RAISE EXCEPTION 'invalid signup intent role';
+  END IF;
+
+  IF btrim(COALESCE(p_first_name, '')) = ''
+     OR btrim(COALESCE(p_last_name, '')) = ''
+  THEN
+    RAISE EXCEPTION 'invalid signup intent identity';
+  END IF;
+
+  IF p_requested_role = 'seller'
+     AND p_seller_type NOT IN ('individual', 'sole_trader', 'company')
+  THEN
+    RAISE EXCEPTION 'invalid seller type';
+  END IF;
+
+  IF p_requested_role = 'buyer'
+     AND p_seller_type IS NOT NULL
+  THEN
+    RAISE EXCEPTION 'buyer intent cannot carry seller type';
+  END IF;
+
+  IF v_expires_at <= now() THEN
+    RAISE EXCEPTION 'signup intent expiry must be in the future';
+  END IF;
+
+  PERFORM pg_advisory_xact_lock(
+    hashtextextended(v_provider || ':' || v_subject, 0)
+  );
+
+  UPDATE private.signup_intents
+  SET consumed_at = now()
+  WHERE auth_provider = v_provider
+    AND provider_subject = v_subject
+    AND consumed_at IS NULL;
+
+  RETURN QUERY
+  INSERT INTO private.signup_intents AS si (
+    email,
+    auth_provider,
+    provider_subject,
+    requested_role,
+    first_name,
+    last_name,
+    seller_type,
+    expires_at
+  )
+  VALUES (
+    v_email,
+    v_provider,
+    v_subject,
+    p_requested_role,
+    btrim(p_first_name),
+    btrim(p_last_name),
+    p_seller_type,
+    v_expires_at
+  )
+  RETURNING
+    si.id,
+    si.expires_at;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.create_social_signup_intent(
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  timestamptz
+)
+FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.create_social_signup_intent(
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  text,
+  timestamptz
+)
+TO service_role;
+
+-- ---------------------------------------------------------------------------
+-- Ongoing email-confirmation projection.
 -- ---------------------------------------------------------------------------
 
 CREATE OR REPLACE FUNCTION private.sync_public_email_verified_from_auth()
@@ -295,6 +460,31 @@ BEGIN
   THEN
     RAISE EXCEPTION
       '676 signup intent RPC security failure: service role cannot execute RPC';
+  END IF;
+
+  IF has_function_privilege(
+       'anon',
+       'public.create_social_signup_intent(text,text,text,text,text,text,text,timestamptz)',
+       'EXECUTE'
+     )
+     OR has_function_privilege(
+       'authenticated',
+       'public.create_social_signup_intent(text,text,text,text,text,text,text,timestamptz)',
+       'EXECUTE'
+     )
+  THEN
+    RAISE EXCEPTION
+      '676 social signup intent security failure: client role can execute RPC';
+  END IF;
+
+  IF NOT has_function_privilege(
+       'service_role',
+       'public.create_social_signup_intent(text,text,text,text,text,text,text,timestamptz)',
+       'EXECUTE'
+     )
+  THEN
+    RAISE EXCEPTION
+      '676 social signup intent security failure: service role cannot execute RPC';
   END IF;
 
   IF has_function_privilege(

--- a/supabase/migrations/20260825201500_auth_signup_intent_consumption.sql
+++ b/supabase/migrations/20260825201500_auth_signup_intent_consumption.sql
@@ -5,9 +5,12 @@
 --   Requires a valid server-owned signup intent.
 --   Buyer/Seller relationship is derived only from private.signup_intents.
 --
--- OAUTH
---   Generic Google/Facebook sign-in cannot create a new Loadify account.
---   Fresh social registration requires dedicated registration authorization.
+-- GOOGLE
+--   Fresh account creation requires a provider-bound social signup intent.
+--
+-- FACEBOOK
+--   Fresh creation remains fail-closed until its dedicated registration
+--   boundary is implemented and verified independently.
 --
 -- UNKNOWN PROVIDERS
 --   Fail closed.
@@ -22,6 +25,7 @@ SET search_path = ''
 AS $$
 DECLARE
   v_provider text;
+  v_provider_subject text;
   v_intent_id uuid;
   v_intent private.signup_intents%ROWTYPE;
   v_email text;
@@ -43,64 +47,82 @@ BEGIN
       'signup rejected: auth email is missing';
   END IF;
 
-  -- No public identity may choose its authorization role through metadata.
   IF NEW.raw_user_meta_data ? 'role' THEN
     RAISE EXCEPTION
       'signup rejected: client role metadata is forbidden';
   END IF;
 
-  -- -------------------------------------------------------------------------
-  -- OAuth identity creation.
-  --
-  -- Generic Google/Facebook sign-in may authenticate an EXISTING identity,
-  -- but it may not create a new Loadify account. Fresh social registration
-  -- must first pass through the dedicated Buyer/Seller registration boundary.
-  -- -------------------------------------------------------------------------
-  IF v_provider IN ('google', 'facebook') THEN
-    RAISE EXCEPTION
-      'signup rejected: social signup requires registration authorization';
-  END IF;
+  IF v_provider = 'google' THEN
+    v_provider_subject :=
+      btrim(COALESCE(NEW.raw_user_meta_data ->> 'sub', ''));
 
-  -- -------------------------------------------------------------------------
-  -- Public email/password signup.
-  -- -------------------------------------------------------------------------
-  IF v_provider <> 'email' THEN
+    IF v_provider_subject = '' THEN
+      RAISE EXCEPTION
+        'signup rejected: verified Google subject is missing';
+    END IF;
+
+    SELECT *
+    INTO v_intent
+    FROM private.signup_intents
+    WHERE auth_provider = 'google'
+      AND provider_subject = v_provider_subject
+      AND email = v_email
+      AND consumed_at IS NULL
+      AND expires_at > now()
+    ORDER BY created_at DESC
+    LIMIT 1
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION
+        'signup rejected: Google registration authorization not found';
+    END IF;
+
+    v_intent_id := v_intent.id;
+
+  ELSIF v_provider = 'facebook' THEN
+    RAISE EXCEPTION
+      'signup rejected: Facebook signup requires registration authorization';
+
+  ELSIF v_provider = 'email' THEN
+    IF NEW.raw_app_meta_data ? 'role' THEN
+      RAISE EXCEPTION
+        'signup rejected: public email signup cannot carry app role metadata';
+    END IF;
+
+    BEGIN
+      v_intent_id :=
+        NULLIF(
+          NEW.raw_user_meta_data ->> 'intent_id',
+          ''
+        )::uuid;
+    EXCEPTION
+      WHEN invalid_text_representation THEN
+        RAISE EXCEPTION
+          'signup rejected: invalid signup intent';
+    END;
+
+    IF v_intent_id IS NULL THEN
+      RAISE EXCEPTION
+        'signup rejected: signup intent is required';
+    END IF;
+
+    SELECT *
+    INTO v_intent
+    FROM private.signup_intents
+    WHERE id = v_intent_id
+      AND auth_provider = 'email'
+      AND provider_subject IS NULL
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+      RAISE EXCEPTION
+        'signup rejected: signup intent not found';
+    END IF;
+
+  ELSE
     RAISE EXCEPTION
       'signup rejected: unsupported auth provider';
-  END IF;
-
-  -- app_metadata role is also forbidden on public email signup.
-  IF NEW.raw_app_meta_data ? 'role' THEN
-    RAISE EXCEPTION
-      'signup rejected: public email signup cannot carry app role metadata';
-  END IF;
-
-  BEGIN
-    v_intent_id :=
-      NULLIF(
-        NEW.raw_user_meta_data ->> 'intent_id',
-        ''
-      )::uuid;
-  EXCEPTION
-    WHEN invalid_text_representation THEN
-      RAISE EXCEPTION
-        'signup rejected: invalid signup intent';
-  END;
-
-  IF v_intent_id IS NULL THEN
-    RAISE EXCEPTION
-      'signup rejected: signup intent is required';
-  END IF;
-
-  SELECT *
-  INTO v_intent
-  FROM private.signup_intents
-  WHERE id = v_intent_id
-  FOR UPDATE;
-
-  IF NOT FOUND THEN
-    RAISE EXCEPTION
-      'signup rejected: signup intent not found';
   END IF;
 
   IF v_intent.consumed_at IS NOT NULL THEN
@@ -142,11 +164,7 @@ BEGIN
     v_intent.phone
   );
 
-  -- public.users AFTER INSERT provisioning is synchronous, so the canonical
-  -- buyer/seller profile rows exist before execution continues here.
-
   IF v_intent.requested_role = 'buyer' THEN
-
     UPDATE public.buyer_profiles
     SET
       "customerType" = COALESCE(
@@ -165,7 +183,6 @@ BEGIN
     END IF;
 
   ELSIF v_intent.requested_role = 'seller' THEN
-
     UPDATE public.seller_profiles
     SET
       "sellerType" = v_intent.seller_type,
@@ -220,7 +237,7 @@ END;
 $$;
 
 COMMENT ON FUNCTION public.handle_new_auth_user() IS
-  'Fail-closed Auth provisioning: email signup requires a valid single-use private intent; Google/Facebook provision Buyer-only; client role metadata is never authorization.';
+  'Fail-closed Auth provisioning: email signup requires a private intent; Google requires provider-bound authorization; Facebook remains fail-closed; client role metadata is never authorization.';
 
 REVOKE ALL ON FUNCTION public.handle_new_auth_user()
 FROM PUBLIC, anon, authenticated;

--- a/supabase/migrations/20260826070000_auth_before_user_created_hook.sql
+++ b/supabase/migrations/20260826070000_auth_before_user_created_hook.sql
@@ -10,7 +10,8 @@
 --   * It does NOT activate/configure the hosted Auth hook.
 --   * Email signup intents are validated here but NOT consumed here.
 --   * Consumption remains atomic in handle_new_auth_user() migration 677.
---   * Fresh Google/Facebook creation requires dedicated registration authorization.
+--   * Fresh Google creation requires provider-bound registration authorization.
+--   * Fresh Facebook creation remains fail-closed.
 --   * Client-supplied role metadata is forbidden.
 
 create or replace function public.before_user_created_validate_signup_intent(event jsonb)
@@ -26,6 +27,7 @@ declare
 
   v_email text;
   v_provider text;
+  v_provider_subject text;
   v_intent_id_text text;
   v_intent_id uuid;
 
@@ -98,9 +100,6 @@ begin
   v_seller_registration :=
     (v_feature_flags->>'sellerRegistration')::boolean;
 
-  -- Role selection is server-governed. Neither user_metadata nor
-  -- app_metadata may be used by a public client to authorize Buyer,
-  -- Seller or Admin access.
   if v_user_metadata ? 'role'
      or v_app_metadata ? 'role' then
     return jsonb_build_object(
@@ -112,57 +111,91 @@ begin
     );
   end if;
 
-  -- Generic social sign-in remains valid for EXISTING identities.
-  -- Fresh Google/Facebook account creation is not allowed through
-  -- the generic sign-in path. It must use dedicated Buyer/Seller
-  -- social-registration authorization.
-  if v_provider in ('google', 'facebook') then
+  if v_provider = 'google' then
+    v_provider_subject :=
+      btrim(coalesce(v_user_metadata->>'sub', ''));
+
+    if v_provider_subject = '' then
+      return jsonb_build_object(
+        'error',
+        jsonb_build_object(
+          'http_code', 403,
+          'message', 'verified Google subject is missing'
+        )
+      );
+    end if;
+
+    select si.*
+    into v_intent
+    from private.signup_intents as si
+    where si.auth_provider = 'google'
+      and si.provider_subject = v_provider_subject
+      and lower(trim(si.email)) = v_email
+      and si.consumed_at is null
+      and si.expires_at > now()
+    order by si.created_at desc
+    limit 1;
+
+    if not found then
+      return jsonb_build_object(
+        'error',
+        jsonb_build_object(
+          'http_code', 403,
+          'message', 'Google registration authorization not found'
+        )
+      );
+    end if;
+
+    v_intent_id := v_intent.id;
+
+  elsif v_provider = 'facebook' then
     return jsonb_build_object(
       'error',
       jsonb_build_object(
         'http_code', 403,
-        'message', 'social signup requires registration authorization'
+        'message', 'Facebook signup requires registration authorization'
       )
     );
-  end if;
-  -- Public email/password signup must be backed by a short-lived
-  -- server-created signup intent.
-  if v_provider <> 'email' then
+
+  elsif v_provider = 'email' then
+    v_intent_id_text := trim(coalesce(v_user_metadata->>'intent_id', ''));
+
+    if v_intent_id_text = ''
+       or v_intent_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
+      return jsonb_build_object(
+        'error',
+        jsonb_build_object(
+          'http_code', 400,
+          'message', 'signup intent is required'
+        )
+      );
+    end if;
+
+    v_intent_id := v_intent_id_text::uuid;
+
+    select si.*
+    into v_intent
+    from private.signup_intents as si
+    where si.id = v_intent_id
+      and si.auth_provider = 'email'
+      and si.provider_subject is null;
+
+    if not found then
+      return jsonb_build_object(
+        'error',
+        jsonb_build_object(
+          'http_code', 400,
+          'message', 'signup intent not found'
+        )
+      );
+    end if;
+
+  else
     return jsonb_build_object(
       'error',
       jsonb_build_object(
         'http_code', 403,
         'message', 'unsupported auth provider'
-      )
-    );
-  end if;
-
-  v_intent_id_text := trim(coalesce(v_user_metadata->>'intent_id', ''));
-
-  if v_intent_id_text = ''
-     or v_intent_id_text !~* '^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$' then
-    return jsonb_build_object(
-      'error',
-      jsonb_build_object(
-        'http_code', 400,
-        'message', 'signup intent is required'
-      )
-    );
-  end if;
-
-  v_intent_id := v_intent_id_text::uuid;
-
-  select si.*
-  into v_intent
-  from private.signup_intents as si
-  where si.id = v_intent_id;
-
-  if not found then
-    return jsonb_build_object(
-      'error',
-      jsonb_build_object(
-        'http_code', 400,
-        'message', 'signup intent not found'
       )
     );
   end if;
@@ -251,9 +284,6 @@ begin
     );
   end if;
 
-  -- Validation only.
-  -- DO NOT mark consumed_at here. The AFTER INSERT provisioning trigger
-  -- owns atomic intent consumption in the auth.users insert transaction.
   return '{}'::jsonb;
 end;
 $function$;


### PR DESCRIPTION
Stacked recovery PR for #596. Base is the existing #596 branch, not main.

## Implemented

### G1 provider-bound foundation
- extend private signup intents with `auth_provider` + `provider_subject`
- add service-role-only `create_social_signup_intent` RPC
- bind fresh Google account creation to provider + verified subject + normalized email
- keep fresh Facebook account creation fail-closed
- keep email/password signup on email-only `intent_id` flow
- rebuild Before User Created hook cleanly without the prior local patch corruption
- align Auth contract tests with explicit google/facebook/email branches

### G2 Google server boundary
- add `register-social-intent` Netlify function + modern wrapper
- Google-only fresh social registration boundary
- verify JWT with Node crypto against Google official JWKS
- require RS256 + matching signing key
- validate issuer, audience, expiry and bounded token age
- validate Supabase-compatible nonce contract: Google token must carry SHA-256(raw nonce)
- require verified email, provider subject and email
- recheck Buyer/Seller registration feature flags
- persist authorization only through service-role `create_social_signup_intent`
- add contract tests for the verified Google boundary

### Role-first public entry
- add `SignupEntry.tsx` chooser with Buyer / Marketplace Seller only
- generic registration no longer has an intended Buyer-default design
- Buyer and Seller explicit routes remain `/register?type=buyer` and `/register?type=seller`

## Remaining wiring
- connect `/register` and `/signup` routes to `SignupEntry` with an atomic App.tsx patch
- load Google Identity Services on the selected role form
- generate raw + SHA-256 nonce client-side
- call `register-social-intent` with Google credential + raw nonce + selected role
- after verified intent is persisted, call `supabase.auth.signInWithIdToken({ provider: 'google', token, nonce: rawNonce })`
- add required Google GIS CSP directives and preview/runtime gate
- confirm/introduce `GOOGLE_CLIENT_ID` / `VITE_GOOGLE_CLIENT_ID` in deployment configuration before runtime validation
- preserve Login Google OAuth as existing-identity sign-in; fresh generic creation remains blocked
- Facebook remains fail-closed until its dedicated verified registration flow is implemented

## Validation state
- GitHub PR is OPEN / DRAFT / MERGEABLE
- latest HEAD has no completed CI/status checks yet; do NOT treat this PR as PASS
- no production Supabase migration
- no hosted Auth hook activation
- no production deploy
- no merge to main

## Guardrails
- this PR is stacked on #596 only
- Footer is outside scope
- no broad Workspace/Admin/Super Admin visual changes
- no PR #359 visual import
- no Supplier Commerce activation
